### PR TITLE
feat(endo): Module specifier and URL math

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,5 +32,6 @@
     "import/extensions": "off",
     "import/prefer-default-export": "off",
     "eslint-comments/no-unused-disable": "error"
-  }
+  },
+  "ignorePatterns": ["**/dist/**"]
 }

--- a/packages/endo/REMOVEME.js
+++ b/packages/endo/REMOVEME.js
@@ -1,2 +1,0 @@
-// TODO remove before flight.
-// This file retained to give eslint something to chew on.

--- a/packages/endo/package.json
+++ b/packages/endo/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "depcheck": "depcheck",
     "lint": "eslint '**/*.js'",
-    "lint-fix": "eslint --fix '**/*.js'"
+    "lint-fix": "eslint --fix '**/*.js'",
+    "test": "tap --no-esm --no-coverage --reporter spec 'test/**/*.test.js'"
   },
   "dependencies": {
     "jszip": "^3.4.0",
@@ -20,7 +21,9 @@
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.19.1",
-    "eslint-plugin-prettier": "^3.1.2"
+    "eslint-plugin-prettier": "^3.1.2",
+    "tap": "14.10.5",
+    "tape": "4.12.1"
   },
   "files": [
     "LICENSE*",

--- a/packages/endo/src/node-module-specifier.js
+++ b/packages/endo/src/node-module-specifier.js
@@ -1,0 +1,114 @@
+// q, as in quote, for error messages.
+const q = JSON.stringify;
+
+const isRelative = spec =>
+  spec.startsWith("./") ||
+  spec.startsWith("../") ||
+  spec === "." ||
+  spec === "..";
+
+const normalize = (parts, path) => {
+  for (const part of path) {
+    if (part === "." || part === "") {
+      // no-op
+    } else if (part === "..") {
+      if (parts.length === 0) {
+        return undefined;
+      }
+      parts.pop();
+    } else {
+      parts.push(part);
+    }
+  }
+  return parts;
+};
+
+export const resolve = (spec, referrer) => {
+  spec = String(spec || "");
+  referrer = String(referrer || "");
+
+  if (spec.startsWith("/")) {
+    throw new Error(`Module specifier ${q(spec)} must not begin with "/"`);
+  }
+  if (!referrer.startsWith("./")) {
+    throw new Error(`Module referrer ${q(referrer)} must begin with "./"`);
+  }
+
+  let parts = [];
+  const path = [];
+  if (isRelative(spec)) {
+    path.push(...referrer.split("/"));
+    path.pop();
+    parts.push(".");
+  }
+  path.push(...spec.split("/"));
+
+  parts = normalize(parts, path);
+  if (parts === undefined) {
+    throw new Error(
+      `Module specifier ${q(spec)} via referrer ${q(
+        referrer
+      )} must not traverse behind an empty path`
+    );
+  }
+
+  return parts.join("/");
+};
+
+// To construct a module map from a node_modules package,
+// inter-package linkage requires connecting a full base module specifier like
+// "dependency-package" to the other package's full internal module specifier
+// like "." or "./utility", to form a local full module specifier like
+// "dependency-package" or "dependency-package/utility".
+// This type of join may assert that the base is absolute and the referrent is
+// relative.
+export const join = (base, spec) => {
+  spec = String(spec || "");
+  base = String(base || "");
+
+  if (spec.startsWith("/")) {
+    throw new Error(`Module specifier ${q(spec)} must not start with "/"`);
+  }
+  if (base.startsWith("./") || base === ".") {
+    throw new Error(
+      `External module base ${q(
+        base
+      )} must be absolute, must not be "." nor begin with "./"`
+    );
+  }
+  if (!spec.startsWith("./") && spec !== ".") {
+    throw new Error(
+      `Base module specifier ${q(
+        base
+      )} must be relative, being either "." or starting with "./"`
+    );
+  }
+
+  const parts = normalize([], spec.split("/"));
+  if (parts === undefined) {
+    throw new Error(
+      `Module specifier ${q(spec)} via referrer ${q(
+        base
+      )} must not refer to a module outside of the base`
+    );
+  }
+
+  return [base, ...parts].join("/");
+};
+
+// Relativize turns absolute identifiers into relative identifiers.
+// In package.json, internal module identifiers can be either relative or
+// absolute, but Endo compartments backed by node_modules always use relative
+// module specifiers for internal linkage.
+export const relativize = spec => {
+  spec = String(spec || "");
+
+  const parts = normalize([], spec.split("/"));
+  if (parts === undefined) {
+    throw Error(
+      `Module specifier ${q(spec)} must not traverse behind an empty path`
+    );
+  }
+
+  return [".", ...parts].join("/");
+};

--- a/packages/endo/src/node-module-specifier.js
+++ b/packages/endo/src/node-module-specifier.js
@@ -84,18 +84,10 @@ export const join = (base, spec) => {
     throw new Error(`Module specifier ${q(spec)} must not start with "/"`);
   }
   if (baseParts[0] === "." || baseParts[0] === "..") {
-    throw new Error(
-      `External module specifier ${q(
-        base
-      )} must be absolute`
-    );
+    throw new Error(`External module specifier ${q(base)} must be absolute`);
   }
   if (specParts[0] !== ".") {
-    throw new Error(
-      `Internal module specifier ${q(
-        spec
-      )} must be relative`
-    );
+    throw new Error(`Internal module specifier ${q(spec)} must be relative`);
   }
 
   const solution = [];

--- a/packages/endo/src/url.js
+++ b/packages/endo/src/url.js
@@ -1,0 +1,78 @@
+// Derrived from https://github.com/junosuarez/url-relative
+//
+// Copyright (c) MMXV jden jason@denizac.org
+//
+// ISC License
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+export const relative = (referrer, location) => {
+  referrer = String(referrer || "");
+  location = String(location || "");
+
+  if (referrer === location) {
+    return "";
+  }
+
+  const referrerURL = new URL(referrer);
+  const locationURL = new URL(location);
+
+  if (referrerURL.host !== locationURL.host) {
+    return location;
+  }
+
+  if (referrerURL.protocol !== locationURL.protocol) {
+    return location;
+  }
+
+  if (referrerURL.auth !== locationURL.auth) {
+    return location;
+  }
+
+  // left location right, look for closest common path segment
+  const referrerParts = referrerURL.pathname.substr(1).split("/");
+  const locationParts = locationURL.pathname.substr(1).split("/");
+
+  if (referrerURL.pathname === locationURL.pathname) {
+    if (locationURL.pathname[locationURL.pathname.length - 1] === "/") {
+      return ".";
+    }
+    return locationParts[locationParts.length - 1];
+  }
+
+  while (referrerParts[0] === locationParts[0]) {
+    referrerParts.shift();
+    locationParts.shift();
+  }
+
+  let length = referrerParts.length - locationParts.length;
+  if (length > 0) {
+    if (referrer.endsWith("/")) {
+      locationParts.unshift("..");
+    }
+    while (length > 0) {
+      length -= 1;
+      locationParts.unshift("..");
+    }
+    return locationParts.join("/");
+  }
+  if (length < 0) {
+    return locationParts.join("/");
+  }
+  length = locationParts.length - 1;
+  while (length > 0) {
+    length -= 1;
+    locationParts.unshift("..");
+  }
+  return locationParts.join("/");
+};

--- a/packages/endo/test/join.test.js
+++ b/packages/endo/test/join.test.js
@@ -1,0 +1,53 @@
+import tape from "tape";
+import { join } from "../src/node-module-specifier.js";
+
+const { test } = tape;
+
+const q = JSON.stringify;
+
+[
+  { via: "", rel: "./", res: "" },
+  { via: "external", rel: "./main.js", res: "external/main.js" },
+  {
+    via: "external",
+    rel: "./internal/main.js",
+    res: "external/internal/main.js"
+  },
+  { via: "@org/lib", rel: "./lib/app.js", res: "@org/lib/lib/app.js" },
+  { via: "external", rel: "./internal/../main.js", res: "external/main.js" }
+].forEach(c => {
+  test(`join(${q(c.via)}, ${q(c.rel)}) -> ${q(c.res)}`, t => {
+    t.plan(1);
+    const res = join(c.via, c.rel);
+    t.equal(res, c.res);
+    t.end();
+  });
+});
+
+test("throws if the specifier is absolute", t => {
+  t.throws(() => {
+    join("", "/");
+  }, /Module specifier "\/" must not start with "\/"/);
+  t.end();
+});
+
+test("throws if the specifier is absolute", t => {
+  t.throws(() => {
+    join("from", "to");
+  }, /Base module specifier "from" must be relative, being either "\." or starting with "\.\/"/);
+  t.end();
+});
+
+test("throws if the referrer is relative", t => {
+  t.throws(() => {
+    join("./", "foo");
+  }, /External module base "\.\/" must be absolute/);
+  t.end();
+});
+
+test("throws if specifier reaches outside of base", t => {
+  t.throws(() => {
+    join("path/to/base", "./deeper/../..");
+  }, /Module specifier "\.\/deeper\/\.\.\/.\." via referrer "path\/to\/base" must not refer to a module outside of the base/);
+  t.end();
+});

--- a/packages/endo/test/join.test.js
+++ b/packages/endo/test/join.test.js
@@ -25,29 +25,45 @@ const q = JSON.stringify;
 });
 
 test("throws if the specifier is a fully qualified path", t => {
-  t.throws(() => {
-    join("", "/");
-  }, undefined, 'throws if the specifier is a fully qualified path');
+  t.throws(
+    () => {
+      join("", "/");
+    },
+    undefined,
+    "throws if the specifier is a fully qualified path"
+  );
   t.end();
 });
 
 test("throws if the specifier is absolute", t => {
-  t.throws(() => {
-    join("from", "to");
-  }, undefined, 'throws if the specifier is absolute');
+  t.throws(
+    () => {
+      join("from", "to");
+    },
+    undefined,
+    "throws if the specifier is absolute"
+  );
   t.end();
 });
 
 test("throws if the referrer is relative", t => {
-  t.throws(() => {
-    join("./", "foo");
-  }, undefined, 'throws if the referrer is relative');
+  t.throws(
+    () => {
+      join("./", "foo");
+    },
+    undefined,
+    "throws if the referrer is relative"
+  );
   t.end();
 });
 
 test("throws if specifier reaches outside of base", t => {
-  t.throws(() => {
-    join("path/to/base", "./deeper/../..");
-  }, undefined, 'throw if specifier reaches outside of base');
+  t.throws(
+    () => {
+      join("path/to/base", "./deeper/../..");
+    },
+    undefined,
+    "throw if specifier reaches outside of base"
+  );
   t.end();
 });

