### PR TITLE
fix(ses): remove code that failed to add species

### DIFF
--- a/packages/ses/src/tame-global-reg-exp-object.js
+++ b/packages/ses/src/tame-global-reg-exp-object.js
@@ -1,8 +1,4 @@
-const {
-  defineProperties,
-  getOwnPropertyDescriptors,
-  getOwnPropertyDescriptor,
-} = Object;
+const { defineProperties, getOwnPropertyDescriptors } = Object;
 
 export default function tameGlobalRegExpObject() {
   // Tame the %RegExp% intrinsic.
@@ -20,10 +16,6 @@ export default function tameGlobalRegExpObject() {
     }
     return unsafeRegExp(...rest);
   };
-
-  // Whitelist static properties.
-  const desc = getOwnPropertyDescriptor(unsafeRegExp, Symbol.species);
-  defineProperties(tamedRegExp, Symbol.species, desc);
 
   // Copy prototype properties.
   const prototypeDescs = getOwnPropertyDescriptors(unsafeRegExp.prototype);

--- a/packages/ses/test/tame-global-reg-exp-object.test.js
+++ b/packages/ses/test/tame-global-reg-exp-object.test.js
@@ -20,6 +20,8 @@ test('tameGlobalRegExpObject - constructor', t => {
   const properties = Reflect.ownKeys(RegExp);
   t.deepEqual(
     properties.sort(),
+    // What about species?
+    // See https://github.com/Agoric/SES-shim/issues/239
     ['length', 'name', 'prototype'].sort(),
     'RegExp should not have static properties',
   );

--- a/scripts/build-post-release-test.sh
+++ b/scripts/build-post-release-test.sh
@@ -4,6 +4,6 @@ DIR=$(dirname -- "${BASH_SOURCE[0]}")
 cd "$DIR/.."
 npm run-script build
 cd packages/ses-integration-test
-npm install --no-save "$( npm pack ../ses )"
+npm install --no-save "$( npm pack ../ses | tail -1 )"
 npm run create-test-file-no-lib-cjs
 npm run create-test-file-browserified-tape

--- a/scripts/build-pre-release-test.sh
+++ b/scripts/build-pre-release-test.sh
@@ -4,7 +4,7 @@ DIR=$(dirname -- "${BASH_SOURCE[0]}")
 cd "$DIR/.."
 npm run-script build
 cd packages/ses-integration-test
-npm install --no-save "$( npm pack ../ses )"
+npm install --no-save "$( npm pack ../ses | tail -1 )"
 npm run create-test-file-no-lib-cjs
 npm run create-test-file-esm
 npm run create-test-file-cjs


### PR DESCRIPTION
Fixes #239 

The existing code attempted to set the species of the `tamedRegExp` constructor, but failed to. This removes the useless attempt. Were it to successfully set species, another test would already fail because it would fall outside that test's whitelist. Thus, no additional test was needed. Just removing useless code.