### PR TITLE
Add script to generate dependency graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ typings/
 
 # dist
 dist/
+
+/packages.png

--- a/scripts/graph.sh
+++ b/scripts/graph.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# scripts/graph.sh generates packages.png, a visualization of the internal
+# package dependency graph.
+set -ueo pipefail
+DIR=$(dirname -- "${BASH_SOURCE[0]}")
+{
+    echo 'digraph {'
+    echo 'rankdir=LR'
+    cat "$DIR"/../packages/*/package.json | jq -r '
+        .name as $from |
+        (.dependencies // {}) |
+        keys[] |
+        {$from, to: .} |
+        "\"\(.from)\" -> \"\(.to)\""
+    '
+    echo '}'
+} | dot -Tpng > "$DIR"/../packages.png

--- a/scripts/graph.sh
+++ b/scripts/graph.sh
@@ -6,11 +6,16 @@ DIR=$(dirname -- "${BASH_SOURCE[0]}")
 {
     echo 'digraph {'
     echo 'rankdir=LR'
-    cat "$DIR"/../packages/*/package.json | jq -r '
+    cat "$DIR"/../packages/*/package.json | jq -r --slurp '
+        . as $all |
+        [.[] | {(.name): true}] | add as $locals |
+
+        $all[] |
         .name as $from |
         (.dependencies // {}) |
         keys[] |
         {$from, to: .} |
+        select($locals[.from] and $locals[.to]) |
         "\"\(.from)\" -> \"\(.to)\""
     '
     echo '}'


### PR DESCRIPTION
This change introduces a script for generating the shallow interdependency graph among packages in the SES monorepo.

This is a preview at time of writing:

![image](https://user-images.githubusercontent.com/60294/75828593-0a0c2380-5d61-11ea-989f-2244598768de.png)
