### PR TITLE
Use test plan for compartment tests

### DIFF
--- a/packages/ses/test/import-gauntlet.test.js
+++ b/packages/ses/test/import-gauntlet.test.js
@@ -7,7 +7,7 @@ import { resolveNode, makeNodeImporter } from './node.js';
 
 const { test } = tap;
 
-test('import for side effect', async t => {
+test('import for side effect', async _t => {
   const makeImportHook = makeNodeImporter({
     'https://example.com/import-for-side-effect.js': `
       // empty
@@ -27,8 +27,6 @@ test('import for side effect', async t => {
   );
 
   await compartment.import('./main.js');
-
-  t.end();
 });
 
 test('import all from module', async t => {
@@ -56,8 +54,6 @@ test('import all from module', async t => {
 
   t.equal(namespace.default.a, 10);
   t.equal(namespace.default.b, 20);
-
-  t.end();
 });
 
 test('import named exports from me', async t => {
@@ -85,8 +81,6 @@ test('import named exports from me', async t => {
 
   t.equal(namespace.default.fizz, 10);
   t.equal(namespace.default.buzz, 20);
-
-  t.end();
 });
 
 test('import all from module', async t => {
@@ -112,8 +106,6 @@ test('import all from module', async t => {
   const { namespace } = await compartment.import('./main.js');
 
   t.equal(namespace.color, 'blue');
-
-  t.end();
 });
 
 test('import and reexport', async t => {
@@ -138,8 +130,6 @@ test('import and reexport', async t => {
   const { namespace } = await compartment.import('./main.js');
 
   t.equal(namespace.qux, 42);
-
-  t.end();
 });
 
 test('import and export all', async t => {
@@ -166,8 +156,6 @@ test('import and export all', async t => {
 
   t.equal(namespace.alpha, 0);
   t.equal(namespace.omega, 23);
-
-  t.end();
 });
 
 test('live binding', async t => {

--- a/packages/ses/test/import-gauntlet.test.js
+++ b/packages/ses/test/import-gauntlet.test.js
@@ -7,7 +7,9 @@ import { resolveNode, makeNodeImporter } from './node.js';
 
 const { test } = tap;
 
-test('import for side effect', async _t => {
+test('import for side effect', async t => {
+  t.plan(0);
+
   const makeImportHook = makeNodeImporter({
     'https://example.com/import-for-side-effect.js': `
       // empty
@@ -30,6 +32,8 @@ test('import for side effect', async _t => {
 });
 
 test('import all from module', async t => {
+  t.plan(2);
+
   const makeImportHook = makeNodeImporter({
     'https://example.com/import-all-from-me.js': `
       export const a = 10;
@@ -57,6 +61,8 @@ test('import all from module', async t => {
 });
 
 test('import named exports from me', async t => {
+  t.plan(2);
+
   const makeImportHook = makeNodeImporter({
     'https://example.com/import-named-exports-from-me.js': `
       export const fizz = 10;
@@ -84,6 +90,8 @@ test('import named exports from me', async t => {
 });
 
 test('import all from module', async t => {
+  t.plan(1);
+
   const makeImportHook = makeNodeImporter({
     'https://example.com/import-named-export-and-rename.js': `
       export const color = 'blue';
@@ -109,6 +117,8 @@ test('import all from module', async t => {
 });
 
 test('import and reexport', async t => {
+  t.plan(1);
+
   const makeImportHook = makeNodeImporter({
     'https://example.com/import-and-reexport-name-from-me.js': `
       export const qux = 42;
@@ -133,6 +143,8 @@ test('import and reexport', async t => {
 });
 
 test('import and export all', async t => {
+  t.plan(2);
+
   const makeImportHook = makeNodeImporter({
     'https://example.com/import-and-export-all-from-me.js': `
       export const alpha = 0;
@@ -159,6 +171,8 @@ test('import and export all', async t => {
 });
 
 test('live binding', async t => {
+  t.plan(1);
+
   const makeImportHook = makeNodeImporter({
     'https://example.com/import-live-export.js': `
       export let quuux = null;

--- a/packages/ses/test/import-stack-traces.test.js
+++ b/packages/ses/test/import-stack-traces.test.js
@@ -5,6 +5,12 @@ import { resolveNode, makeNodeImporter } from './node.js';
 const { test } = tap;
 
 test('preserve file names in stack traces', async t => {
+  if (new Error().stack != null) {
+    t.plan(1);
+  } else {
+    t.plan(0);
+  }
+
   const makeImportHook = makeNodeImporter({
     'https://example.com/packages/erroneous/main.js': `
       throw new Error("threw an error");
@@ -36,6 +42,4 @@ test('preserve file names in stack traces', async t => {
       'stack trace contains file name of emitting module',
     );
   }
-
-  t.end();
 });

--- a/packages/ses/test/import.test.js
+++ b/packages/ses/test/import.test.js
@@ -1,6 +1,8 @@
 // These tests exercise the Compartment import interface and linkage
 // between compartments, and Compartment endowments.
 
+/* eslint max-lines: 0 */
+
 import tap from 'tap';
 import { Compartment } from '../src/main.js';
 import { resolveNode, makeNodeImporter } from './node.js';
@@ -12,6 +14,8 @@ const { test } = tap;
 // that uses fully qualified URLs as module specifiers and module locations,
 // not distinguishing one from the other.
 test('import within one compartment, web resolution', async t => {
+  t.plan(1);
+
   const retrieve = makeStaticRetriever({
     'https://example.com/packages/example/half.js': `
       export default 21;
@@ -49,6 +53,8 @@ test('import within one compartment, web resolution', async t => {
 // This case demonstrates the same arrangement except that the Compartment uses
 // Node.js module specifier resolution.
 test('import within one compartment, node resolution', async t => {
+  t.plan(1);
+
   const makeImportHook = makeNodeImporter({
     'https://example.com/packages/example/half.js': `
       export default 21;
@@ -80,6 +86,8 @@ test('import within one compartment, node resolution', async t => {
 
 // This demonstrates a pair of linked Node.js compartments.
 test('two compartments, three modules, one endowment', async t => {
+  t.plan(1);
+
   const makeImportHook = makeNodeImporter({
     'https://example.com/packages/example/half.js': `
       if (typeof double !== 'undefined') {
@@ -134,7 +142,7 @@ test('two compartments, three modules, one endowment', async t => {
 });
 
 test('module exports namespace as an object', async t => {
-  t.plan(6);
+  t.plan(7);
 
   const makeImportHook = makeNodeImporter({
     'https://example.com/packages/meaning/main.js': `
@@ -155,6 +163,12 @@ test('module exports namespace as an object', async t => {
   );
 
   const { namespace } = await compartment.import('./main.js');
+
+  t.equals(
+    namespace.meaning,
+    42,
+    'exported constant must have a namespace property',
+  );
 
   t.throws(() => {
     namespace.alternateMeaning = 10;
@@ -184,6 +198,8 @@ test('module exports namespace as an object', async t => {
 });
 
 test('modules are memoized', async t => {
+  t.plan(1);
+
   const makeImportHook = makeNodeImporter({
     'https://example.com/packages/example/c-s-lewis.js': `
       export const entity = {};
@@ -219,10 +235,11 @@ test('modules are memoized', async t => {
   const { clive, clerk } = namespace;
 
   t.ok(clive === clerk, 'diamond dependency must refer to the same module');
-  t.end();
 });
 
 test('compartments with same sources do not share instances', async t => {
+  t.plan(1);
+
   const makeImportHook = makeNodeImporter({
     'https://example.com/packages/arm/main.js': `
       export default {};
@@ -263,5 +280,4 @@ test('compartments with same sources do not share instances', async t => {
     leftArm !== rightArm,
     'different compartments with same sources do not share instances',
   );
-  t.end();
 });


### PR DESCRIPTION
This brings the compartment tests in conformance with the style @Chris-Hibbert and I discussed to best signal test completion and ensure that all planned assertions have an opportunity to fail the test. Using async tests precludes the need for calling `end` explicitly (it is implied by the resolution of the returned promise), but `plan` is necessary to ensure a test that goes off the rails fails.