### PR TITLE
fix(ses)!: Simplify transforms

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -8,6 +8,12 @@ User-visible changes in SES:
   introduced as properties of `globalThis`.
 * The `Compartment` `global` getter is now named `globalThis`, consistent with
   the specification proposal.
+* The `Compartment` `transforms` constructor option is now just an array of
+  transform functions that accept and return program strings.
+  Transforms can no longer introduce `endowments`.
+  The compartment constructor's `endowments` argument (first) and assigning
+  properties to `globalThis` are the remaining supported ways to introduce
+  endowments.
 * Repair `Function.apply` and `TypeError.message` (as well as `.message` on
   all the other Error types), to tolerate what the npm `es-abstract` module
   does. This allows `tape` (version 4.x) to be loaded in a locked-down SES

--- a/packages/ses/src/evaluate.js
+++ b/packages/ses/src/evaluate.js
@@ -15,7 +15,7 @@ import { makeEvaluateFactory } from './make-evaluate-factory.js';
  */
 export function performEval(
   realmRec,
-  src,
+  source,
   globalObject,
   endowments = {},
   {
@@ -26,8 +26,7 @@ export function performEval(
 ) {
   // Execute the mandatory transforms last to ensure that any rewritten code
   // meets those mandatory requirements.
-  let rewriterState = { src, endowments };
-  rewriterState = applyTransforms(rewriterState, [
+  source = applyTransforms(source, [
     ...localTransforms,
     ...globalTransforms,
     mandatoryTransforms,
@@ -36,13 +35,13 @@ export function performEval(
   const scopeHandler = createScopeHandler(
     realmRec,
     globalObject,
-    rewriterState.endowments,
+    endowments,
     { sloppyGlobalsMode },
   );
   const scopeProxyRevocable = proxyRevocable(immutableObject, scopeHandler);
   // Ensure that "this" resolves to the scope proxy.
 
-  const constants = getScopeConstants(globalObject, rewriterState.endowments);
+  const constants = getScopeConstants(globalObject, endowments);
   const evaluateFactory = makeEvaluateFactory(realmRec, constants);
   const evaluate = apply(evaluateFactory, scopeProxyRevocable.proxy, []);
 
@@ -50,7 +49,7 @@ export function performEval(
   let err;
   try {
     // Ensure that "this" resolves to the safe global.
-    return apply(evaluate, globalObject, [rewriterState.src]);
+    return apply(evaluate, globalObject, [source]);
   } catch (e) {
     // stash the child-code error in hopes of debugging the internal failure
     err = e;

--- a/packages/ses/src/evaluate.js
+++ b/packages/ses/src/evaluate.js
@@ -32,12 +32,9 @@ export function performEval(
     mandatoryTransforms,
   ]);
 
-  const scopeHandler = createScopeHandler(
-    realmRec,
-    globalObject,
-    endowments,
-    { sloppyGlobalsMode },
-  );
+  const scopeHandler = createScopeHandler(realmRec, globalObject, endowments, {
+    sloppyGlobalsMode,
+  });
   const scopeProxyRevocable = proxyRevocable(immutableObject, scopeHandler);
   // Ensure that "this" resolves to the scope proxy.
 

--- a/packages/ses/src/transforms.js
+++ b/packages/ses/src/transforms.js
@@ -1,4 +1,5 @@
 import { stringSearch, stringSlice, stringSplit } from './commons.js';
+import { assert } from './assert.js';
 
 // Find the first occurence of the given pattern and return
 // the location as the approximate line number.
@@ -95,6 +96,7 @@ export function rejectImportExpressions(src) {
 
 const someDirectEvalPattern = new RegExp('\\beval\\s*(?:\\(|/[/*])');
 
+// Exported for unit tests.
 export function rejectSomeDirectEvalExpressions(src) {
   const linenum = getLineNumber(src, someDirectEvalPattern);
   if (linenum < 0) {
@@ -105,23 +107,16 @@ export function rejectSomeDirectEvalExpressions(src) {
   );
 }
 
-// Export a rewriter transform.
-export const mandatoryTransforms = {
-  rewrite(rewriterState) {
-    rejectHtmlComments(rewriterState.src);
-    rejectImportExpressions(rewriterState.src);
-    rejectSomeDirectEvalExpressions(rewriterState.src);
-    return rewriterState;
-  },
-};
+export function mandatoryTransforms(source) {
+  source = rejectHtmlComments(source);
+  source = rejectImportExpressions(source);
+  source = rejectSomeDirectEvalExpressions(source);
+  return source;
+}
 
-export function applyTransforms(rewriterState, transforms) {
-  // Rewrite the source, threading through rewriter state as necessary.
+export function applyTransforms(source, transforms) {
   for (const transform of transforms) {
-    if (typeof transform.rewrite === 'function') {
-      rewriterState = transform.rewrite(rewriterState);
-    }
+    source = transform(source);
   }
-
-  return rewriterState;
+  return source;
 }

--- a/packages/ses/src/transforms.js
+++ b/packages/ses/src/transforms.js
@@ -1,5 +1,4 @@
 import { stringSearch, stringSlice, stringSplit } from './commons.js';
-import { assert } from './assert.js';
 
 // Find the first occurence of the given pattern and return
 // the location as the approximate line number.

--- a/packages/ses/test/compartment.test.js
+++ b/packages/ses/test/compartment.test.js
@@ -111,24 +111,3 @@ test('main use case', t => {
   t.throws(() => user(-1), c.globalThis.TypeError);
   t.end();
 });
-
-const transform = {
-  rewrite(rewriterState) {
-    const { src, endowments } = rewriterState;
-    return {
-      src: src.replace('replaceme', 'substitution'),
-      endowments: { added: 'by transform', ...endowments },
-    };
-  },
-};
-
-test('transforms can add endowments', t => {
-  // eslint-disable-next-line no-template-curly-in-string
-  const src = '(function f4(a) {  return `replaceme ${added} ${a}`; })';
-  const transforms = [transform];
-  const c = new Compartment({}, {}, { transforms });
-  const f4 = c.evaluate(src);
-  const out = f4('ok');
-  t.equal(out, 'substitution by transform ok');
-  t.end();
-});

--- a/packages/ses/test/evaluate.test.js
+++ b/packages/ses/test/evaluate.test.js
@@ -63,25 +63,21 @@ test('performEval - transforms - rewrite source', t => {
   const endowments = { abc: 123, def: 456 };
 
   const globalTransforms = [
-    {
-      rewrite(rs) {
-        if (rs.src === 'ABC') {
-          rs.src = 'abc';
-        }
-        return rs;
-      },
+    source => {
+      if (source === 'ABC') {
+        source = 'abc';
+      }
+      return source;
     },
   ];
 
   const localTransforms = [
-    {
-      rewrite(rs) {
-        if (rs.src === 'ABC') {
-          rs.src = 'def';
-        }
-        return rs;
-      },
-    },
+    source => {
+      if (source === 'ABC') {
+        return 'def';
+      }
+      return source;
+    }
   ];
 
   t.equal(
@@ -111,94 +107,5 @@ test('performEval - transforms - rewrite source', t => {
     'localTransforms rewrite source first',
   );
 
-  sinon.restore();
-});
-
-test('performEval - transforms - modify endowments', t => {
-  t.plan(5);
-
-  // Mimic repairFunctions.
-  stubFunctionConstructors(sinon);
-
-  const realmRec = { intrinsics: { eval: globalThis.eval, Function } }; // bypass esm
-  const globalObject = {};
-
-  const globalTransforms = [
-    {
-      rewrite(rs) {
-        if (!rs.endowments.abc) {
-          rs.endowments.abc = 123;
-        }
-        rs.endowments.ABC = 123;
-        return rs;
-      },
-    },
-  ];
-
-  const localTransforms = [
-    {
-      rewrite(rs) {
-        if (!rs.endowments.abc) {
-          rs.endowments.abc = 456;
-        }
-        rs.endowments.ABC = 456;
-        return rs;
-      },
-    },
-  ];
-
-  t.equal(
-    performEval(realmRec, 'abc', globalObject, { abc: 999 }),
-    999,
-    'no override',
-  );
-
-  t.equal(
-    performEval(
-      realmRec,
-      'abc',
-      globalObject,
-      {},
-      {
-        globalTransforms,
-      },
-    ),
-    123,
-    'globalTransforms override endowments',
-  );
-  t.equal(
-    performEval(realmRec, 'abc', globalObject, {}, { localTransforms }),
-    456,
-    'localTransforms override endowments',
-  );
-  t.equal(
-    performEval(
-      realmRec,
-      'abc',
-      globalObject,
-      {},
-      {
-        localTransforms,
-        globalTransforms,
-      },
-    ),
-    456,
-    'localTransforms override endowments first',
-  );
-
-  t.equal(
-    performEval(
-      realmRec,
-      'ABC',
-      globalObject,
-      {},
-      {
-        localTransforms,
-        globalTransforms,
-      },
-    ),
-    123,
-    'globalTransforms override endowments last',
-  );
   sinon.restore();
 });

--- a/packages/ses/test/evaluate.test.js
+++ b/packages/ses/test/evaluate.test.js
@@ -77,7 +77,7 @@ test('performEval - transforms - rewrite source', t => {
         return 'def';
       }
       return source;
-    }
+    },
   ];
 
   t.equal(


### PR DESCRIPTION
This change simplifies the compartment transforms for evaluated programs to just an array of functions that accept and return program strings.  The previous version of this API enabled transforms to add endowments and left room for future transformable properties.  We have elected to use the compartment `evaluate` function to introduce lexical endowments and `globalThis` to introduce enumerable and computable endowments.

Fixes #321