### PR TITLE
feat(endo): Add import

### DIFF
--- a/packages/endo/src/assemble.js
+++ b/packages/endo/src/assemble.js
@@ -15,8 +15,8 @@ const q = JSON.stringify;
 // compartment that imports them.
 // Returns the root of the compartment DAG.
 // Does not load or execute any modules.
-// Uses makeImportHook with the given "root" string of each compartment in the
-// DAG.
+// Uses makeImportHook with the given "location" string of each compartment in
+// the DAG.
 // Passes the given endowments and external modules into the root compartment
 // only.
 export const assemble = ({
@@ -60,7 +60,7 @@ export const assemble = ({
 
   const compartment = new Compartment(endowments, modules, {
     resolveHook: resolve,
-    importHook: makeImportHook(descriptor.root)
+    importHook: makeImportHook(descriptor.location)
   });
 
   loaded[name] = compartment;

--- a/packages/endo/src/import.js
+++ b/packages/endo/src/import.js
@@ -1,0 +1,57 @@
+/* global StaticModuleRecord */
+/* eslint no-shadow: 0 */
+
+import { compartmentMapForNodeModules } from "./compartmap.js";
+import { search } from "./search.js";
+import { assemble } from "./assemble.js";
+
+const decoder = new TextDecoder();
+
+const resolve = (rel, abs) => new URL(rel, abs).toString();
+
+const makeImportHookMaker = (read, rootLocation) => packagePath => {
+  const packageLocation = resolve(packagePath, rootLocation);
+  return async moduleSpecifier => {
+    const moduleLocation = resolve(moduleSpecifier, packageLocation);
+    const moduleBytes = await read(moduleLocation);
+    const moduleSource = decoder.decode(moduleBytes);
+    return new StaticModuleRecord(moduleSource, moduleLocation);
+  };
+};
+
+export const loadPath = async (read, modulePath) => {
+  const { packagePath, packageDescriptorText, moduleSpecifier } = await search(
+    read,
+    modulePath
+  );
+
+  const packageDescriptor = JSON.parse(packageDescriptorText);
+  const compartmentMap = await compartmentMapForNodeModules(
+    read,
+    packagePath,
+    [],
+    packageDescriptor
+  );
+
+  const { compartments, main } = compartmentMap;
+
+  const makeImportHook = makeImportHookMaker(read, packagePath);
+
+  const execute = async (endowments, modules) => {
+    const compartment = assemble({
+      name: main,
+      compartments,
+      makeImportHook,
+      endowments,
+      modules
+    });
+    return compartment.import(moduleSpecifier);
+  };
+
+  return { execute };
+};
+
+export const importPath = async (read, modulePath, endowments, modules) => {
+  const application = await loadPath(read, modulePath, endowments, modules);
+  return application.execute(endowments, modules);
+};

--- a/packages/endo/src/import.js
+++ b/packages/endo/src/import.js
@@ -9,14 +9,18 @@ const decoder = new TextDecoder();
 
 const resolve = (rel, abs) => new URL(rel, abs).toString();
 
-const makeImportHookMaker = (read, baseLocation) => packageLocation => {
-  packageLocation = resolve(packageLocation, baseLocation);
-  return async moduleSpecifier => {
-    const moduleLocation = resolve(moduleSpecifier, packageLocation);
-    const moduleBytes = await read(moduleLocation);
-    const moduleSource = decoder.decode(moduleBytes);
-    return new StaticModuleRecord(moduleSource, moduleLocation);
+const makeImportHookMaker = (read, baseLocation) => {
+  const makeImportHook = packageLocation => {
+    packageLocation = resolve(packageLocation, baseLocation);
+    const importHook = async moduleSpecifier => {
+      const moduleLocation = resolve(moduleSpecifier, packageLocation);
+      const moduleBytes = await read(moduleLocation);
+      const moduleSource = decoder.decode(moduleBytes);
+      return new StaticModuleRecord(moduleSource, moduleLocation);
+    };
+    return importHook;
   };
+  return makeImportHook;
 };
 
 export const loadPath = async (read, modulePath) => {
@@ -53,6 +57,6 @@ export const loadPath = async (read, modulePath) => {
 };
 
 export const importPath = async (read, modulePath, endowments, modules) => {
-  const application = await loadPath(read, modulePath, endowments, modules);
+  const application = await loadPath(read, modulePath);
   return application.execute(endowments, modules);
 };

--- a/packages/endo/src/import.js
+++ b/packages/endo/src/import.js
@@ -20,10 +20,11 @@ const makeImportHookMaker = (read, rootLocation) => packageLocation => {
 };
 
 export const loadPath = async (read, modulePath) => {
-  const { packageLocation, packageDescriptorText, moduleSpecifier } = await search(
-    read,
-    modulePath
-  );
+  const {
+    packageLocation,
+    packageDescriptorText,
+    moduleSpecifier
+  } = await search(read, modulePath);
 
   const packageDescriptor = JSON.parse(packageDescriptorText);
   const compartmentMap = await compartmentMapForNodeModules(

--- a/packages/endo/src/import.js
+++ b/packages/endo/src/import.js
@@ -9,8 +9,8 @@ const decoder = new TextDecoder();
 
 const resolve = (rel, abs) => new URL(rel, abs).toString();
 
-const makeImportHookMaker = (read, rootLocation) => packagePath => {
-  const packageLocation = resolve(packagePath, rootLocation);
+const makeImportHookMaker = (read, rootLocation) => packageLocation => {
+  packageLocation = resolve(packageLocation, rootLocation);
   return async moduleSpecifier => {
     const moduleLocation = resolve(moduleSpecifier, packageLocation);
     const moduleBytes = await read(moduleLocation);
@@ -20,7 +20,7 @@ const makeImportHookMaker = (read, rootLocation) => packagePath => {
 };
 
 export const loadPath = async (read, modulePath) => {
-  const { packagePath, packageDescriptorText, moduleSpecifier } = await search(
+  const { packageLocation, packageDescriptorText, moduleSpecifier } = await search(
     read,
     modulePath
   );
@@ -28,14 +28,14 @@ export const loadPath = async (read, modulePath) => {
   const packageDescriptor = JSON.parse(packageDescriptorText);
   const compartmentMap = await compartmentMapForNodeModules(
     read,
-    packagePath,
+    packageLocation,
     [],
     packageDescriptor
   );
 
   const { compartments, main } = compartmentMap;
 
-  const makeImportHook = makeImportHookMaker(read, packagePath);
+  const makeImportHook = makeImportHookMaker(read, packageLocation);
 
   const execute = async (endowments, modules) => {
     const compartment = assemble({

--- a/packages/endo/src/import.js
+++ b/packages/endo/src/import.js
@@ -9,8 +9,8 @@ const decoder = new TextDecoder();
 
 const resolve = (rel, abs) => new URL(rel, abs).toString();
 
-const makeImportHookMaker = (read, rootLocation) => packageLocation => {
-  packageLocation = resolve(packageLocation, rootLocation);
+const makeImportHookMaker = (read, baseLocation) => packageLocation => {
+  packageLocation = resolve(packageLocation, baseLocation);
   return async moduleSpecifier => {
     const moduleLocation = resolve(moduleSpecifier, packageLocation);
     const moduleBytes = await read(moduleLocation);


### PR DESCRIPTION
The import function most directly models the Node.js command line:
pass the path to the entry module and the capability to read files on
the corresponding file system.
Importing a module creates a compartment graph and executes the entry
module of the root compartment.