### PR TITLE
Fix importing CJS, RESM, and ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "depcheck": "lerna run --no-bail depcheck",
     "update": "lernaupdate --dedupe",
     "prettier": "lerna run prettier",
-    "lint": "lerna run lint",
+    "lint": "yarn clean && lerna run lint",
     "lint-fix": "lerna run --no-bail lint-fix",
     "test": "lerna run test",
     "test262": "lerna run test262",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "depcheck": "lerna run --no-bail depcheck",
     "update": "lernaupdate --dedupe",
     "prettier": "lerna run prettier",
-    "lint": "yarn clean && lerna run lint",
+    "lint": "yes | yarn clean && lerna run lint",
     "lint-fix": "lerna run --no-bail lint-fix",
     "test": "lerna run test",
     "test262": "lerna run test262",

--- a/packages/ses-integration-test/scaffolding/rollup/ses.js
+++ b/packages/ses-integration-test/scaffolding/rollup/ses.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-unresolved
 import SES from "ses";
 
 export default SES;

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -13,8 +13,9 @@
   },
   "scripts": {
     "depcheck": "depcheck",
-    "lint": "rm -rf dist && eslint '**/*.js'",
-    "lint-fix": "rm -rf dist && eslint --fix '**/*.js' '**/*.mjs' '**/*.cjs'",
+    "clean": "rm -rf dist",
+    "lint": "yarn clean && eslint '**/*.js'",
+    "lint-fix": "yarn clean && eslint --fix '**/*.js' '**/*.mjs' '**/*.cjs'",
     "test": "yarn build && tap --no-esm --no-coverage --reporter spec 'test/**/*.test.js'",
     "test262": "tap --no-esm --no-coverage --reporter spec test262/*.js",
     "build": "rollup --config rollup.config.js",

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -5,11 +5,10 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "type": "module",
-  "main": "./src/lockdown-shim.js",
+  "main": "./dist/ses.cjs",
   "exports": {
-    "import": "./src/lockdown-shim.js",
-    "require": "./dist/ses.cjs.js",
-    "browser": "./dist/ses.umd.js"
+    "import": "./src/main.js",
+    "require": "./dist/ses.cjs"
   },
   "scripts": {
     "depcheck": "depcheck",

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -8,12 +8,13 @@
   "main": "./dist/ses.cjs",
   "exports": {
     "import": "./src/main.js",
-    "require": "./dist/ses.cjs"
+    "require": "./dist/ses.cjs",
+    "browser": "./dist/ses.cjs"
   },
   "scripts": {
     "depcheck": "depcheck",
-    "lint": "eslint '**/*.js'",
-    "lint-fix": "eslint --fix '**/*.js'",
+    "lint": "rm -rf dist && eslint '**/*.js'",
+    "lint-fix": "rm -rf dist && eslint --fix '**/*.js' '**/*.mjs' '**/*.cjs'",
     "test": "yarn build && tap --no-esm --no-coverage --reporter spec 'test/**/*.test.js'",
     "test262": "tap --no-esm --no-coverage --reporter spec test262/*.js",
     "build": "rollup --config rollup.config.js",

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -9,7 +9,7 @@
   "exports": {
     "import": "./src/main.js",
     "require": "./dist/ses.cjs",
-    "browser": "./dist/ses.cjs"
+    "browser": "./dist/ses.umd.js"
   },
   "scripts": {
     "depcheck": "depcheck",

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -14,7 +14,7 @@
     "depcheck": "depcheck",
     "lint": "eslint '**/*.js'",
     "lint-fix": "eslint --fix '**/*.js'",
-    "test": "tap --no-esm --no-coverage --reporter spec 'test/**/*.test.js'",
+    "test": "yarn build && tap --no-esm --no-coverage --reporter spec 'test/**/*.test.js'",
     "test262": "tap --no-esm --no-coverage --reporter spec test262/*.js",
     "build": "rollup --config rollup.config.js",
     "demo": "http-server -o /demos"

--- a/packages/ses/rollup.config.js
+++ b/packages/ses/rollup.config.js
@@ -6,11 +6,11 @@ export default [
     input: 'src/main.js',
     output: [
       {
-        file: 'dist/ses.esm.js',
+        file: 'dist/ses.mjs',
         format: 'esm',
       },
       {
-        file: 'dist/ses.cjs.js',
+        file: 'dist/ses.cjs',
         format: 'cjs',
       },
     ],

--- a/packages/ses/test/package.test.js
+++ b/packages/ses/test/package.test.js
@@ -1,0 +1,38 @@
+import tap from 'tap';
+import { spawn } from 'child_process';
+import { dirname, join } from 'path';
+
+const { test } = tap;
+
+const cwd = join(dirname(new URL(import.meta.url).pathname), 'package');
+
+const table = {
+  cjs: {
+    args: ['test.cjs'],
+    code: 0,
+  },
+  resm: {
+    args: ['-r', 'esm', 'test.js'],
+    code: 0,
+  },
+  esm: {
+    args: ['test.mjs'],
+    code: 0,
+  },
+  'who tests the tests': {
+    args: ['-e', 'throw "barff"'],
+    code: 1,
+  },
+};
+
+const stdio = ['ignore', 'ignore', 'ignore'];
+
+for (const [name, { args, code }] of Object.entries(table)) {
+  test(name, t => {
+    t.plan(1);
+    const child = spawn('node', args, { cwd, stdio });
+    child.on('close', actualCode => {
+      t.equals(actualCode, code);
+    });
+  });
+}

--- a/packages/ses/test/package/package.json
+++ b/packages/ses/test/package/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "dependencies": {
-    "ses": "*"
+    "ses": "file:../.."
   }
 }

--- a/packages/ses/test/package/package.json
+++ b/packages/ses/test/package/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "ses": "*"
+  }
+}

--- a/packages/ses/test/package/test.cjs
+++ b/packages/ses/test/package/test.cjs
@@ -1,0 +1,6 @@
+// node test.cjs
+
+const { lockdown } = require('ses');
+
+lockdown();
+console.log(Compartment);

--- a/packages/ses/test/package/test.js
+++ b/packages/ses/test/package/test.js
@@ -1,0 +1,7 @@
+// node -r esm test.js
+
+import { lockdown } from 'ses';
+
+lockdown();
+// eslint-disable-next-line no-undef
+console.log(Compartment);

--- a/packages/ses/test/package/test.js
+++ b/packages/ses/test/package/test.js
@@ -1,5 +1,6 @@
 // node -r esm test.js
 
+// eslint-disable-next-line import/no-unresolved
 import { lockdown } from 'ses';
 
 lockdown();

--- a/packages/ses/test/package/test.mjs
+++ b/packages/ses/test/package/test.mjs
@@ -1,0 +1,6 @@
+// node test.mjs
+
+import { lockdown } from 'ses';
+
+lockdown();
+console.log(Compartment);


### PR DESCRIPTION
This aligns ses/package.json such that SES can be imported with a CommonJS
loader, with the `esm` package using `node -r esm`, as well as Node.js ESM
support, all using the same "ses" name.

node main.js

    const { lockdown } = require('ses');

node main.mjs and node -r esm main.js

    import { lockdown } from 'ses';

This change includes a regression test that verifies each of these cases.

Fixes #214