### PR TITLE
Allow silencing SecurityWarning

### DIFF
--- a/packages/harden/src/main.js
+++ b/packages/harden/src/main.js
@@ -26,7 +26,9 @@ if (h === undefined) {
 
 if (h === undefined) {
   // Warn if they haven't explicitly set harden or SES.harden.
-  console.warn(`SecurityWarning: '@agoric/harden' is ineffective without SES`);
+  console.warn(
+    `SecurityWarning: '@agoric/harden' doesn't prevent prototype poisoning without SES`,
+  );
 }
 
 // Create the shim if h is anything falsey.

--- a/packages/harden/src/main.js
+++ b/packages/harden/src/main.js
@@ -18,15 +18,19 @@ import makeHardener from '@agoric/make-hardener';
 import buildTable from './buildTable.js';
 
 // Try to use SES's own harden if available.
-let h = typeof harden !== 'undefined' && harden;
-if (!h) {
+let h = typeof harden === 'undefined' ? undefined : harden;
+if (h === undefined) {
   // Legacy SES compatibility.
-  h = typeof SES !== 'undefined' && SES.harden;
+  h = typeof SES === 'undefined' ? undefined : SES.harden;
 }
 
-if (!h) {
+if (h === undefined) {
+  // Warn if they haven't explicitly set harden or SES.harden.
   console.warn(`SecurityWarning: '@agoric/harden' is ineffective without SES`);
+}
 
+// Create the shim if h is anything falsey.
+if (!h) {
   // Hunt down our globals.
   // eslint-disable-next-line no-new-func
   const g = Function('return this')();


### PR DESCRIPTION
The `SecurityWarning` should be able to be explicitly silenced.  One way to do this is:

`my-test.js`:

```js
import './initialize-ses.js';
import harden from '@agoric/harden';

... test code
```

`initialize-ses.js`:

```js
// Tell that we don't have harden yet, but don't want to warn.
globalThis.harden = false;
```
</details>

Also, update the text of the `SecurityWarning` to describe what the issue is.
