### PR TITLE
release make-hardener v0.0.7

### DIFF
--- a/packages/harden/package.json
+++ b/packages/harden/package.json
@@ -37,7 +37,7 @@
     "build": "rollup -c rollup.config.js"
   },
   "dependencies": {
-    "@agoric/make-hardener": "0.0.6"
+    "@agoric/make-hardener": "0.0.7"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",

--- a/packages/make-hardener-integration-test/package.json
+++ b/packages/make-hardener-integration-test/package.json
@@ -28,7 +28,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@agoric/make-hardener": "0.0.6"
+    "@agoric/make-hardener": "0.0.7"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",

--- a/packages/make-hardener/NEWS.md
+++ b/packages/make-hardener/NEWS.md
@@ -1,5 +1,10 @@
 User-visible changes in make-hardener:
 
+## Release 0.0.7 (13-Mar-2019)
+
+* The `harden` function no longer has a `prototype`.
+  This is necessary for compatibility with SES 0.7.
+
 ## Release 0.0.6 (20-Apr-2019)
 
 * Tolerate objects with unstringifyable prototypes, like `async function`.

--- a/packages/make-hardener/package.json
+++ b/packages/make-hardener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/make-hardener",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Create a 'hardener' which freezes the API surface of a set of objects",
   "author": "Agoric",
   "license": "Apache-2.0",

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -21,7 +21,7 @@
     "demo": "http-server -o /demos"
   },
   "dependencies": {
-    "@agoric/make-hardener": "^0.0.6"
+    "@agoric/make-hardener": "0.0.7"
   },
   "devDependencies": {
     "@agoric/test262-runner": "~0.1.0",


### PR DESCRIPTION
This release is the first to be published from the ses-shim monorepo and
includes changes necessary for compatibility with SES 0.7.