### PR TITLE
Rename compartment.global to globalThis

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -8,7 +8,7 @@ User-visible changes in SES:
 
 * This version decouples lockdown and the Compartment constructor.
   The Compartment constructor is now exported by `ses` (was previously only
-  available as a property of the global object *after* lockdown).
+  available as a property of `globalThis` *after* lockdown).
   The Compartment constructor will also create "privileged" compartments when
   constructed before lockdown.
 

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -145,7 +145,7 @@ export class Compartment {
     });
   }
 
-  get global() {
+  get globalThis() {
     return privateFields.get(this).globalObject;
   }
 
@@ -204,13 +204,10 @@ export class Compartment {
 
     assertModuleHooks(this);
 
-    await load(privateFields, moduleAnalyses, this, specifier);
-    const module = this.importNow(specifier);
-    // TODO consider revising the specification to use the term `module`
-    // instead of `namespace` to be consistent with the `module` method,
-    // since this establishes a precedent that the term `module` without any
-    // further qualification denotes the module exports namespace.
-    return { namespace: module };
+    return load(privateFields, moduleAnalyses, this, specifier).then(() => {
+      const namespace = this.importNow(specifier);
+      return { namespace };
+    });
   }
 
   importNow(specifier) {

--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -58,8 +58,15 @@ export const FunctionInstance = {
   // since prototpye properties are instance-specific, we define it there.
 };
 
+export const AsyncFunctionInstance = {
+  '**proto**': 'AsyncFunctionPrototype',
+  length: 'number',
+  name: 'string',
+};
+
 // Aliases
 const fn = FunctionInstance;
+const asyncFn = AsyncFunctionInstance;
 
 const getter = {
   get: fn,
@@ -1532,7 +1539,10 @@ export default {
   CompartmentPrototype: {
     constructor: 'Compartment',
     evaluate: fn,
-    global: getter,
+    globalThis: getter,
+    import: asyncFn,
+    importNow: fn,
+    module: fn,
   },
 
   ModuleStaticRecord: {

--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -58,9 +58,14 @@ export const FunctionInstance = {
   // since prototpye properties are instance-specific, we define it there.
 };
 
+// 25.7.4 AsyncFunction Instances
 export const AsyncFunctionInstance = {
+  // This property is not mentioned in ECMA 262, but is present in V8 and
+  // necessary for lockdown to succeed.
   '**proto**': 'AsyncFunctionPrototype',
+  // 25.7.4.1 length
   length: 'number',
+  // 25.7.4.2 name
   name: 'string',
 };
 

--- a/packages/ses/test/compartment-instance.test.js
+++ b/packages/ses/test/compartment-instance.test.js
@@ -44,7 +44,7 @@ test('Compartment instance', t => {
       'import',
       'importNow',
       'module',
-      'global',
+      'globalThis',
       'toString',
     ].sort(),
     'prototype properties',

--- a/packages/ses/test/compartment-prototype.test.js
+++ b/packages/ses/test/compartment-prototype.test.js
@@ -20,7 +20,7 @@ test('Compartment prototype', t => {
       'import',
       'importNow',
       'module',
-      'global',
+      'globalThis',
       'toString',
     ].sort(),
     'prototype properties',

--- a/packages/ses/test/compartment.test.js
+++ b/packages/ses/test/compartment.test.js
@@ -108,7 +108,7 @@ test('main use case', t => {
     endowments: { power: attenuatedPower },
   });
   t.equal(user(1), 2);
-  t.throws(() => user(-1), c.global.TypeError);
+  t.throws(() => user(-1), c.globalThis.TypeError);
   t.end();
 });
 

--- a/packages/ses/test/confinement.test.js
+++ b/packages/ses/test/confinement.test.js
@@ -73,8 +73,8 @@ test('confinement evaluation eval', t => {
   const c = new Compartment();
 
   // Strict mode
-  t.equal(c.evaluate('(0, eval)("this")'), c.global);
-  t.equal(c.evaluate('var evil = eval; evil("this")'), c.global);
+  t.equal(c.evaluate('(0, eval)("this")'), c.globalThis);
+  t.equal(c.evaluate('var evil = eval; evil("this")'), c.globalThis);
 
   sinon.restore();
 });

--- a/packages/ses/test/global-object-properties.test.js
+++ b/packages/ses/test/global-object-properties.test.js
@@ -15,21 +15,21 @@ test('globalObject properties', t => {
 
   const c = new Compartment();
 
-  t.notEqual(c.global, this);
-  t.notEqual(c.global, globalThis);
-  t.equal(c.global.globalThis, c.global);
+  t.notEqual(c.globalThis, this);
+  t.notEqual(c.globalThis, globalThis);
+  t.equal(c.globalThis.globalThis, c.globalThis);
 
-  t.equal(c.global.Array, Array);
-  t.equal(c.global.Array, globalThis.Array);
+  t.equal(c.globalThis.Array, Array);
+  t.equal(c.globalThis.Array, globalThis.Array);
 
   // eslint-disable-next-line no-eval
-  t.notEqual(c.global.eval, eval);
-  t.notEqual(c.global.eval, globalThis.eval);
+  t.notEqual(c.globalThis.eval, eval);
+  t.notEqual(c.globalThis.eval, globalThis.eval);
 
-  t.notEqual(c.global.Function, Function);
-  t.notEqual(c.global.Function, globalThis.Function);
+  t.notEqual(c.globalThis.Function, Function);
+  t.notEqual(c.globalThis.Function, globalThis.Function);
 
-  t.equal(c.global.Compartment, Compartment);
+  t.equal(c.globalThis.Compartment, Compartment);
 
   delete globalThis.Compartment;
   sinon.restore();

--- a/packages/ses/test/identity-continuity.test.js
+++ b/packages/ses/test/identity-continuity.test.js
@@ -15,7 +15,7 @@ test('identity Array', t => {
   globalThis.Compartment = Compartment;
 
   const c1 = new Compartment();
-  const c2 = new c1.global.Compartment();
+  const c2 = new c1.globalThis.Compartment();
 
   t.equal(c1.evaluate('Array'), Array);
   t.equal(c1.evaluate('Array'), c1.evaluate('Array'));
@@ -24,8 +24,8 @@ test('identity Array', t => {
 
   const a2 = c2.evaluate('[]');
   t.ok(a2 instanceof Array);
-  t.ok(a2 instanceof c1.global.Array);
-  t.ok(a2 instanceof c2.global.Array);
+  t.ok(a2 instanceof c1.globalThis.Array);
+  t.ok(a2 instanceof c2.globalThis.Array);
 
   delete globalThis.Compartment;
   sinon.restore();
@@ -41,7 +41,7 @@ test('identity Compartment', t => {
   globalThis.Compartment = Compartment;
 
   const c1 = new Compartment();
-  const c2 = new c1.global.Compartment();
+  const c2 = new c1.globalThis.Compartment();
 
   t.equal(c1.evaluate('Compartment'), Compartment);
   t.equal(c1.evaluate('Compartment'), c1.evaluate('Compartment'));
@@ -50,8 +50,8 @@ test('identity Compartment', t => {
 
   const e3 = c2.evaluate('(new Compartment())');
   t.ok(e3 instanceof Compartment);
-  t.ok(e3 instanceof c1.global.Compartment);
-  t.ok(e3 instanceof c2.global.Compartment);
+  t.ok(e3 instanceof c1.globalThis.Compartment);
+  t.ok(e3 instanceof c2.globalThis.Compartment);
 
   delete globalThis.Compartment;
   sinon.restore();
@@ -67,7 +67,7 @@ test('identity eval', t => {
   globalThis.Compartment = Compartment;
 
   const c1 = new Compartment();
-  const c2 = new c1.global.Compartment();
+  const c2 = new c1.globalThis.Compartment();
 
   t.ok(c2.evaluate('eval') instanceof Function);
   t.ok(c2.evaluate('eval') instanceof Object);
@@ -94,8 +94,8 @@ test('identity Function', t => {
   globalThis.Compartment = Compartment;
 
   const c1 = new Compartment();
-  const c2 = new c1.global.Compartment();
-  const c3 = new c2.global.Compartment();
+  const c2 = new c1.globalThis.Compartment();
+  const c3 = new c2.globalThis.Compartment();
 
   t.ok(c2.evaluate('Function') instanceof Function);
   t.ok(c2.evaluate('Function') instanceof Object);
@@ -108,9 +108,9 @@ test('identity Function', t => {
   t.notEqual(c2.evaluate('Function'), c1.evaluate('Function'));
 
   const f2 = c2.evaluate('function x(a, b) { return a+b; }; x');
-  t.ok(f2 instanceof c1.global.Function);
-  t.ok(f2 instanceof c2.global.Function);
-  t.ok(f2 instanceof c3.global.Function);
+  t.ok(f2 instanceof c1.globalThis.Function);
+  t.ok(f2 instanceof c2.globalThis.Function);
+  t.ok(f2 instanceof c3.globalThis.Function);
 
   delete globalThis.Compartment;
   sinon.restore();

--- a/packages/ses/test/leak-endowments.test.js
+++ b/packages/ses/test/leak-endowments.test.js
@@ -38,7 +38,7 @@ test('endowments are mutable but not shared between calls to c.evaluate', t => {
 
   // the global is not modified when an endowment shadows it
   t.throws(() => c.evaluate(`endow1`), ReferenceError);
-  t.equal(c.global.endow1, undefined);
+  t.equal(c.globalThis.endow1, undefined);
 
   // assignment to global works even when an endowment shadows it
   t.equal(
@@ -51,7 +51,7 @@ test('endowments are mutable but not shared between calls to c.evaluate', t => {
   );
 
   // the modified global is now visible when there is no endowment to shadow it
-  t.equal(c.global.endow1, 4);
+  t.equal(c.globalThis.endow1, 4);
   t.equal(c.evaluate(`endow1`), 4);
 
   // endowments shadow globals

--- a/packages/ses/test/leak-unsafe-eval.test.js
+++ b/packages/ses/test/leak-unsafe-eval.test.js
@@ -36,7 +36,7 @@ test('HostException in eval revokes unsafeEval', t => {
     // eslint-disable-next-line no-empty
   } catch (err) {}
 
-  t.equal(endowments.$$eval$$, c.global.eval, "should be realm's eval");
+  t.equal(endowments.$$eval$$, c.globalThis.eval, "should be realm's eval");
   t.notEqual(endowments.$$eval$$, globalThis.eval, 'should not be unsafe eval');
 
   sinon.restore();
@@ -73,7 +73,7 @@ test('HostException in Function revokes unsafeEval', t => {
     // eslint-disable-next-line no-empty
   } catch (err) {}
 
-  t.equal(endowments.$$eval$$, c.global.eval, "should be realm's eval");
+  t.equal(endowments.$$eval$$, c.globalThis.eval, "should be realm's eval");
   t.notEqual(endowments.$$eval$$, globalThis.eval, 'should not be unsafe eval');
 
   sinon.restore();

--- a/packages/ses/test/ses.test.js
+++ b/packages/ses/test/ses.test.js
@@ -180,7 +180,7 @@ test('main use case', t => {
     endowments: { power: attenuatedPower },
   });
   t.equal(user(1), 2);
-  t.throws(() => user(-1), c.global.TypeError);
+  t.throws(() => user(-1), c.globalThis.TypeError);
   t.end();
 });
 

--- a/packages/ses/test/typeof.test.js
+++ b/packages/ses/test/typeof.test.js
@@ -22,6 +22,7 @@ test('typeof', t => {
 
   // TODO: the Compartment currently censors objects from the unsafe global, but
   // they appear defined as 'undefined' and don't throw a ReferenceError.
+  // https://github.com/Agoric/SES-shim/issues/309
   t.doesNotThrow(() => c.evaluate('global'), ReferenceError);
   t.equal(c.evaluate('global'), undefined);
   t.equal(c.evaluate('typeof global'), 'undefined');

--- a/packages/ses/test/whitelist.test.js
+++ b/packages/ses/test/whitelist.test.js
@@ -58,12 +58,12 @@ test('do not remove Object.prototype.__proto__', t => {
   const c = new Compartment();
   t.equal(
     c.evaluate('({}).__proto__'),
-    c.global.Object.prototype,
+    c.globalThis.Object.prototype,
     '({}).__proto__ is accessible',
   );
   t.equal(
     c.evaluate('[].__proto__'),
-    c.global.Array.prototype,
+    c.globalThis.Array.prototype,
     '[].__proto__ is accessible',
   );
   t.equal(
@@ -73,7 +73,7 @@ X.prototype.__proto__ = Array.prototype;
 const x=new X();
 x.slice;
 `),
-    c.global.Array.prototype.slice,
+    c.globalThis.Array.prototype.slice,
     `prototype __proto__ inheritance works`,
   );
 


### PR DESCRIPTION
This change brings the shim in compliance with the current proposed specification.