### PR TITLE
fix(transform-module)!: Use @agoric/babel-standalone over @babel/core

### DIFF
--- a/packages/transform-module/NEWS.md
+++ b/packages/transform-module/NEWS.md
@@ -1,0 +1,8 @@
+# Next release BREAKING CHANGES
+
+* This version changes the contract of all functions that receive a Babel
+  dependency from accepting an object implementing { transformSync and
+  transformFromAstSync } to merely { transform and transformFromAst }.
+  The former were exported by `@babel/core`, but we are now using the
+  API that surfaces from `@babel/standalone` and our fork
+  `@agoric/babel-standalone`.

--- a/packages/transform-module/README.md
+++ b/packages/transform-module/README.md
@@ -12,8 +12,8 @@ record's metadata, evaluate the functor, call the functor with linkage.
 
 ```js
 import { makeModuleAnalyzer } from './src/main.js';
-import babelCore from '@babel/core';
-const analyze = makeModuleAnalyzer(babelCore);
+import * as babel from '@agoric/babel-standalone';
+const analyze = makeModuleAnalyzer(babel.default);
 const moduleStaticRecord = analyze(moduleSource);
 const moduleFunctor = evaluateModuleFunctor(moduleStaticRecord.functorSource, /* ... */);
 moduleFunctor({

--- a/packages/transform-module/package.json
+++ b/packages/transform-module/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@agoric/make-simple-evaluate": "0.1.0",
-    "@babel/core": "7.7.5",
+    "@babel/standalone": "^7.9.5",
     "rollup": "1.31.0",
     "rollup-plugin-node-resolve": "5.2.0"
   },

--- a/packages/transform-module/package.json
+++ b/packages/transform-module/package.json
@@ -43,8 +43,8 @@
     "tap": "14.10.5"
   },
   "dependencies": {
+    "@agoric/babel-standalone": "^7.9.5",
     "@agoric/make-simple-evaluate": "0.1.0",
-    "@babel/standalone": "^7.9.5",
     "rollup": "1.31.0",
     "rollup-plugin-node-resolve": "5.2.0"
   },

--- a/packages/transform-module/src/main.js
+++ b/packages/transform-module/src/main.js
@@ -1,7 +1,7 @@
 import * as h from './hidden.js';
 import makeModulePlugins from './babelPlugin.js';
 
-const makeTransformSource = babelCore =>
+const makeTransformSource = babel =>
   function transformSource(source, sourceOptions = {}) {
     // Transform the script/expression source for import expressions.
     const parserPlugins = [];
@@ -44,7 +44,7 @@ const makeTransformSource = babelCore =>
 
     // console.log(`transforming`, sourceOptions, source);
     const modulePlugins = makeModulePlugins(sourceOptions);
-    const output = babelCore.transformSync(source, {
+    const output = babel.transform(source, {
       parserOpts: {
         // allowAwaitOutsideFunction: true,
         plugins: parserPlugins,
@@ -58,7 +58,7 @@ const makeTransformSource = babelCore =>
     });
     let { ast, code } = output;
     for (let i = 1; i < modulePlugins.length - 1; i += 1) {
-      const middleOut = babelCore.transformFromAstSync(ast, source, {
+      const middleOut = babel.transformFromAst(ast, source, {
         plugins: [modulePlugins[i]],
         ast: true,
         code: false,
@@ -66,7 +66,7 @@ const makeTransformSource = babelCore =>
       ast = middleOut.ast;
     }
     if (modulePlugins.length > 1) {
-      const finalOut = babelCore.transformFromAstSync(ast, source, {
+      const finalOut = babel.transformFromAst(ast, source, {
         generatorOpts: {
           retainLines: true,
         },
@@ -162,14 +162,14 @@ const makeCreateStaticRecord = transformSource =>
     return moduleStaticRecord;
   };
 
-export const makeModuleAnalyzer = babelCore => {
-  const transformSource = makeTransformSource(babelCore);
+export const makeModuleAnalyzer = babel => {
+  const transformSource = makeTransformSource(babel);
   const createStaticRecord = makeCreateStaticRecord(transformSource);
   return ({ string }) => createStaticRecord(string);
 };
 
-export const makeModuleTransformer = (babelCore, importer) => {
-  const transformSource = makeTransformSource(babelCore);
+export const makeModuleTransformer = (babel, importer) => {
+  const transformSource = makeTransformSource(babel);
   const createStaticRecord = makeCreateStaticRecord(transformSource);
   return {
     rewrite(ss) {

--- a/packages/transform-module/test/export-default.test.js
+++ b/packages/transform-module/test/export-default.test.js
@@ -4,10 +4,11 @@ import {
   evaluateProgram as evaluate,
 } from '@agoric/make-simple-evaluate';
 
-import * as babelCore from '@babel/core';
+import * as babelStandalone from '@babel/standalone';
 
 import { makeModuleTransformer } from '../src/main.js';
 
+const { default: babel } = babelStandalone;
 const { test } = tap;
 
 const makeImporter = () => (srcSpec, endowments) => {
@@ -39,7 +40,7 @@ const makeImporter = () => (srcSpec, endowments) => {
 
 test('export default', async t => {
   try {
-    const transforms = [makeModuleTransformer(babelCore, makeImporter())];
+    const transforms = [makeModuleTransformer(babel, makeImporter())];
     const { evaluateExpr, evaluateProgram, evaluateModule } = makeEvaluators({
       transforms,
     });

--- a/packages/transform-module/test/export-named.test.js
+++ b/packages/transform-module/test/export-named.test.js
@@ -4,10 +4,11 @@ import {
   evaluateProgram as evaluate,
 } from '@agoric/make-simple-evaluate';
 
-import * as babelCore from '@babel/core';
+import * as babelStandalone from '@babel/standalone';
 
 import { makeModuleTransformer } from '../src/main.js';
 
+const { default: babel } = babelStandalone;
 const { test } = tap;
 
 const makeImporter = (liveVars = []) => async (srcSpec, endowments) => {
@@ -61,7 +62,7 @@ const makeImporter = (liveVars = []) => async (srcSpec, endowments) => {
 test(`export named`, async t => {
   try {
     const importer = makeImporter(['def']);
-    const transforms = [makeModuleTransformer(babelCore, importer)];
+    const transforms = [makeModuleTransformer(babel, importer)];
     const { evaluateModule } = makeEvaluators({
       transforms,
     });
@@ -103,7 +104,7 @@ export const { def, nest: [, ghi, ...nestrest], ...rest } = { def: 456, nest: [ 
 test(`export hoisting`, async t => {
   try {
     const importer = makeImporter(['abc', 'fn']);
-    const transforms = [makeModuleTransformer(babelCore, importer)];
+    const transforms = [makeModuleTransformer(babel, importer)];
     const { evaluateModule } = makeEvaluators({
       transforms,
     });
@@ -155,7 +156,7 @@ export const fn3 = fn;
 test(`export class`, async t => {
   try {
     const importer = makeImporter(['C', 'F', 'count']);
-    const transforms = [makeModuleTransformer(babelCore, importer)];
+    const transforms = [makeModuleTransformer(babel, importer)];
     const { evaluateModule } = makeEvaluators({
       transforms,
     });

--- a/packages/transform-module/test/import.test.js
+++ b/packages/transform-module/test/import.test.js
@@ -4,10 +4,11 @@ import {
   evaluateProgram as evaluate,
 } from '@agoric/make-simple-evaluate';
 
-import * as babelCore from '@babel/core';
+import * as babelStandalone from '@babel/standalone';
 
 import { makeModuleTransformer } from '../src/main.js';
 
+const { default: babel } = babelStandalone;
 const { test } = tap;
 
 const makeImporter = () => async (srcSpec, endowments) => {
@@ -36,7 +37,7 @@ const makeImporter = () => async (srcSpec, endowments) => {
 test('import', async t => {
   try {
     const importer = makeImporter();
-    const transforms = [makeModuleTransformer(babelCore, importer)];
+    const transforms = [makeModuleTransformer(babel, importer)];
     const { evaluateModule } = makeEvaluators({
       transforms,
     });

--- a/packages/transform-module/test/sanity.test.js
+++ b/packages/transform-module/test/sanity.test.js
@@ -1,15 +1,16 @@
 import tap from 'tap';
 import { makeEvaluators } from '@agoric/make-simple-evaluate';
 
-import * as babelCore from '@babel/core';
+import * as babelStandalone from '@babel/standalone';
 
 import { makeModuleTransformer } from '../src/main.js';
 
+const { default: babel } = babelStandalone;
 const { test } = tap;
 
 test('sanity', async t => {
   try {
-    const transforms = [makeModuleTransformer(babelCore)];
+    const transforms = [makeModuleTransformer(babel)];
     const { evaluateExpr, evaluateProgram: evaluateModule } = makeEvaluators({
       transforms,
     });


### PR DESCRIPTION
Rolling up @babel/core and @babel/standalone in SES both proved problematic. The former because of a bad interaction with Rollup. The latter because it entrains the package `private` which shims intrinsics and interferes with SES lockdown. To that end @michaelfig has published a version of @babel/standalone as @agoric/babel-standalone with the packages that interfere with SES omitted.

This is a preamble to introducing @agoric/transform-module as a dependency of SES and supporting module loaders in compartments.