### PR TITLE
fix(ses): Use CommonJS Rollup plugin

### DIFF
--- a/packages/ses-integration-test/package.json
+++ b/packages/ses-integration-test/package.json
@@ -29,6 +29,8 @@
     "ses": "file:../ses"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^13.0.0",
+    "@rollup/plugin-node-resolve": "^6.1.0",
     "babel-eslint": "^10.0.3",
     "browserify": "^16.2.3",
     "eslint": "^6.8.0",
@@ -42,7 +44,6 @@
     "puppeteer": "^1.13.0",
     "rollup": "1.31.0",
     "rollup-plugin-multi-entry": "^2.1.0",
-    "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-replace": "^2.1.0",
     "tape": "4.12.1",
     "tape-promise": "^4.0.0",

--- a/packages/ses-integration-test/scaffolding/rollup/rollup.config.test.js
+++ b/packages/ses-integration-test/scaffolding/rollup/rollup.config.test.js
@@ -1,5 +1,6 @@
 import path from "path";
-import resolve from "rollup-plugin-node-resolve";
+import resolve from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
 
 export default [
   {
@@ -18,7 +19,8 @@ export default [
           "@agoric/transform-module",
           "@agoric/babel-standalone"
         ]
-      })
+      }),
+      commonjs()
     ]
   }
 ];

--- a/packages/ses-integration-test/transform-tests/config/rollup.config.cjs.js
+++ b/packages/ses-integration-test/transform-tests/config/rollup.config.cjs.js
@@ -1,5 +1,6 @@
 import multiEntry from "rollup-plugin-multi-entry";
-import resolve from "rollup-plugin-node-resolve";
+import resolve from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
 
 export default [
   {
@@ -15,7 +16,8 @@ export default [
       multiEntry(),
       resolve({
         only: ["@agoric/nat", "ses"]
-      })
+      }),
+      commonjs()
     ]
   }
 ];

--- a/packages/ses-integration-test/transform-tests/config/rollup.config.esm.js
+++ b/packages/ses-integration-test/transform-tests/config/rollup.config.esm.js
@@ -1,5 +1,6 @@
 import multiEntry from "rollup-plugin-multi-entry";
-import resolve from "rollup-plugin-node-resolve";
+import resolve from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
 
 export default [
   {
@@ -16,6 +17,7 @@ export default [
       resolve({
         only: ["@agoric/nat", "ses"]
       }),
+      commonjs(),
       multiEntry()
     ]
   }

--- a/packages/ses-integration-test/transform-tests/config/rollup.config.no-lib.js
+++ b/packages/ses-integration-test/transform-tests/config/rollup.config.no-lib.js
@@ -1,6 +1,7 @@
 import replace from "rollup-plugin-replace";
 import multiEntry from "rollup-plugin-multi-entry";
-import resolve from "rollup-plugin-node-resolve";
+import resolve from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
 
 export default [
   {
@@ -20,6 +21,7 @@ export default [
       resolve({
         only: ["@agoric/nat"]
       }),
+      commonjs(),
       multiEntry()
     ]
   }

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@agoric/test262-runner": "~0.1.0",
+    "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^6.1.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.8.0",

--- a/packages/ses/rollup.config.js
+++ b/packages/ses/rollup.config.js
@@ -1,4 +1,5 @@
 import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
 import { terser } from 'rollup-plugin-terser';
 import fs from 'fs';
 
@@ -20,7 +21,7 @@ export default [
         format: 'cjs',
       },
     ],
-    plugins: [resolve()],
+    plugins: [resolve(), commonjs()],
   },
   {
     input: 'src/main.js',
@@ -29,7 +30,7 @@ export default [
       format: 'umd',
       name: umd,
     },
-    plugins: [resolve()],
+    plugins: [resolve(), commonjs()],
   },
   {
     input: 'src/main.js',
@@ -38,6 +39,6 @@ export default [
       format: 'umd',
       name: umd,
     },
-    plugins: [resolve(), terser()],
+    plugins: [resolve(), commonjs(), terser()],
   },
 ];

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -2,16 +2,7 @@
 // communicate through the moduleAnalyses private side-table.
 /* eslint max-classes-per-file: ["error", 2] */
 
-import * as babel from '@agoric/babel-standalone';
-// We are using the above import form, and referring to its default export
-// explicitly below like babel.default, because the proper construct causes a
-// Rollup error.
-// This form:
-//   import babel from '@agoric/babel-standalone';
-// And this variant:
-//   import { default as babel } from '@agoric/babel-standalone';
-// Both produce:
-//   Error: 'default' is not exported by .../@agoric/babel-standalone/babel.js
+import babel from '@agoric/babel-standalone';
 import { makeModuleAnalyzer } from '@agoric/transform-module';
 import {
   assign,
@@ -34,7 +25,7 @@ import { getGlobalIntrinsics } from './intrinsics.js';
 // q, for quoting strings.
 const q = JSON.stringify;
 
-const analyzeModule = makeModuleAnalyzer(babel.default);
+const analyzeModule = makeModuleAnalyzer(babel);
 
 // moduleAnalyses are the private data of a StaticModuleRecord.
 // We use moduleAnalyses in the loader/linker to look up


### PR DESCRIPTION
This plugin eliminates the problem I previously encountered with importing standalone Babel idiomatically. It sadly does not redress our fork of standalone Babel, because we still need to cull  dependencies that do not play well with lockdown.