### PR TITLE
feat(endo): Add zip

### DIFF
--- a/packages/endo/src/zip.js
+++ b/packages/endo/src/zip.js
@@ -1,0 +1,17 @@
+// Decouples Endo's usage from JSZip's particular presentation.
+
+import JSZip from "jszip";
+
+export const readZip = async data => {
+  const zip = new JSZip();
+  await zip.loadAsync(data);
+  const read = async path => zip.file(path).async("uint8array");
+  return { read };
+};
+
+export const writeZip = () => {
+  const zip = new JSZip();
+  const write = async (path, data) => zip.file(path, data);
+  const data = async () => zip.generateAsync({ type: "uint8array" });
+  return { write, data };
+};


### PR DESCRIPTION
Our current archive format of choice is Zip.  Our current implementation of choice is stuk/jszip.  Endo's functions that interact with archives assume an Archive interface with read, write, data, and a from-data constructor.  To decouple Endo's internals from the specifics of JSZip, this thin adapter presents the JSZip API as this Archive interface.