### PR TITLE
Add module exports namespace proxy

### DIFF
--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -1,3 +1,11 @@
+// For brevity, in this file, as in module-link.js, the term "moduleRecord"
+// without qualification means "module compartment record".
+// This is a super-set of the "module static record", that is reusable between
+// compartments with different hooks.
+// The "module compartment record" captures the compartment and overlays the
+// module's "imports" with the more specific "resolvedImports" as inferred from
+// the particular compartment's "resolveHook".
+
 const { create, keys, values, freeze } = Object;
 
 // `makeAlias` constructs compartment specifier tuples for the `aliases`

--- a/packages/ses/src/module-proxy.js
+++ b/packages/ses/src/module-proxy.js
@@ -1,0 +1,154 @@
+// Compartments need a mechanism to link a module from one compartment
+// to another.
+// The procedure is to use `compartment.module(specifier)` to obtain the module
+// exports namespace from one compartment, possibly before importing or even
+// merely loading module, and threading it into the module map of another
+// compartment.
+// For this to be possible, it is necessary to model the module exports
+// namespace as a proxy that will treat all access to those exported properties
+// as reference errors until the properties of the actual module are known.
+// This provides the mechanism for modeling the public exports proxy
+// and eventually connecting it to to the proxied exports.
+
+import { makeAlias } from './module-load.js';
+
+const { create, freeze } = Object;
+// q, as in quote, for error messages.
+const q = JSON.stringify;
+
+// `deferExports` creates a module's exports proxy, proxied exports, and
+// activator.
+// A `Compartment` can create a module for any module specifier, regardless of
+// whether it is loadable or executable, and use that object as a token that
+// can be fed into another compartment's module map.
+// Only after the specified module has been analyzed is it possible for the
+// module namespace proxy to behave properly, so it throws exceptions until
+// after the compartment has begun executing the module.
+// The module instance must freeze the proxied exports and activate the exports
+// proxy before executing the module.
+//
+// The module exports proxy's behavior differs from the ECMAScript 262
+// specification for "module namespace exotic objects" only in that according
+// to the specification value property descriptors have a non-writable "value"
+// and this implementation models all properties with accessors.
+//
+// https://tc39.es/ecma262/#sec-module-namespace-exotic-objects
+//
+export const deferExports = () => {
+  let active = false;
+  const proxiedExports = create(null);
+  return freeze({
+    activate() {
+      active = true;
+    },
+    proxiedExports,
+    exportsProxy: new Proxy(proxiedExports, {
+      get(_target, name, receiver) {
+        if (!active) {
+          throw new TypeError(
+            `Cannot get property ${q(
+              name,
+            )} of module exports namespace, the module has not yet begun to execute`,
+          );
+        }
+        return Reflect.get(proxiedExports, name, receiver);
+      },
+      set(_target, name, _value) {
+        throw new TypeError(
+          `Cannot set property ${q(name)} of module exports namespace`,
+        );
+      },
+      has(_target, name) {
+        if (!active) {
+          throw new TypeError(
+            `Cannot check property ${q(
+              name,
+            )}, the module has not yet begun to execute`,
+          );
+        }
+        return Reflect.has(proxiedExports, name);
+      },
+      deleteProperty(_target, name) {
+        throw new TypeError(
+          `Cannot delete property ${q(name)}s of module exports namespace`,
+        );
+      },
+      ownKeys(_target) {
+        if (!active) {
+          throw new TypeError(
+            `Cannot enumerate keys, the module has not yet begun to execute`,
+          );
+        }
+        // return Object.keys(proxiedExports);
+        return Reflect.ownKeys(proxiedExports);
+      },
+      getOwnPropertyDescriptor(_target, name) {
+        if (!active) {
+          throw new TypeError(
+            `Cannot get own property descriptor ${q(
+              name,
+            )}, the module has not yet begun to execute`,
+          );
+        }
+        return Reflect.getOwnPropertyDescriptor(proxiedExports, name);
+      },
+      preventExtensions(_target) {
+        if (!active) {
+          throw new TypeError(
+            `Cannot prevent extensions of module exports namespace, the module has not yet begun to execute`,
+          );
+        }
+        return Reflect.preventExtensions(proxiedExports);
+      },
+      isExtensible() {
+        if (!active) {
+          throw new TypeError(
+            `Cannot check extensibility of module exports namespace, the module has not yet begun to execute`,
+          );
+        }
+        return Reflect.isExtensible(proxiedExports);
+      },
+      getPrototypeOf(_target) {
+        return null;
+      },
+      setPrototypeOf(_target, _proto) {
+        throw new TypeError(`Cannot set prototype of module exports namespace`);
+      },
+      defineProperty(_target, name, _descriptor) {
+        throw new TypeError(
+          `Cannot define property ${q(name)} of module exports namespace`,
+        );
+      },
+      apply(_target, _thisArg, _args) {
+        throw new TypeError(
+          `Cannot call module exports namespace, it is not a function`,
+        );
+      },
+      construct(_target, _args) {
+        throw new TypeError(
+          `Cannot construct module exports namespace, it is not a constructor`,
+        );
+      },
+    }),
+  });
+};
+
+// `getDeferredExports` memoizes the creation of a deferred module exports
+// namespace proxy for any abritrary full specifier in a compartment.
+// It also records the compartment and specifier affiliated with that module
+// exports namespace proxy so it can be used as an alias into another
+// compartment when threaded through a compartment's `moduleMap` argument.
+export const getDeferredExports = (
+  compartment,
+  compartmentPrivateFields,
+  moduleAliases,
+  specifier,
+) => {
+  const { deferredExports } = compartmentPrivateFields;
+  if (!deferredExports.has(specifier)) {
+    const deferred = deferExports();
+    moduleAliases.set(deferred.exportsProxy, makeAlias(compartment, specifier));
+    deferredExports.set(specifier, deferred);
+  }
+  return deferredExports.get(specifier);
+};

