### PR TITLE
chore(harden): Fix dev version nit

### DIFF
--- a/packages/harden/package.json
+++ b/packages/harden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agoric/harden",
-  "version": "0.0.8-1-dev",
+  "version": "0.0.8+1-dev",
   "description": "Create a 'hardener' which freezes the API surface of a set of objects",
   "author": "Agoric",
   "license": "Apache-2.0",


### PR DESCRIPTION
Evidently the package check script isn’t failing builds. This is a correction inspired by the package.json linter `scripts/check-packages.sh`.