### PR TITLE
make-hardener: Fix direct Node.js ESM support

### DIFF
--- a/packages/harden/src/main.js
+++ b/packages/harden/src/main.js
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// eslint-disable-next-line import/no-unresolved
 import makeHardener from '@agoric/make-hardener';
 import buildTable from './buildTable.js';
 

--- a/packages/make-hardener-integration-test/pre-release-browser-tests/rollup/make-hardener.js
+++ b/packages/make-hardener-integration-test/pre-release-browser-tests/rollup/make-hardener.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-unresolved
 import makeHardener from "@agoric/make-hardener";
 
 export default makeHardener;

--- a/packages/make-hardener/package.json
+++ b/packages/make-hardener/package.json
@@ -25,8 +25,14 @@
     "test": "test"
   },
   "type": "module",
-  "main": "./src/main.js",
-  "browser": "dist/make-hardener.umd.js",
+  "main": "./dist/make-hardener.cjs",
+  "module": "./src/main.js",
+  "browser": "./dist/make-hardener.umd.js",
+  "exports": {
+    "import": "./src/main.js",
+    "require": "./dist/make-hardener.cjs",
+    "browser": "./dist/make-hardener.umd.js"
+  },
   "scripts": {
     "depcheck": "depcheck",
     "lint": "eslint '**/*.js'",
@@ -35,6 +41,7 @@
     "build": "rollup -c rollup.config.js"
   },
   "devDependencies": {
+    "@rollup/plugin-node-resolve": "^6.1.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.0.0",
@@ -44,7 +51,7 @@
     "eslint-plugin-prettier": "^3.1.2",
     "prettier": "^1.19.1",
     "rollup": "1.31.0",
-    "rollup-plugin-node-resolve": "5.2.0",
+    "rollup-plugin-terser": "^5.1.3",
     "tap": "14.10.5"
   }
 }

--- a/packages/make-hardener/package.json
+++ b/packages/make-hardener/package.json
@@ -28,6 +28,7 @@
   "main": "./dist/make-hardener.cjs",
   "module": "./src/main.js",
   "browser": "./dist/make-hardener.umd.js",
+  "unpkg": "./dist/make-hardener.umd.js",
   "exports": {
     "import": "./src/main.js",
     "require": "./dist/make-hardener.cjs",

--- a/packages/make-hardener/rollup.config.js
+++ b/packages/make-hardener/rollup.config.js
@@ -1,16 +1,37 @@
+import resolve from '@rollup/plugin-node-resolve';
+import { terser } from 'rollup-plugin-terser';
+
 export default [
   {
     input: 'src/main.js',
     output: [
       {
-        file: 'dist/make-hardener.umd.js',
-        format: 'umd',
-        name: 'makeHardener',
+        file: 'dist/make-hardener.mjs',
+        format: 'esm',
       },
       {
-        file: 'dist/make-hardener.cjs.js',
+        file: 'dist/make-hardener.cjs',
         format: 'cjs',
       },
     ],
+    plugins: [resolve()],
+  },
+  {
+    input: 'src/main.js',
+    output: {
+      file: 'dist/make-hardener.umd.js',
+      format: 'umd',
+      name: 'make-hardener',
+    },
+    plugins: [resolve()],
+  },
+  {
+    input: 'src/main.js',
+    output: {
+      file: 'dist/make-hardener.umd.min.js',
+      format: 'umd',
+      name: 'make-hardener',
+    },
+    plugins: [resolve(), terser()],
   },
 ];

--- a/packages/make-hardener/rollup.config.js
+++ b/packages/make-hardener/rollup.config.js
@@ -30,7 +30,7 @@ export default [
     output: {
       file: 'dist/make-hardener.umd.min.js',
       format: 'umd',
-      name: 'make-hardener',
+      name: 'makeHardener',
     },
     plugins: [resolve(), terser()],
   },

--- a/packages/make-hardener/rollup.config.js
+++ b/packages/make-hardener/rollup.config.js
@@ -21,7 +21,7 @@ export default [
     output: {
       file: 'dist/make-hardener.umd.js',
       format: 'umd',
-      name: 'make-hardener',
+      name: 'makeHardener',
     },
     plugins: [resolve()],
   },

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// eslint-disable-next-line import/no-unresolved
 import makeHardener from '@agoric/make-hardener';
 
 import { getIntrinsics } from './intrinsics.js';

--- a/packages/ses/test/enable-property-overrides.test.js
+++ b/packages/ses/test/enable-property-overrides.test.js
@@ -1,5 +1,6 @@
 import tap from 'tap';
 import { captureGlobals } from '@agoric/test262-runner';
+// eslint-disable-next-line import/no-unresolved
 import makeHardener from '@agoric/make-hardener';
 import enablePropertyOverrides from '../src/enable-property-overrides.js';
 


### PR DESCRIPTION
This change rearranges make-hardener so that it supports the full hybrid of ESM, RESM, and CJS module systems.