--- a/packages/endo/test/join.test.js
+++ b/packages/endo/test/join.test.js
@@ -6,7 +6,7 @@ const { test } = tape;
 const q = JSON.stringify;
 
 [
-  { via: "", rel: "./", res: "" },
+  // { via: "", rel: "./", res: "" },
   { via: "external", rel: "./main.js", res: "external/main.js" },
   {
     via: "external",
@@ -19,35 +19,35 @@ const q = JSON.stringify;
   test(`join(${q(c.via)}, ${q(c.rel)}) -> ${q(c.res)}`, t => {
     t.plan(1);
     const res = join(c.via, c.rel);
-    t.equal(res, c.res);
+    t.equal(res, c.res, `join(${q(c.via)}, ${q(c.rel)}) === ${q(c.res)}`);
     t.end();
   });
 });
 
-test("throws if the specifier is absolute", t => {
+test("throws if the specifier is a fully qualified path", t => {
   t.throws(() => {
     join("", "/");
-  }, /Module specifier "\/" must not start with "\/"/);
+  }, undefined, 'throws if the specifier is a fully qualified path');
   t.end();
 });
 
 test("throws if the specifier is absolute", t => {
   t.throws(() => {
     join("from", "to");
-  }, /Base module specifier "from" must be relative, being either "\." or starting with "\.\/"/);
+  }, undefined, 'throws if the specifier is absolute');
   t.end();
 });
 
 test("throws if the referrer is relative", t => {
   t.throws(() => {
     join("./", "foo");
-  }, /External module base "\.\/" must be absolute/);
+  }, undefined, 'throws if the referrer is relative');
   t.end();
 });
 
 test("throws if specifier reaches outside of base", t => {
   t.throws(() => {
     join("path/to/base", "./deeper/../..");
-  }, /Module specifier "\.\/deeper\/\.\.\/.\." via referrer "path\/to\/base" must not refer to a module outside of the base/);
+  }, undefined, 'throw if specifier reaches outside of base');
   t.end();
 });

