### PR TITLE
Export Compartment as Compartment instead of default

### DIFF
--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -10,7 +10,7 @@ import { getCurrentRealmRec } from './realm-rec.js';
  */
 const privateFields = new WeakMap();
 
-export default class Compartment {
+export class Compartment {
   constructor(endowments, modules, options = {}) {
     // Extract options, and shallow-clone transforms.
     const { transforms = [] } = options;

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -25,7 +25,7 @@ import tameGlobalMathObject from './tame-global-math-object.js';
 import tameGlobalRegExpObject from './tame-global-reg-exp-object.js';
 
 import enablePropertyOverrides from './enable-property-overrides.js';
-import Compartment from './compartment-shim.js';
+import { Compartment } from './compartment-shim.js';
 
 let previousOptions;
 

--- a/packages/ses/src/main.js
+++ b/packages/ses/src/main.js
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 export { lockdown } from './lockdown-shim.js';
+export { Compartment } from './compartment-shim.js';

--- a/packages/ses/test/break-function-eval.test.js
+++ b/packages/ses/test/break-function-eval.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import Compartment from '../src/compartment-shim.js';
+import { Compartment } from '../src/compartment-shim.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/compartment-constructor.test.js
+++ b/packages/ses/test/compartment-constructor.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import Compartment from '../src/compartment-shim.js';
+import { Compartment } from '../src/compartment-shim.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/compartment-instance.test.js
+++ b/packages/ses/test/compartment-instance.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import Compartment from '../src/compartment-shim.js';
+import { Compartment } from '../src/compartment-shim.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/compartment-prototype.test.js
+++ b/packages/ses/test/compartment-prototype.test.js
@@ -1,5 +1,5 @@
 import tap from 'tap';
-import Compartment from '../src/compartment-shim.js';
+import { Compartment } from '../src/compartment-shim.js';
 
 const { test } = tap;
 

--- a/packages/ses/test/confinement.test.js
+++ b/packages/ses/test/confinement.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import Compartment from '../src/compartment-shim.js';
+import { Compartment } from '../src/compartment-shim.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/global-object-mutability.test.js
+++ b/packages/ses/test/global-object-mutability.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import Compartment from '../src/compartment-shim.js';
+import { Compartment } from '../src/compartment-shim.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/global-object-properties.test.js
+++ b/packages/ses/test/global-object-properties.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import Compartment from '../src/compartment-shim.js';
+import { Compartment } from '../src/compartment-shim.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/identity-continuity.test.js
+++ b/packages/ses/test/identity-continuity.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import Compartment from '../src/compartment-shim.js';
+import { Compartment } from '../src/compartment-shim.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/leak-endowments.test.js
+++ b/packages/ses/test/leak-endowments.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import Compartment from '../src/compartment-shim.js';
+import { Compartment } from '../src/compartment-shim.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/leak-unsafe-eval.test.js
+++ b/packages/ses/test/leak-unsafe-eval.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import Compartment from '../src/compartment-shim.js';
+import { Compartment } from '../src/compartment-shim.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/lockdown.test.js
+++ b/packages/ses/test/lockdown.test.js
@@ -1,5 +1,5 @@
 import test from 'tape';
-import Compartment from '../src/compartment-shim.js';
+import { Compartment } from '../src/compartment-shim.js';
 import { lockdown } from '../src/lockdown-shim.js';
 
 test('lockdown returns boolean or throws in SES', t => {

--- a/packages/ses/test/reject-direct-eval.test.js
+++ b/packages/ses/test/reject-direct-eval.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import Compartment from '../src/compartment-shim.js';
+import { Compartment } from '../src/compartment-shim.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/reject-html-comment.test.js
+++ b/packages/ses/test/reject-html-comment.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import Compartment from '../src/compartment-shim.js';
+import { Compartment } from '../src/compartment-shim.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/reject-import-expression.test.js
+++ b/packages/ses/test/reject-import-expression.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import Compartment from '../src/compartment-shim.js';
+import { Compartment } from '../src/compartment-shim.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/typeof.test.js
+++ b/packages/ses/test/typeof.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import Compartment from '../src/compartment-shim.js';
+import { Compartment } from '../src/compartment-shim.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test262/compartment-shim.js
+++ b/packages/ses/test262/compartment-shim.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test262Runner from '@agoric/test262-runner';
-import Compartment from '../src/compartment-shim.js';
+import { Compartment } from '../src/compartment-shim.js';
 
 export default function patchFunctionConstructors() {
   /* eslint-disable no-proto */


### PR DESCRIPTION
With this change, Compartment becomes a public export.  This puts lockdown and Compartment on even footing, since it will no longer be necessary to lockdown to realize the Compartment global. In a planned change, Compartment will likely become a separate package.