--- a/packages/ses/test/module-proxy.test.js
+++ b/packages/ses/test/module-proxy.test.js
@@ -1,0 +1,134 @@
+import tap from 'tap';
+import { deferExports } from '../src/module-proxy.js';
+
+const { test } = tap;
+const { keys, seal, isExtensible } = Object;
+
+test('proxied exports keys are readable', t => {
+  t.plan(2);
+  const { proxiedExports, exportsProxy, activate } = deferExports();
+  t.throws(
+    () => {
+      keys(exportsProxy);
+    },
+    /^Cannot enumerate keys/,
+    'keys fails for inactive module',
+  );
+  proxiedExports.a = 10;
+  proxiedExports.b = 20;
+  activate();
+  t.deepEqual(keys(exportsProxy), ['a', 'b']);
+});
+
+test('proxied exports is not extensible', t => {
+  t.plan(1);
+  const { proxiedExports, exportsProxy, activate } = deferExports();
+  seal(proxiedExports);
+  activate();
+  t.ok(
+    !isExtensible(exportsProxy),
+    'sealed module means sealed proxied exports',
+  );
+});
+
+test('proxied exports has own keys', t => {
+  t.plan(3);
+  const { proxiedExports, exportsProxy, activate } = deferExports();
+  t.throws(
+    () => {
+      'irrelevant' in exportsProxy;
+    },
+    /^Cannot check property/,
+    'module must throw error for owns trap before it begins executing',
+  );
+  proxiedExports.present = 'here';
+  activate(seal());
+  t.ok('present' in exportsProxy, 'module has key');
+  t.ok(!('absent' in exportsProxy), 'module does not have key');
+});
+
+test('proxied exports set/get round-trip', t => {
+  t.plan(3);
+  const { proxiedExports, exportsProxy, activate } = deferExports();
+  t.throws(
+    () => {
+      exportsProxy.ceciNEstPasUnePipe;
+    },
+    /^Cannot get property/,
+    'properties must not be known until execution begins',
+  );
+  t.throws(
+    () => {
+      exportsProxy.ceciNEstPasUnePipe = 'pipe';
+    },
+    /^Cannot set property/,
+    'properties must not be mutable',
+  );
+
+  proxiedExports.ceciNEstPasUnePipe = 'pipe';
+  seal(proxiedExports);
+  activate();
+
+  t.throws(
+    () => {
+      exportsProxy.ceciNEstPasUnePipe = 'not a pipe';
+    },
+    /^Cannot set property/,
+    'properties must not be mutable, even after activation',
+  );
+});
+
+test('proxied exports delete', t => {
+  t.plan(2);
+  const { exportsProxy, activate } = deferExports();
+  t.throws(
+    () => {
+      delete exportsProxy.existentialDread;
+    },
+    /^Cannot delete property/,
+    'deleting before existing throws',
+  );
+  activate();
+  t.throws(
+    () => {
+      delete exportsProxy.cogitoErgoSum;
+    },
+    /^Cannot delete property/,
+    'deleting from a sealed proxy',
+  );
+});
+
+test('proxied exports prototype', t => {
+  t.plan(1);
+  const { exportsProxy } = deferExports();
+  t.equals(
+    Object.getPrototypeOf(exportsProxy),
+    null,
+    'prototype of module exports namespace must be null',
+  );
+});
+
+test('proxied exports is not a function', t => {
+  t.plan(1);
+  const { exportsProxy } = deferExports();
+  t.throws(
+    () => {
+      exportsProxy();
+    },
+    /is not a function$/,
+    'proxied exports must not be callable',
+  );
+});
+
+test('proxied exports is not a constructor', t => {
+  t.plan(1);
+  const { exportsProxy } = deferExports();
+  t.throws(
+    () => {
+      const Constructor = exportsProxy;
+      return new Constructor();
+    },
+    /is not a constructor$/,
+    'proxied exports must not be constructable',
+  );
+});


### PR DESCRIPTION
For a module in one compartment to import a module in another compartment, the Compartments must pre-arrange for a module specifier to alias the other compartment. The mechanism @erights and I discussed to make this possible is the introduction of a compartment.module method that would return the module exports namespace object for a module, possibly before that module has even been loaded. Behind the scenes, a weak map tracks the corresponding compartment and specifier for each module exports namespace object, so the Compartment constructor can infer the alias for any module exports namespace object received through its module map.

To facilitate this, the presentation of a module exports namespace needs to be a proxy for the eventual internal representation, so that any property access on the namespace can throw a reference error before the shape of the exports are known.