### PR TITLE
Fix private package metadata (and similar)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "private": true,
   "name": "SES",
+  "private": true,
   "useWorkspaces": true,
   "workspaces": [
     "packages/compartment-shim",
@@ -27,8 +27,8 @@
     "packages/transform-module",
     "packages/whitelist-intrinsics"
   ],
-  "engines" : { 
-    "node" : ">=13" 
+  "engines": {
+    "node": ">=13"
   },
   "devDependencies": {
     "lerna": "^3.19.0",

--- a/packages/error-stack-shim/package.json
+++ b/packages/error-stack-shim/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@Agoric/error-stack-shim",
+  "name": "@agoric/error-stack-shim",
   "version": "0.0.1",
   "description": "Shim the Error Stack proposal plus async deep stacks",
   "author": "Agoric",

--- a/packages/ses-integration-test/package.json
+++ b/packages/ses-integration-test/package.json
@@ -6,6 +6,7 @@
     "last 1 chrome versions"
   ],
   "main": "index.js",
+  "private": true,
   "scripts": {
     "depcheck": "depcheck",
     "lint": "eslint '**/*.js'",


### PR DESCRIPTION
This change marks a couple test repositories as private, fixes the
capitalization of one package name, and updates the release process to
reflect the pivot to Yarn workspaces and Lerna.