### PR TITLE
feat(endo): Add import-archive

### DIFF
--- a/packages/endo/src/import-archive.js
+++ b/packages/endo/src/import-archive.js
@@ -1,0 +1,50 @@
+/* global StaticModuleRecord */
+/* eslint no-shadow: 0 */
+
+import { readZip } from "./zip.js";
+import { join } from "./node-module-specifier.js";
+import { assemble } from "./assemble.js";
+
+const decoder = new TextDecoder();
+
+const makeArchiveImportHookMaker = archive => packagePath => async moduleSpecifier => {
+  const moduleLocation = join(packagePath, moduleSpecifier);
+  const moduleBytes = await archive.read(moduleLocation);
+  const moduleSource = decoder.decode(moduleBytes);
+  return new StaticModuleRecord(moduleSource, moduleLocation);
+};
+
+export const parseArchive = async archiveBytes => {
+  const archive = await readZip(archiveBytes);
+
+  const compartmentMapBytes = await archive.read("compartmap.json");
+  const compartmentMapText = decoder.decode(compartmentMapBytes);
+  const compartmentMap = JSON.parse(compartmentMapText);
+
+  const { compartments, main, entry: moduleSpecifier } = compartmentMap;
+
+  const makeImportHook = makeArchiveImportHookMaker(archive);
+
+  const execute = (endowments, modules) => {
+    const compartment = assemble({
+      name: main,
+      compartments,
+      makeImportHook,
+      endowments,
+      modules
+    });
+    return compartment.import(moduleSpecifier);
+  };
+
+  return { execute };
+};
+
+export const loadArchive = async (read, archivePath) => {
+  const archiveBytes = await read(archivePath);
+  return parseArchive(archiveBytes);
+};
+
+export const importArchive = async (read, archivePath, endowments, modules) => {
+  const archive = await loadArchive(read, archivePath);
+  return archive.execute(endowments, modules);
+};

--- a/packages/endo/src/import-archive.js
+++ b/packages/endo/src/import-archive.js
@@ -7,8 +7,8 @@ import { assemble } from "./assemble.js";
 
 const decoder = new TextDecoder();
 
-const makeArchiveImportHookMaker = archive => packagePath => async moduleSpecifier => {
-  const moduleLocation = join(packagePath, moduleSpecifier);
+const makeArchiveImportHookMaker = archive => packageLocation => async moduleSpecifier => {
+  const moduleLocation = join(packageLocation, moduleSpecifier);
   const moduleBytes = await archive.read(moduleLocation);
   const moduleSource = decoder.decode(moduleBytes);
   return new StaticModuleRecord(moduleSource, moduleLocation);


### PR DESCRIPTION
Running an application mostly uses the same parts needed to run the
original application from disk.
Instead of building a compartment map, we just deserialize the
ready-made compartmap.json from the archive.
We use the same compartment assembler, but with importHooks backed by
the archive instead of the file system.