--- a/packages/endo/test/relative.test.js
+++ b/packages/endo/test/relative.test.js
@@ -1,0 +1,117 @@
+// Derrived from https://github.com/junosuarez/url-relative
+//
+// Copyright (c) MMXV jden jason@denizac.org
+//
+// ISC License
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+// OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+// CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import tape from "tape";
+import { relative } from "../src/url.js";
+
+const { test } = tape;
+
+test("different protocol", t => {
+  t.plan(2);
+  t.equal(
+    relative("http://a.com:12/a", "https://a.com:12/a"),
+    "https://a.com:12/a"
+  );
+  t.equal(
+    relative("http://a.com:12/a/", "https://a.com:12/a/"),
+    "https://a.com:12/a/"
+  );
+});
+
+test("file protocol", t => {
+  t.plan(1);
+  t.equal(relative("file:///a", "file:///b"), "b");
+});
+
+test("different domain", t => {
+  t.plan(2);
+  t.equal(relative("http://a.com:12/a", "http://b.com/a"), "http://b.com/a");
+  t.equal(relative("http://a.com:12/a/", "http://b.com/a/"), "http://b.com/a/");
+});
+
+test("same domain", t => {
+  t.plan(2);
+  t.equal(relative("http://a.com/a", "http://a.com/b"), "b");
+  t.equal(relative("http://a.com/a/", "http://a.com/b/"), "../b/");
+});
+
+test("divergent paths, longer from", t => {
+  t.plan(4);
+  t.equal(
+    relative("http://example.com/a/b/c/d", "http://example.com/a/b/d"),
+    "../d"
+  );
+  t.equal(
+    relative("http://example.com/a/b/c/d/e", "http://example.com/a/d/e"),
+    "../../d/e"
+  );
+  t.equal(
+    relative("http://example.com/a/b/c/d/", "http://example.com/a/b/d/"),
+    "../../d/"
+  );
+  t.equal(
+    relative("http://example.com/a/b/c/d/e/", "http://example.com/a/d/e/"),
+    "../../../d/e/"
+  );
+});
+
+test("divergent paths, longer to", t => {
+  t.plan(6);
+  t.equal(
+    relative("http://example.com/a/b/c/d", "http://example.com/a/b/c/d/e"),
+    "e"
+  );
+  t.equal(
+    relative("http://example.com/a/b/c/d", "http://example.com/a/b/c/d/e/f"),
+    "e/f"
+  );
+  t.equal(relative("http://example.com/", "http://example.com/a/b"), "a/b");
+  t.equal(
+    relative("http://example.com/a/b/c/d/", "http://example.com/a/b/c/d/e/"),
+    "e/"
+  );
+  t.equal(
+    relative("http://example.com/a/b/c/d/", "http://example.com/a/b/c/d/e/f/"),
+    "e/f/"
+  );
+  t.equal(relative("http://example.com/", "http://example.com/a/b/"), "a/b/");
+});
+
+test("divergent paths, equal length", t => {
+  t.plan(2);
+  t.equal(
+    relative(
+      "http://example.com/a/b/c/d/e/f",
+      "http://example.com/a/b/c/g/h/j"
+    ),
+    "../../g/h/j"
+  );
+  t.equal(
+    relative(
+      "http://example.com/a/b/c/d/e/f/",
+      "http://example.com/a/b/c/g/h/j/"
+    ),
+    "../../../g/h/j/"
+  );
+});
+
+test("identical", t => {
+  t.plan(2);
+  t.equal(relative("https://a.com/a", "https://a.com/a"), "");
+  t.equal(relative("https://a.com/a/", "https://a.com/a/"), "");
+});

