### PR TITLE
fix(transform-module)!: Freeze module static records

### DIFF
--- a/packages/transform-module/NEWS.md
+++ b/packages/transform-module/NEWS.md
@@ -6,3 +6,4 @@
   The former were exported by `@babel/core`, but we are now using the
   API that surfaces from `@babel/standalone` and our fork
   `@agoric/babel-standalone`.
+* Module static records are now frozen.

--- a/packages/transform-module/src/main.js
+++ b/packages/transform-module/src/main.js
@@ -1,6 +1,8 @@
 import * as h from './hidden.js';
 import makeModulePlugins from './babelPlugin.js';
 
+const { freeze } = Object;
+
 const makeTransformSource = babel =>
   function transformSource(source, sourceOptions = {}) {
     // Transform the script/expression source for import expressions.
@@ -151,13 +153,13 @@ const makeCreateStaticRecord = transformSource =>
   ${scriptSource}
 })`;
 
-    const moduleStaticRecord = {
-      exportAlls: sourceOptions.exportAlls,
-      imports: sourceOptions.imports,
-      liveExportMap: sourceOptions.liveExportMap,
-      fixedExportMap: sourceOptions.fixedExportMap,
+    const moduleStaticRecord = freeze({
+      exportAlls: freeze(sourceOptions.exportAlls),
+      imports: freeze(sourceOptions.imports),
+      liveExportMap: freeze(sourceOptions.liveExportMap),
+      fixedExportMap: freeze(sourceOptions.fixedExportMap),
       functorSource,
-    };
+    });
     // console.log(moduleStaticRecord);
     return moduleStaticRecord;
   };


### PR DESCRIPTION
This change freezes the surface of module static records provided by transform-module.

While this is not necessary for any security property of SES, it is one more assurance to ease them through review.

Notably, this “inner” module static record still carries the transformed source and SES will create a thin ModuleStaticRecord that hides this “analysis” result entirely, not for any security property, but to avoid unnecessarily exposing implementation details that should remain free to evolve.