### PR TITLE
add enablements to fix tape-4.x

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -2,7 +2,11 @@ User-visible changes in SES:
 
 ## Next release
 
-* No changes yet.
+* Repair `Function.apply` and `TypeError.message` (as well as `.message` on
+  all the other Error types), to tolerate what the npm `es-abstract` module
+  does. This allows `tape` (version 4.x) to be loaded in a locked-down SES
+  world, and also allows its `t.throws` assertion to work. `tape` (version
+  5.x) still has problems. (#293)
 
 ## Release 0.7.7 (27-Apr-2020)
 

--- a/packages/ses/src/enablements.js
+++ b/packages/ses/src/enablements.js
@@ -69,6 +69,7 @@ export default {
   FunctionPrototype: {
     constructor: t, // set by "regenerator-runtime"
     bind: t, // set by "underscore"
+    apply: t, // set by "tape"
     name: t,
     toString: t,
   },
@@ -82,7 +83,28 @@ export default {
 
   TypeErrorPrototype: {
     constructor: t, // set by "readable-stream"
+    message: t, // set by "tape"
     name: t, // set by "readable-stream"
+  },
+
+  SyntaxErrorPrototype: {
+    message: t, // to match TypeErrorPrototype.message
+  },
+
+  RangeErrorPrototype: {
+    message: t, // to match TypeErrorPrototype.message
+  },
+
+  URIErrorPrototype: {
+    message: t, // to match TypeErrorPrototype.message
+  },
+
+  EvalErrorPrototype: {
+    message: t, // to match TypeErrorPrototype.message
+  },
+
+  ReferenceErrorPrototype: {
+    message: t, // to match TypeErrorPrototype.message
   },
 
   PromisePrototype: {

--- a/packages/ses/test/enable-property-overrides.test.js
+++ b/packages/ses/test/enable-property-overrides.test.js
@@ -83,6 +83,7 @@ test('enablePropertyOverrides - on', t => {
     'constructor',
     // 'name', // TODO
     'bind',
+    'apply',
     'toString',
   ]);
   testOverriding(t, 'Error', new Error(), [
@@ -91,7 +92,11 @@ test('enablePropertyOverrides - on', t => {
     'message',
     'toString',
   ]);
-  testOverriding(t, 'TypeError', new TypeError(), ['constructor', 'name']);
+  testOverriding(t, 'TypeError', new TypeError(), [
+    'constructor',
+    'name',
+    'message',
+  ]);
   // eslint-disable-next-line func-names
   testOverriding(t, 'Promise', new Promise(function() {}), ['constructor']);
   testOverriding(t, 'JSON', JSON);


### PR DESCRIPTION
This adds `FunctionPrototype.apply`, as well as `.message` for all the
various Error prototypes, to the enablements list.

This allows tape-4.x to be imported after lockdown, as well as fixing tape's
t.throws() method.

refs #293, but does not close it because tape-5.x is still broken

Note: this currently fails local tests, I think because we have assertions that these items are *not* on the list. I'd appreciate some pointers as to how to fix these.