--- a/packages/endo/test/relativize.test.js
+++ b/packages/endo/test/relativize.test.js
@@ -1,0 +1,18 @@
+import tape from "tape";
+import { relativize } from "../src/node-module-specifier.js";
+
+const { test } = tape;
+
+const q = JSON.stringify;
+
+[
+  { spec: "index.js", rel: "./index.js" },
+  { spec: "./index.js", rel: "./index.js" }
+].forEach(c => {
+  test(`relativize(${q(c.spec)}) -> ${q(c.rel)}`, t => {
+    t.plan(1);
+    const rel = relativize(c.spec);
+    t.equal(rel, c.rel);
+    t.end();
+  });
+});

--- a/packages/endo/test/relativize.test.js
+++ b/packages/endo/test/relativize.test.js
@@ -12,7 +12,7 @@ const q = JSON.stringify;
   test(`relativize(${q(c.spec)}) -> ${q(c.rel)}`, t => {
     t.plan(1);
     const rel = relativize(c.spec);
-    t.equal(rel, c.rel);
+    t.equal(rel, c.rel, `relativize(${q(c.spec)}) === ${q(c.rel)}`);
     t.end();
   });
 });

--- a/packages/endo/test/resolve.test.js
+++ b/packages/endo/test/resolve.test.js
@@ -1,0 +1,71 @@
+import tape from "tape";
+import { resolve } from "../src/node-module-specifier.js";
+
+const { test } = tape;
+
+const q = JSON.stringify;
+
+[
+  // Cover degenerate cases
+  { res: "", rel: "", via: "./main.js" },
+  { res: ".", rel: ".", via: "./main.js" },
+
+  // Non-relative (external) specifiers disregard the referrer.
+  { res: "external", rel: "external", via: "./main.js" },
+  { res: "out/side", rel: "out/side", via: "./main.js" },
+  { res: "external", rel: "external", via: "./anywhere/main.js" },
+  { res: "out/side", rel: "out/side", via: "./anywhere/main.js" },
+  { res: "external", rel: "external", via: "./some/where/main.js" },
+  { res: "out/side", rel: "out/side", via: "./some/where/main.js" },
+  // And path arithmetic works.
+  { res: "side", rel: "out/../side", via: "./some/where/main.js" },
+  { res: "out/side", rel: "out/./side", via: "./some/where/main.js" },
+  { res: "out/side", rel: "out//side", via: "./some/where/main.js" },
+
+  // Relative (internal) references build upon the referrer.
+  { res: "./internal", rel: "./internal", via: "./main.js" },
+  { res: "./from/to", rel: "./to", via: "./from/main.js" },
+  // And path arithmetic works.
+  { res: ".", rel: "./into/..", via: "./main.js" },
+  { res: ".", rel: "./into/./..", via: "./main.js" },
+  { res: ".", rel: "./into//..", via: "./main.js" },
+  { res: "./from", rel: "./to/..", via: "./from/main.js" },
+  { res: "./to", rel: "../to", via: "./from/main.js" },
+  { res: "./from", rel: ".", via: "./from/main.js" },
+  { res: ".", rel: "..", via: "./from/main.js" }
+].forEach(c => {
+  test(`resolve(${q(c.rel)}, ${q(c.via)}) -> ${q(c.res)}`, t => {
+    t.plan(1);
+    const res = resolve(c.rel, c.via);
+    t.equal(res, c.res);
+    t.end();
+  });
+});
+
+test("throws if the specifier is non-relative", t => {
+  t.throws(() => {
+    resolve("/", "");
+  }, /Module specifier "\/" must not begin with "\/"/);
+  t.end();
+});
+
+test("throws if the referrer is non-relative", t => {
+  t.throws(() => {
+    resolve("", "/");
+  }, /Module referrer "\/" must begin with "\.\/"/);
+  t.end();
+});
+
+test("throws if the referrer is external", t => {
+  t.throws(() => {
+    resolve("", "external");
+  }, /Module referrer "external" must begin with "\.\/"/);
+  t.end();
+});
+
+test("throws if the referrer is external (degenerate case)", t => {
+  t.throws(() => {
+    resolve("", "");
+  }, /Module referrer "" must begin with "\.\/"/);
+  t.end();
+});

