### PR TITLE
We need to publish the harden src directory for NPM to work

### DIFF
--- a/packages/harden/package.json
+++ b/packages/harden/package.json
@@ -23,7 +23,8 @@
   },
   "files": [
     "dist",
-    "index.d.ts"
+    "index.d.ts",
+    "src"
   ],
   "type": "module",
   "main": "./src/main.js",


### PR DESCRIPTION
@kriskowal would you be able to publish a new version of `@agoric/harden` based on this?  The current 0.0.6 is broken.

Without this PR, we get:

```
Error: Cannot find module '@agoric/harden'. Please verify that the package.json has a valid "main" entry] {
  code: 'MODULE_NOT_FOUND',
  path: '/Users/michael/agoric/agoric-sdk/node_modules/@agoric/harden/package.json',
  requestPath: '@agoric/harden'
}
```
