### PR TITLE
ses/enablements: add some missing enablements

### DIFF
--- a/packages/ses/src/enablements.js
+++ b/packages/ses/src/enablements.js
@@ -77,6 +77,12 @@ export default {
     constructor: t, // set by "fast-json-patch"
     message: t,
     name: t, // set by "precond"
+    toString: t, // set by "bluebird"
+  },
+
+  TypeErrorPrototype: {
+    constructor: t, // set by "readable-stream"
+    name: t, // set by "readable-stream"
   },
 
   PromisePrototype: {

--- a/packages/ses/test/enable-property-overrides.test.js
+++ b/packages/ses/test/enable-property-overrides.test.js
@@ -65,6 +65,7 @@ test('enablePropertyOverrides - on', t => {
     ArrayPrototype: Array.prototype,
     FunctionPrototype: Function.prototype,
     ErrorPrototype: Error.prototype,
+    TypeErrorPrototype: TypeError.prototype,
     PromisePrototype: Promise.prototype,
     JSON,
   };
@@ -83,7 +84,13 @@ test('enablePropertyOverrides - on', t => {
     'bind',
     'toString',
   ]);
-  testOverriding(t, 'Error', new Error(), ['constructor', 'name', 'message']);
+  testOverriding(t, 'Error', new Error(), [
+    'constructor',
+    'name',
+    'message',
+    'toString',
+  ]);
+  testOverriding(t, 'TypeError', new TypeError(), ['constructor', 'name']);
   // eslint-disable-next-line func-names
   testOverriding(t, 'Promise', new Promise(function() {}), ['constructor']);
   testOverriding(t, 'JSON', JSON);


### PR DESCRIPTION
Fixes #226 

I didn't include these two. Looks like there were also tests validating that they are override-able, wouldn't want to lose them either 
https://github.com/Agoric/SES/commit/d695dfbcf3b37a31d4ae0ab3f9ae7a754f02fd26
```
   AsyncFunction: {
      prototype: {
        constructor: t,
        name: t,
        toString: t,
      },
    },

    AsyncGeneratorFunction: {
      prototype: {
        constructor: t,
        name: t,
        toString: t,
      },
    },
```