--- a/packages/endo/test/resolve.test.js
+++ b/packages/endo/test/resolve.test.js
@@ -37,7 +37,7 @@ const q = JSON.stringify;
   test(`resolve(${q(c.rel)}, ${q(c.via)}) -> ${q(c.res)}`, t => {
     t.plan(1);
     const res = resolve(c.rel, c.via);
-    t.equal(res, c.res);
+    t.equal(res, c.res, `resolve(${q(c.rel)}, ${q(c.via)}) === ${q(c.res)}`);
     t.end();
   });
 });
@@ -45,27 +45,27 @@ const q = JSON.stringify;
 test("throws if the specifier is non-relative", t => {
   t.throws(() => {
     resolve("/", "");
-  }, /Module specifier "\/" must not begin with "\/"/);
+  }, undefined, "throw if the specifier is non-relative");
   t.end();
 });
 
 test("throws if the referrer is non-relative", t => {
   t.throws(() => {
     resolve("", "/");
-  }, /Module referrer "\/" must begin with "\.\/"/);
+  }, undefined, "throws if the referrer is non-relative");
   t.end();
 });
 
 test("throws if the referrer is external", t => {
   t.throws(() => {
     resolve("", "external");
-  }, /Module referrer "external" must begin with "\.\/"/);
+  }, undefined, "throws if the referrer is external");
   t.end();
 });
 
 test("throws if the referrer is external (degenerate case)", t => {
   t.throws(() => {
     resolve("", "");
-  }, /Module referrer "" must begin with "\.\/"/);
+  }, undefined, "throws if the referrer is a null string");
   t.end();
 });

