### PR TITLE
chore(ses): Introduce Node-style module specifier resolver

### DIFF
--- a/packages/ses/test/node.js
+++ b/packages/ses/test/node.js
@@ -1,0 +1,62 @@
+// Module node.js provides resolve and locate hooks that follow a subset of
+// Node.js module semantics.
+
+const q = JSON.stringify;
+
+const isRelative = spec =>
+  spec.startsWith('./') ||
+  spec.startsWith('../') ||
+  spec === '.' ||
+  spec === '..';
+
+export const resolve = (spec, referrer) => {
+  spec = String(spec || '');
+  referrer = String(referrer || '');
+
+  if (spec.startsWith('/')) {
+    throw TypeError(`Module specifier ${q(spec)} must not begin with "/"`);
+  }
+  if (!referrer.startsWith('./')) {
+    throw TypeError(`Module referrer ${q(referrer)} must begin with "./"`);
+  }
+
+  const parts = [];
+  const path = [];
+  if (isRelative(spec)) {
+    path.push(...referrer.split('/'));
+    path.pop();
+    parts.push('.');
+  }
+  path.push(...spec.split('/'));
+
+  for (const part of path) {
+    if (part === '.' || part === '') {
+      // no-op
+    } else if (part === '..') {
+      if (path.length === 0) {
+        throw TypeError(
+          `Module specifier ${q(spec)} via referrer ${q(
+            referrer,
+          )} must not traverse behind an empty path`,
+        );
+      }
+      parts.pop();
+    } else {
+      parts.push(part);
+    }
+  }
+
+  return parts.join('/');
+};
+
+export const makeLocator = root => {
+  if (!root.endsWith('/')) {
+    root += '/';
+  }
+  return spec => {
+    if (!isRelative(spec)) {
+      throw TypeError(`Cannot locate module ${q(spec)}.`);
+    }
+    return new URL(spec, root).toString();
+  };
+};

--- a/packages/ses/test/node.test.js
+++ b/packages/ses/test/node.test.js
@@ -1,0 +1,70 @@
+import tap from 'tap';
+import { resolve } from './node.js';
+
+const { test } = tap;
+
+const q = JSON.stringify;
+
+[
+  // Cover degenerate cases
+  { res: '', rel: '', via: './main.js' },
+  { res: '.', rel: '.', via: './main.js' },
+
+  // Non-relative (external) specifiers disregard the referrer.
+  { res: 'external', rel: 'external', via: './main.js' },
+  { res: 'out/side', rel: 'out/side', via: './main.js' },
+  { res: 'external', rel: 'external', via: './anywhere/main.js' },
+  { res: 'out/side', rel: 'out/side', via: './anywhere/main.js' },
+  { res: 'external', rel: 'external', via: './some/where/main.js' },
+  { res: 'out/side', rel: 'out/side', via: './some/where/main.js' },
+  // And path arithmetic works.
+  { res: 'side', rel: 'out/../side', via: './some/where/main.js' },
+  { res: 'out/side', rel: 'out/./side', via: './some/where/main.js' },
+  { res: 'out/side', rel: 'out//side', via: './some/where/main.js' },
+
+  // Relative (internal) references build upon the referrer.
+  { res: './internal', rel: './internal', via: './main.js' },
+  { res: './from/to', rel: './to', via: './from/main.js' },
+  // And path arithmetic works.
+  { res: '.', rel: './into/..', via: './main.js' },
+  { res: '.', rel: './into/./..', via: './main.js' },
+  { res: '.', rel: './into//..', via: './main.js' },
+  { res: './from', rel: './to/..', via: './from/main.js' },
+  { res: './to', rel: '../to', via: './from/main.js' },
+  { res: './from', rel: '.', via: './from/main.js' },
+  { res: '.', rel: '..', via: './from/main.js' },
+].forEach(c => {
+  test(`resolve(${q(c.rel)}, ${q(c.via)}) -> ${q(c.res)}`, t => {
+    const res = resolve(c.rel, c.via);
+    t.equal(res, c.res);
+    t.end();
+  });
+});
+
+test('throws if the specifier is non-relative', t => {
+  t.throws(() => {
+    resolve('/', '');
+  }, /Module specifier "\/" must not begin with "\/"/);
+  t.end();
+});
+
+test('throws if the referrer is non-relative', t => {
+  t.throws(() => {
+    resolve('', '/');
+  }, /Module referrer "\/" must begin with "\.\/"/);
+  t.end();
+});
+
+test('throws if the referrer is external', t => {
+  t.throws(() => {
+    resolve('', 'external');
+  }, /Module referrer "external" must begin with "\.\/"/);
+  t.end();
+});
+
+test('throws if the referrer is external (degenerate case)', t => {
+  t.throws(() => {
+    resolve('', '');
+  }, /Module referrer "" must begin with "\.\/"/);
+  t.end();
+});


### PR DESCRIPTION
Toward introducing Compartment.import, we will need a resolveHook to pass to the Compartment constructor.  This resolve function implements Node.js style module specifier resolution.  A Node.js package compartment distinguishes internal and external specifier based on whether they resemble relative paths.  The referrer in a Compartment will always have an internal path.  The specifier may be relative or non-relative to address internal or external modules respectively.  Although Node.js affords absolute paths as module specififers, the Compartment API will not accommodate these specifiers at least upon the first draft.

This module is neither yet used nor public.  Its behavior may be a suitable default for all Compartment but that remains undecided.  Consequently, this module is likely to move to an external package as a utility for Node.js compartment specifically.