### PR TITLE
feat(ses): Add Compartment load function

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -2,7 +2,9 @@ User-visible changes in SES:
 
 ## Next release
 
-* No changes yet.
+* Adds the `load` method to `Compartment`.
+  Load allows a bundler or archiver to use the `Compartment` API to gather the
+  transitive dependencies of modules without executing them.
 
 ## Release 0.9.1 (16-July-2020)
 

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -205,6 +205,16 @@ const CompartmentPrototype = {
     });
   },
 
+  async load(specifier) {
+    if (typeof specifier !== 'string') {
+      throw new TypeError('first argument of load() must be a string');
+    }
+
+    assertModuleHooks(this);
+
+    return load(privateFields, moduleAnalyses, this, specifier);
+  },
+
   importNow(specifier) {
     if (typeof specifier !== 'string') {
       throw new TypeError('first argument of importNow() must be a string');

--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -1807,6 +1807,7 @@ export const whitelist = {
     evaluate: fn,
     globalThis: getter,
     import: asyncFn,
+    load: asyncFn,
     importNow: fn,
     module: fn,
     // Should this be proposed?

--- a/packages/ses/test/compartment-instance.test.js
+++ b/packages/ses/test/compartment-instance.test.js
@@ -43,6 +43,7 @@ test('Compartment instance', t => {
       'evaluate',
       'import',
       'importNow',
+      'load',
       'module',
       'globalThis',
       'toString',

--- a/packages/ses/test/compartment-prototype.test.js
+++ b/packages/ses/test/compartment-prototype.test.js
@@ -19,6 +19,7 @@ test('Compartment prototype', t => {
       'evaluate',
       'import',
       'importNow',
+      'load',
       'module',
       'globalThis',
       'toString',


### PR DESCRIPTION
This change surfaces the `load` function so compartments can be used to create archives without executing any of the assembled modules.