--- a/packages/endo/test/resolve.test.js
+++ b/packages/endo/test/resolve.test.js
@@ -43,29 +43,45 @@ const q = JSON.stringify;
 });
 
 test("throws if the specifier is non-relative", t => {
-  t.throws(() => {
-    resolve("/", "");
-  }, undefined, "throw if the specifier is non-relative");
+  t.throws(
+    () => {
+      resolve("/", "");
+    },
+    undefined,
+    "throw if the specifier is non-relative"
+  );
   t.end();
 });
 
 test("throws if the referrer is non-relative", t => {
-  t.throws(() => {
-    resolve("", "/");
-  }, undefined, "throws if the referrer is non-relative");
+  t.throws(
+    () => {
+      resolve("", "/");
+    },
+    undefined,
+    "throws if the referrer is non-relative"
+  );
   t.end();
 });
 
 test("throws if the referrer is external", t => {
-  t.throws(() => {
-    resolve("", "external");
-  }, undefined, "throws if the referrer is external");
+  t.throws(
+    () => {
+      resolve("", "external");
+    },
+    undefined,
+    "throws if the referrer is external"
+  );
   t.end();
 });
 
 test("throws if the referrer is external (degenerate case)", t => {
-  t.throws(() => {
-    resolve("", "");
-  }, undefined, "throws if the referrer is a null string");
+  t.throws(
+    () => {
+      resolve("", "");
+    },
+    undefined,
+    "throws if the referrer is a null string"
+  );
   t.end();
 });


### PR DESCRIPTION
The `url.js` module implements `relative(referrer, specifier)` to reconstruct a relative path between two URLs. This is useful for creating references in a `compartmap.json` that are normalized relative to the root of an archive.

The remaining `module-specifier.js` provides three functions for manipulating Node.js packaged module specifiers.

The Node.js package.json allows relative or absolute module specifiers
like `"main": "./index.js"` or `"main": "index.js"`.
The `relativize` function normalizes all such paths to their relative
form since Endo compartments use absolute specifiers for external
linkage and relative specifiers for internal linkage.
It is not possible for `package.json` to express a module specifier
that refers to a module in another package.

The join function joins an absolute module specifier to a relative
module specifier.
Creating a compartment map joins external dependency package names to
internal module specifiers.
The external dependency specifier must be absolute and the internal
module specifier must be relative.

Endo uses this resolve function for all compartment resolve hooks.
The referrer is always a relative module specifier like "./index.js".
The referent may be relative to import a module in the same package, or
absolute to import an external dependency, either a built-in module or a
module from a third-party package.