### PR TITLE
Allow re-invocation of lockdown() & reject unrecognized options

### DIFF
--- a/packages/lockdown-shim/test/lockdown-allow.test.js
+++ b/packages/lockdown-shim/test/lockdown-allow.test.js
@@ -1,0 +1,71 @@
+import test from 'tape';
+import { lockdown } from '../src/main.js';
+
+test('lockdown returns boolean or throws in downgraded SES', t => {
+  t.plan(7);
+
+  t.ok(
+    lockdown({
+      noTameDate: true,
+      noTameError: true,
+      noTameMath: true,
+      noTameRegExp: true,
+    }),
+    'return true when called from JS with options',
+  );
+
+  t.notOk(
+    lockdown({
+      noTameDate: true,
+      noTameError: true,
+      noTameMath: true,
+      noTameRegExp: true,
+    }),
+    'return false when called from SES with the same options',
+  );
+
+  t.throws(
+    () => lockdown(),
+    'throws when when called from SES with different options',
+  );
+
+  t.throws(
+    () =>
+      lockdown({
+        noTameError: true,
+        noTameMath: true,
+        noTameRegExp: true,
+      }),
+    'throws when attempting to tame Date',
+  );
+
+  t.throws(
+    () =>
+      lockdown({
+        noTameDate: true,
+        noTameMath: true,
+        noTameRegExp: true,
+      }),
+    'throws when attempting to tame Error',
+  );
+
+  t.throws(
+    () =>
+      lockdown({
+        noTameDate: true,
+        noTameError: true,
+        noTameRegExp: true,
+      }),
+    'throws when attempting to tame Math',
+  );
+
+  t.throws(
+    () =>
+      lockdown({
+        noTameDate: true,
+        noTameError: true,
+        noTameMath: true,
+      }),
+    'throws when attempting to tame RegExp',
+  );
+});

--- a/packages/lockdown-shim/test/lockdown-options.test.js
+++ b/packages/lockdown-shim/test/lockdown-options.test.js
@@ -1,0 +1,15 @@
+import test from 'tape';
+import { lockdown } from '../src/main.js';
+
+test('lockdown throws with non-recognized options', t => {
+  t.plan(2);
+
+  t.throws(
+    () => lockdown({ noTameMath: true, abc: true }),
+    'throws with value true',
+  );
+  t.throws(
+    () => lockdown({ noTameMath: true, abc: false }),
+    'throws with value false',
+  );
+});

--- a/packages/lockdown-shim/test/lockdown.test.js
+++ b/packages/lockdown-shim/test/lockdown.test.js
@@ -1,0 +1,28 @@
+import test from 'tape';
+import { lockdown } from '../src/main.js';
+
+test('lockdown returns boolean or throws in SES', t => {
+  t.plan(6);
+
+  t.ok(lockdown(), 'return true when called from JS without options');
+  t.notOk(
+    lockdown(),
+    'return false when called from SES with the same options',
+  );
+  t.throws(
+    () => lockdown({ noTameDate: true }),
+    'throws when attempting to untame Date',
+  );
+  t.throws(
+    () => lockdown({ noTameError: true }),
+    'throws when attempting to untame Error',
+  );
+  t.throws(
+    () => lockdown({ noTameMath: true }),
+    'throws when attempting to untame Math',
+  );
+  t.throws(
+    () => lockdown({ noTameRegExp: true }),
+    'throws when attempting to untame RegExp',
+  );
+});


### PR DESCRIPTION
Resolves:
*Can/should lockdown() be called twice*
https://github.com/Agoric/SES-shim/issues/40

*Reject unrecognized options*
https://github.com/Agoric/SES-shim/issues/32