### PR TITLE
Fix shellcheck lint

### DIFF
--- a/scripts/build-post-release-test.sh
+++ b/scripts/build-post-release-test.sh
@@ -1,6 +1,8 @@
-#! /bin/sh -e
+#!/bin/bash
+set -ueo pipefail
+DIR=$(dirname -- "${BASH_SOURCE[0]}")
 npm run-script build
 cd integration-test 
-npm install $( npm pack .. )
+npm install "$(npm pack "$DIR/..")"
 npm run create-test-file-no-lib-cjs
 npm run create-test-file-browserified-tape

--- a/scripts/build-pre-release-test.sh
+++ b/scripts/build-pre-release-test.sh
@@ -1,7 +1,9 @@
-#! /bin/sh -e
+#!/bin/bash
+set -ueo pipefail
+DIR=$(dirname -- "${BASH_SOURCE[0]}")
 npm run-script build
 cd integration-test 
-npm install $( npm pack .. )
+npm install "$(npm pack "$DIR/..")"
 npm run create-test-file-no-lib-cjs
 npm run create-test-file-esm
 npm run create-test-file-cjs


### PR DESCRIPTION
This change adds the rote `set -ueo pipefail` incantation, changes the shebang to specifically bash to assist IDE's with highlighting differences between sh and bash, and uses `BASH_SOURCE` to make the script work regardless of `PWD`.