### PR TITLE
make-hardener v0.0.8

### DIFF
--- a/packages/harden/package.json
+++ b/packages/harden/package.json
@@ -37,7 +37,7 @@
     "build": "rollup -c rollup.config.js"
   },
   "dependencies": {
-    "@agoric/make-hardener": "0.0.7"
+    "@agoric/make-hardener": "0.0.8"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",

--- a/packages/make-hardener-integration-test/package.json
+++ b/packages/make-hardener-integration-test/package.json
@@ -28,7 +28,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@agoric/make-hardener": "0.0.7"
+    "@agoric/make-hardener": "0.0.8"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",

--- a/packages/make-hardener/NEWS.md
+++ b/packages/make-hardener/NEWS.md
@@ -1,6 +1,11 @@
 User-visible changes in make-hardener:
 
-## Release 0.0.7 (13-Mar-2019)
+## Release 0.0.8 (16-Mar-2020)
+
+* Hybrid module system support: CommonJS, ESM, emulated ESM with `node -r esm`,
+  Rollup, UMD for script tags, and unpkg.com.
+
+## Release 0.0.7 (13-Mar-2020)
 
 * The `harden` function no longer has a `prototype`.
   This is necessary for compatibility with SES 0.7.

--- a/packages/make-hardener/package.json
+++ b/packages/make-hardener/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/make-hardener",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Create a 'hardener' which freezes the API surface of a set of objects",
   "author": "Agoric",
   "license": "Apache-2.0",

--- a/packages/make-hardener/package.json
+++ b/packages/make-hardener/package.json
@@ -19,7 +19,8 @@
     "url": "git+https://github.com/Agoric/ses-shim.git"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "directories": {
     "test": "test"

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -24,7 +24,7 @@
     "demo": "http-server -o /demos"
   },
   "dependencies": {
-    "@agoric/make-hardener": "0.0.7"
+    "@agoric/make-hardener": "0.0.8"
   },
   "devDependencies": {
     "@agoric/test262-runner": "~0.1.0",


### PR DESCRIPTION
This release addresses #217 so that SES 0.7 will work when imported by an
ECMAScript module in Node.js among other environments.