### PR TITLE
fix: partial intrinsic reform

### DIFF
--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -26,6 +26,8 @@ import tameGlobalMathObject from './tame-global-math-object.js';
 import tameGlobalRegExpObject from './tame-global-reg-exp-object.js';
 import enablePropertyOverrides from './enable-property-overrides.js';
 
+const { defineProperties } = Object;
+
 let firstOptions;
 
 // A successful lockdown call indicates that `harden` can be called and
@@ -90,10 +92,13 @@ export function lockdown(options = {}) {
    */
   tameFunctionConstructors();
 
-  tameGlobalDateObject(dateTaming);
-  tameGlobalErrorObject(errorTaming);
-  tameGlobalMathObject(mathTaming);
-  tameGlobalRegExpObject(regExpTaming);
+  // TODO The tame functions return bindings for both start and shared
+  // which we should make use of in a principled manner. Until then,
+  // we just use the specific start binding explicitly.
+  defineProperties(globalThis, tameGlobalDateObject(dateTaming).start);
+  defineProperties(globalThis, tameGlobalErrorObject(errorTaming).start);
+  defineProperties(globalThis, tameGlobalMathObject(mathTaming).start);
+  defineProperties(globalThis, tameGlobalRegExpObject(regExpTaming).start);
 
   /**
    * 2. WHITELIST to standardize the environment.

--- a/packages/ses/src/tame-global-error-object.js
+++ b/packages/ses/src/tame-global-error-object.js
@@ -14,28 +14,46 @@ export default function tameGlobalErrorObject(errorTaming = 'safe') {
   if (errorTaming !== 'safe' && errorTaming !== 'unsafe') {
     throw new Error(`unrecognized errorTaming ${errorTaming}`);
   }
-  const unsafeError = Error;
+  const originalError = Error;
 
+  // We never expose the originalError constructor. Rather, tamedError
+  // is the one to be installed on the start compartment.
   const tamedError = function Error(...rest) {
     if (new.target === undefined) {
-      return unsafeError(...rest);
+      return originalError(...rest);
     }
-    return Reflect.construct(unsafeError, rest, new.target);
+    return Reflect.construct(originalError, rest, new.target);
   };
+
+  // TODO uncomment the sharedError occurrences. To do this, we need
+  // more intrinsic reform so that the whitelist doesn't get confused
+  // between tamedError and sharedError.
+  const sharedError = tamedError;
+  /*
+  const sharedError = function Error(...rest) {
+    if (new.target === undefined) {
+      return originalError(...rest);
+    }
+    return Reflect.construct(originalError, rest, new.target);
+  };
+  */
 
   // Use concise methods to obtain named functions without constructors.
   const tamedMethods = {
     captureStackTrace(error, optFn = undefined) {
-      if (errorTaming === 'unsafe' && unsafeError.captureStackTrace) {
-        // unsafeError.captureStackTrace is only on v8
-        unsafeError.captureStackTrace(error, optFn);
+      if (
+        errorTaming === 'unsafe' &&
+        typeof originalError.captureStackTrace === 'function'
+      ) {
+        // originalError.captureStackTrace is only on v8
+        originalError.captureStackTrace(error, optFn);
         return;
       }
       Reflect.set(error, 'stack', '');
     },
   };
 
-  const ErrorPrototype = unsafeError.prototype;
+  const ErrorPrototype = originalError.prototype;
   defineProperties(tamedError, {
     length: { value: 1 },
     prototype: {
@@ -52,16 +70,22 @@ export default function tameGlobalErrorObject(errorTaming = 'safe') {
     },
     stackTraceLimit: {
       get() {
-        if (errorTaming === 'unsafe' && unsafeError.stackTraceLimit) {
-          // unsafeError.stackTraceLimit is only on v8
-          return unsafeError.stackTraceLimit;
+        if (
+          errorTaming === 'unsafe' &&
+          typeof originalError.stackTraceLimit === 'number'
+        ) {
+          // originalError.stackTraceLimit is only on v8
+          return originalError.stackTraceLimit;
         }
         return 0;
       },
       set(newLimit) {
-        if (errorTaming === 'unsafe' && unsafeError.stackTraceLimit) {
-          // unsafeError.stackTraceLimit is only on v8
-          unsafeError.stackTraceLimit = newLimit;
+        if (
+          errorTaming === 'unsafe' &&
+          typeof originalError.stackTraceLimit === 'number'
+        ) {
+          // originalError.stackTraceLimit is only on v8
+          originalError.stackTraceLimit = newLimit;
           // We place the useless return on the next line to ensure
           // that anything we place after the if in the future only
           // happens if the then-case does not.
@@ -75,8 +99,32 @@ export default function tameGlobalErrorObject(errorTaming = 'safe') {
     },
   });
 
+  // TODO uncomment. See TODO note above
+  /*
+  defineProperties(sharedError, {
+    length: { value: 1 },
+    prototype: {
+      value: ErrorPrototype,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    },
+    stackTraceLimit: {
+      get() {
+        return 0;
+      },
+      set(_) {
+        // ignore
+      },
+      // WTF on v8 stackTraceLimit is enumerable
+      enumerable: false,
+      configurable: true,
+    },
+  });
+  */
+
   defineProperties(ErrorPrototype, {
-    constructor: { value: tamedError },
+    constructor: { value: sharedError },
     /* TODO
     stack: {
       get() {
@@ -90,8 +138,25 @@ export default function tameGlobalErrorObject(errorTaming = 'safe') {
   });
 
   for (const NativeError of NativeErrors) {
-    setPrototypeOf(NativeError, tamedError);
+    setPrototypeOf(NativeError, sharedError);
   }
 
-  globalThis.Error = tamedError;
+  return {
+    start: {
+      Error: {
+        value: tamedError,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      },
+    },
+    shared: {
+      Error: {
+        value: sharedError,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      },
+    },
+  };
 }

--- a/packages/ses/src/tame-global-math-object.js
+++ b/packages/ses/src/tame-global-math-object.js
@@ -1,12 +1,10 @@
-const { defineProperties } = Object;
+const { create, getOwnPropertyDescriptors } = Object;
 
 export default function tameGlobalMathObject(mathTaming = 'safe') {
-  if (mathTaming === 'unsafe') {
-    return;
-  }
-  if (mathTaming !== 'safe') {
+  if (mathTaming !== 'safe' && mathTaming !== 'unsafe') {
     throw new Error(`unrecognized mathTaming ${mathTaming}`);
   }
+  const originalMath = Math;
 
   // Tame the %Math% intrinsic.
 
@@ -17,7 +15,32 @@ export default function tameGlobalMathObject(mathTaming = 'safe') {
     },
   };
 
-  defineProperties(Math, {
-    random: { value: tamedMethods.random },
+  const sharedMath = create(Object.prototype, {
+    ...getOwnPropertyDescriptors(originalMath),
+    random: {
+      value: tamedMethods.random,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    },
   });
+
+  return {
+    start: {
+      Math: {
+        value: mathTaming === 'unsafe' ? originalMath : sharedMath,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      },
+    },
+    shared: {
+      Math: {
+        value: sharedMath,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      },
+    },
+  };
 }

--- a/packages/ses/src/tame-global-reg-exp-object.js
+++ b/packages/ses/src/tame-global-reg-exp-object.js
@@ -1,25 +1,21 @@
 const { defineProperties, getOwnPropertyDescriptor } = Object;
 
 export default function tameGlobalRegExpObject(regExpTaming = 'safe') {
-  if (regExpTaming === 'unsafe') {
-    return;
-  }
-  if (regExpTaming !== 'safe') {
+  if (regExpTaming !== 'safe' && regExpTaming !== 'unsafe') {
     throw new Error(`unrecognized regExpTaming ${regExpTaming}`);
   }
-
-  const unsafeRegExp = RegExp;
+  const originalRegExp = RegExp;
 
   // RegExp has non-writable static properties we need to omit.
-  const tamedRegExp = function RegExp(...rest) {
+  const sharedRegExp = function RegExp(...rest) {
     if (new.target === undefined) {
-      return unsafeRegExp(...rest);
+      return originalRegExp(...rest);
     }
-    return Reflect.construct(unsafeRegExp, rest, new.target);
+    return Reflect.construct(originalRegExp, rest, new.target);
   };
 
-  const RegExpPrototype = unsafeRegExp.prototype;
-  defineProperties(tamedRegExp, {
+  const RegExpPrototype = originalRegExp.prototype;
+  defineProperties(sharedRegExp, {
     length: { value: 2 },
     prototype: {
       value: RegExpPrototype,
@@ -27,13 +23,32 @@ export default function tameGlobalRegExpObject(regExpTaming = 'safe') {
       enumerable: false,
       configurable: false,
     },
-    [Symbol.species]: getOwnPropertyDescriptor(unsafeRegExp, Symbol.species),
+    [Symbol.species]: getOwnPropertyDescriptor(originalRegExp, Symbol.species),
   });
 
   delete RegExpPrototype.compile;
   defineProperties(RegExpPrototype, {
-    constructor: { value: tamedRegExp },
+    constructor: { value: sharedRegExp },
   });
 
-  globalThis.RegExp = tamedRegExp;
+  return {
+    start: {
+      // TODO do we ever really want to expose the original RegExp constructor,
+      // even just in the start compartment?
+      RegExp: {
+        value: regExpTaming === 'unsafe' ? originalRegExp : sharedRegExp,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      },
+    },
+    shared: {
+      RegExp: {
+        value: sharedRegExp,
+        writable: true,
+        enumerable: false,
+        configurable: true,
+      },
+    },
+  };
 }

--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -254,8 +254,8 @@ export default {
     isPrototypeOf: fn,
     // 19.1.3.4 Object.prototype.propertyIsEnumerable
     propertyIsEnumerable: fn,
-    // 19.1.3.5 Object.prototype.toLocaleString
-    toLocaleString: fn,
+    // 19.1.3.5 Object.prototype.toLocaleString suppressed
+    toLocaleString: false,
     // 19.1.3.6 Object.prototype.toString
     toString: fn,
     // 19.1.3.7 Object.prototype.valueOf
@@ -458,8 +458,8 @@ export default {
     toExponential: fn,
     // 20.1.3.3 Number.prototype.toFixed
     toFixed: fn,
-    // 20.1.3.4 Number.prototype.toLocaleString
-    toLocaleString: fn,
+    // 20.1.3.4 Number.prototype.toLocaleString suppressed
+    toLocaleString: false,
     // 20.1.3.5 Number.prototype.toPrecision
     toPrecision: fn,
     // 20.1.3.6 Number.prototype.toString
@@ -482,8 +482,8 @@ export default {
   BigIntPrototype: {
     // 20.2.3.1 BigInt.prototype.constructor
     constructor: 'BigInt',
-    // 20.2.3.2 BigInt.prototype.toLocaleString
-    toLocaleString: fn,
+    // 20.2.3.2 BigInt.prototype.toLocaleString suppressed
+    toLocaleString: false,
     // 20.2.3.3 BigInt.prototype.toString
     toString: fn,
     // 20.2.3.4 BigInt.prototype.valueOf
@@ -672,12 +672,12 @@ export default {
     toISOString: fn,
     // 20.4.4.37 Date.prototype.toJSON
     toJSON: fn,
-    // 20.4.4.38 Date.prototype.toLocaleDateString
-    toLocaleDateString: fn,
-    // 20.4.4.39 Date.prototype.toLocaleString
-    toLocaleString: fn,
-    // 20.4.4.40 Date.prototype.toLocaleTimeString
-    toLocaleTimeString: fn,
+    // 20.4.4.38 Date.prototype.toLocaleDateString suppressed
+    toLocaleDateString: false,
+    // 20.4.4.39 Date.prototype.toLocaleString suppressed
+    toLocaleString: false,
+    // 20.4.4.40 Date.prototype.toLocaleTimeString suppressed
+    toLocaleTimeString: false,
     // 20.4.4.41 Date.prototype.toString
     toString: fn,
     // 20.4.4.42 Date.prototype.toTimeString
@@ -735,8 +735,8 @@ export default {
     indexOf: fn,
     // 21.1.3.9 String.prototype.lastIndexOf
     lastIndexOf: fn,
-    // 21.1.3.10 String.prototype.localeCompare
-    localeCompare: fn,
+    // 21.1.3.10 String.prototype.localeCompare suppressed
+    localeCompare: false,
     // 21.1.3.11 String.prototype.match
     match: fn,
     // 21.1.3.12 String.prototype.matchAll
@@ -761,10 +761,10 @@ export default {
     startsWith: fn,
     // 21.1.3.22 String.prototype.substring
     substring: fn,
-    // 21.1.3.23 String.prototype.toLocaleLowerCase
-    toLocaleLowerCase: fn,
-    // 21.1.3.24 String.prototype.toLocaleUpperCase
-    toLocaleUpperCase: fn,
+    // 21.1.3.23 String.prototype.toLocaleLowerCase suppressed
+    toLocaleLowerCase: false,
+    // 21.1.3.24 String.prototype.toLocaleUpperCase suppressed
+    toLocaleUpperCase: false,
     // 21.1.3.25 String.prototype.toLowerCase
     toLowerCase: fn,
     // 21.1.3.26 String.prototype.
@@ -964,8 +964,8 @@ export default {
     sort: fn,
     // 22.1.3.28 Array.prototype.splice
     splice: fn,
-    // 22.1.3.29 Array.prototype.toLocaleString
-    toLocaleString: fn,
+    // 22.1.3.29 Array.prototype.toLocaleString suppressed
+    toLocaleString: false,
     // 22.1.3.30 Array.prototype.toString
     toString: fn,
     // 22.1.3.31 Array.prototype.unshift
@@ -1070,8 +1070,8 @@ export default {
     sort: fn,
     // 22.2.3.27 %TypedArray%.prototype.subarray
     subarray: fn,
-    // 22.2.3.28 %TypedArray%.prototype.toLocaleString
-    toLocaleString: fn,
+    // 22.2.3.28 %TypedArray%.prototype.toLocaleString suppressed
+    toLocaleString: false,
     // 22.2.3.29 %TypedArray%.prototype.toString
     toString: fn,
     // 22.2.3.30 %TypedArray%.prototype.values

--- a/packages/ses/test/tame-date-allow.test.js
+++ b/packages/ses/test/tame-date-allow.test.js
@@ -27,7 +27,6 @@ test('lockdown() date allowed - Date in Compartment is not tamed', t => {
   const newDate = c.evaluate('new Date()');
   t.ok(isDate(newDate));
 
-  t.doesNotThrow(() => c.evaluate('({}).toLocaleString()'), Error);
   t.end();
 });
 
@@ -40,6 +39,5 @@ test('lockdown() date allowed - Date in nested Compartment is not tamed', t => {
   const newDate = c.evaluate('new Date()');
   t.ok(isDate(newDate));
 
-  t.doesNotThrow(() => c.evaluate('({}).toLocaleString()'), Error);
   t.end();
 });

--- a/packages/ses/test/tame-date.test.js
+++ b/packages/ses/test/tame-date.test.js
@@ -14,7 +14,6 @@ test('lockdown() default - Date in Compartment is tamed', t => {
   const newDate = c.evaluate('new Date()');
   t.equal(`${newDate}`, 'Invalid Date');
 
-  t.throws(() => c.evaluate('({}).toLocaleString()'), Error);
   t.end();
 });
 
@@ -27,6 +26,5 @@ test('lockdown() default - Date in nested Compartment is tamed', t => {
   const newDate = c.evaluate('new Date()');
   t.equal(`${newDate}`, 'Invalid Date');
 
-  t.throws(() => c.evaluate('({}).toLocaleString()'), Error);
   t.end();
 });

--- a/packages/ses/test/tame-global-date-object-allow.test.js
+++ b/packages/ses/test/tame-global-date-object-allow.test.js
@@ -1,53 +1,38 @@
 import tap from 'tap';
-import { captureGlobals } from '@agoric/test262-runner';
 import tameGlobalDateObject from '../src/tame-global-date-object.js';
 
 const { test } = tap;
 
+const {
+  start: {
+    Date: { value: tamedDate },
+  },
+  shared: {
+    Date: { value: sharedDate },
+  },
+} = tameGlobalDateObject('unsafe');
+
 test('tameGlobalDateObject - constructor without argument', t => {
-  const restore = captureGlobals('Date');
-  tameGlobalDateObject('unsafe');
+  t.equal(tamedDate.name, 'Date');
 
-  t.equal(Date.name, 'Date');
+  // eslint-disable-next-line new-cap
+  const date = new tamedDate();
 
-  const date = new Date();
-
-  t.ok(date instanceof Date);
+  t.ok(date instanceof tamedDate);
   // eslint-disable-next-line no-proto
-  t.equal(date.__proto__.constructor, Date);
+  t.equal(date.__proto__.constructor, sharedDate);
 
   t.isNot(date.toString(), 'Invalid Date');
 
-  restore();
   t.end();
 });
 
 test('tameGlobalDateObject - now', t => {
-  const restore = captureGlobals('Date');
-  tameGlobalDateObject('unsafe');
+  t.equal(tamedDate.now.name, 'now');
 
-  t.equal(Date.now.name, 'now');
-
-  const date = Date.now();
+  const date = tamedDate.now();
 
   t.ok(date > 1);
 
-  restore();
-  t.end();
-});
-
-test('tameGlobalObject - toLocaleString', t => {
-  const restore = captureGlobals('Date');
-  tameGlobalDateObject('unsafe');
-
-  t.equal(Date.prototype.toLocaleString.name, 'toLocaleString');
-  t.equal(Object.prototype.toLocaleString.name, 'toLocaleString');
-
-  const date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
-
-  t.equal(typeof date.toLocaleString(), 'string');
-  t.equal(typeof Object.prototype.toLocaleString.apply(date), 'string');
-
-  restore();
   t.end();
 });

--- a/packages/ses/test/tame-global-date-object.test.js
+++ b/packages/ses/test/tame-global-date-object.test.js
@@ -1,53 +1,38 @@
 import tap from 'tap';
-import { captureGlobals } from '@agoric/test262-runner';
 import tameGlobalDateObject from '../src/tame-global-date-object.js';
 
 const { test } = tap;
 
+const {
+  start: {
+    Date: { value: tamedDate },
+  },
+  shared: {
+    Date: { value: sharedDate },
+  },
+} = tameGlobalDateObject('safe');
+
 test('tameGlobalDateObject - constructor without argument', t => {
-  const restore = captureGlobals('Date');
-  tameGlobalDateObject();
+  t.equal(tamedDate.name, 'Date');
 
-  t.equal(Date.name, 'Date');
+  // eslint-disable-next-line new-cap
+  const date = new tamedDate();
 
-  const date = new Date();
-
-  t.ok(date instanceof Date);
+  t.ok(date instanceof tamedDate);
   // eslint-disable-next-line no-proto
-  t.equal(date.__proto__.constructor, Date);
+  t.equal(date.__proto__.constructor, sharedDate);
 
   t.equal(date.toString(), 'Invalid Date');
 
-  restore();
   t.end();
 });
 
 test('tameGlobalDateObject - now', t => {
-  const restore = captureGlobals('Date');
-  tameGlobalDateObject();
+  t.equal(tamedDate.now.name, 'now');
 
-  t.equal(Date.now.name, 'now');
-
-  const date = Date.now();
+  const date = tamedDate.now();
 
   t.ok(Number.isNaN(date));
 
-  restore();
-  t.end();
-});
-
-test('tameGlobalObject - toLocaleString', t => {
-  const restore = captureGlobals('Date');
-  tameGlobalDateObject();
-
-  t.equal(Date.prototype.toLocaleString.name, 'toLocaleString');
-  t.equal(Object.prototype.toLocaleString.name, 'toLocaleString');
-
-  const date = new Date(Date.UTC(2012, 11, 20, 3, 0, 0));
-
-  t.throws(() => date.toLocaleString(), TypeError);
-  t.throws(() => Object.prototype.toLocaleString.apply(date), TypeError);
-
-  restore();
   t.end();
 });

--- a/packages/ses/test/tame-global-error-object-allow.test.js
+++ b/packages/ses/test/tame-global-error-object-allow.test.js
@@ -1,26 +1,27 @@
 import tap from 'tap';
-import { captureGlobals } from '@agoric/test262-runner';
 import tameGlobalErrorObject from '../src/tame-global-error-object.js';
 
 const { test } = tap;
 
+const {
+  start: {
+    Error: { value: tamedError },
+  },
+} = tameGlobalErrorObject('unsafe');
+
 test('tameGlobalErrorObject', t => {
-  const restore = captureGlobals('Error');
-
   try {
-    tameGlobalErrorObject('unsafe');
-
-    t.equal(typeof Error.stackTraceLimit, 'number');
-    Error.stackTraceLimit = 11;
-    t.equal(Error.stackTraceLimit, 11);
-    const error = new Error();
+    t.equal(typeof tamedError.stackTraceLimit, 'number');
+    tamedError.stackTraceLimit = 11;
+    t.equal(tamedError.stackTraceLimit, 11);
+    // eslint-disable-next-line new-cap
+    const error = new tamedError();
     t.equal(typeof error.stack, 'string');
-    Error.captureStackTrace(error);
+    tamedError.captureStackTrace(error);
     t.equal(typeof error.stack, 'string');
   } catch (e) {
     t.isNot(e, e, 'unexpected exception');
   } finally {
-    restore();
     t.end();
   }
 });

--- a/packages/ses/test/tame-global-error-object.test.js
+++ b/packages/ses/test/tame-global-error-object.test.js
@@ -1,27 +1,28 @@
 import tap from 'tap';
-import { captureGlobals } from '@agoric/test262-runner';
 import tameGlobalErrorObject from '../src/tame-global-error-object.js';
 
 const { test } = tap;
 
+const {
+  start: {
+    Error: { value: tamedError },
+  },
+} = tameGlobalErrorObject('safe');
+
 test('tameGlobalErrorObject', t => {
-  const restore = captureGlobals('Error');
-
   try {
-    tameGlobalErrorObject();
-
-    t.equal(typeof Error.stackTraceLimit, 'number');
-    t.equal(Error.stackTraceLimit, 0);
-    Error.stackTraceLimit = 11;
-    t.equal(Error.stackTraceLimit, 0);
-    const error = new Error();
+    t.equal(typeof tamedError.stackTraceLimit, 'number');
+    t.equal(tamedError.stackTraceLimit, 0);
+    tamedError.stackTraceLimit = 11;
+    t.equal(tamedError.stackTraceLimit, 0);
+    // eslint-disable-next-line new-cap
+    const error = new tamedError();
     t.equal(typeof error.stack, 'string');
-    Error.captureStackTrace(error);
+    tamedError.captureStackTrace(error);
     t.equal(error.stack, '');
   } catch (e) {
     t.isNot(e, e, 'unexpected exception');
   } finally {
-    restore();
     t.end();
   }
 });

--- a/packages/ses/test/tame-global-math-object-allow.test.js
+++ b/packages/ses/test/tame-global-math-object-allow.test.js
@@ -1,17 +1,18 @@
 import tap from 'tap';
-import { captureGlobals } from '@agoric/test262-runner';
 import tameGlobalMathObject from '../src/tame-global-math-object.js';
 
 const { test } = tap;
 
+const {
+  start: {
+    Math: { value: tamedMath },
+  },
+} = tameGlobalMathObject('unsafe');
+
 test('tameGlobalMathObject - tamed properties', t => {
-  const restore = captureGlobals('Math');
-  tameGlobalMathObject('unsafe');
+  t.equal(tamedMath.random.name, 'random');
 
-  t.equal(Math.random.name, 'random');
+  t.equal(typeof tamedMath.random(), 'number');
 
-  t.equal(typeof Math.random(), 'number');
-
-  restore();
   t.end();
 });

--- a/packages/ses/test/tame-global-math-object.test.js
+++ b/packages/ses/test/tame-global-math-object.test.js
@@ -1,17 +1,18 @@
 import tap from 'tap';
-import { captureGlobals } from '@agoric/test262-runner';
 import tameGlobalMathObject from '../src/tame-global-math-object.js';
 
 const { test } = tap;
 
+const {
+  start: {
+    Math: { value: tamedMath },
+  },
+} = tameGlobalMathObject('safe');
+
 test('tameGlobalMathObject - tamed properties', t => {
-  const restore = captureGlobals('Math');
-  tameGlobalMathObject();
+  t.equal(tamedMath.random.name, 'random');
 
-  t.equal(Math.random.name, 'random');
+  t.throws(() => tamedMath.random(), TypeError);
 
-  t.throws(() => Math.random(), TypeError);
-
-  restore();
   t.end();
 });

--- a/packages/ses/test/tame-global-reg-exp-object.test.js
+++ b/packages/ses/test/tame-global-reg-exp-object.test.js
@@ -1,33 +1,35 @@
 import tap from 'tap';
-import { captureGlobals } from '@agoric/test262-runner';
 import tameGlobalRegExpObject from '../src/tame-global-reg-exp-object.js';
 
 const { test } = tap;
 
-test('tameGlobalRegExpObject - unsafeRegExp denied', t => {
-  const unsafeRegExp = RegExp;
-  const restore = captureGlobals('RegExp');
-  tameGlobalRegExpObject();
+const unsafeRegExp = RegExp;
+const {
+  start: {
+    RegExp: { value: tamedRegExp },
+  },
+  shared: {
+    RegExp: { value: sharedRegExp },
+  },
+} = tameGlobalRegExpObject('safe');
 
-  t.ok(unsafeRegExp !== RegExp, 'constructor not replaced');
+test('tameGlobalRegExpObject - unsafeRegExp denied', t => {
+  t.ok(unsafeRegExp !== tamedRegExp, 'constructor not replaced');
   const regexp = /./;
-  t.ok(regexp.constructor === RegExp, 'tamed constructor not reached');
+  t.ok(regexp.constructor === sharedRegExp, 'tamed constructor not reached');
   // Don't leak the unsafe constructor
   // https://github.com/Agoric/SES-shim/issues/237
   t.ok(regexp.constructor !== unsafeRegExp, 'unsafe constructor reachable!');
 
-  restore();
   t.end();
 });
 
 test('tameGlobalRegExpObject - undeniable prototype', t => {
-  const restore = captureGlobals('RegExp');
-  tameGlobalRegExpObject();
-
   // Don't try to deny the undeniable
   // https://github.com/Agoric/SES-shim/issues/237
-  const regexp1 = new RegExp('.');
-  const regexp2 = RegExp('.');
+  // eslint-disable-next-line new-cap
+  const regexp1 = new tamedRegExp('.');
+  const regexp2 = tamedRegExp('.');
   const regexp3 = /./;
   t.ok(
     // eslint-disable-next-line no-proto
@@ -41,30 +43,26 @@ test('tameGlobalRegExpObject - undeniable prototype', t => {
   );
 
   t.ok(
-    regexp1 instanceof RegExp,
+    regexp1 instanceof tamedRegExp,
     'new instance not instanceof tamed constructor',
   );
   t.ok(
-    regexp2 instanceof RegExp,
+    regexp2 instanceof tamedRegExp,
     'non-new instance not instanceof tamed constructor',
   );
   t.ok(
-    regexp3 instanceof RegExp,
+    regexp3 instanceof tamedRegExp,
     'literal instance not instanceof tamed constructor',
   );
 
-  restore();
   t.end();
 });
 
 test('tameGlobalRegExpObject - constructor', t => {
-  const restore = captureGlobals('RegExp');
-  tameGlobalRegExpObject();
-
-  t.equal(RegExp.name, 'RegExp');
-  t.equal(RegExp.prototype.constructor, RegExp);
+  t.equal(tamedRegExp.name, 'RegExp');
+  t.equal(tamedRegExp.prototype.constructor, sharedRegExp);
   t.equal(
-    Object.getOwnPropertyDescriptor(RegExp.prototype, 'compile'),
+    Object.getOwnPropertyDescriptor(tamedRegExp.prototype, 'compile'),
     undefined,
   );
 
@@ -74,7 +72,7 @@ test('tameGlobalRegExpObject - constructor', t => {
     'prototype',
     Symbol.species,
   ]);
-  const properties = Reflect.ownKeys(RegExp);
+  const properties = Reflect.ownKeys(tamedRegExp);
   for (const prop of properties) {
     t.assert(
       allowedProperties.has(prop),
@@ -82,16 +80,16 @@ test('tameGlobalRegExpObject - constructor', t => {
     );
   }
 
-  const regexp = new RegExp();
-  t.ok(regexp instanceof RegExp);
+  // eslint-disable-next-line new-cap
+  const regexp = new tamedRegExp();
+  t.ok(regexp instanceof tamedRegExp);
   // eslint-disable-next-line no-proto
-  t.equal(regexp.__proto__.constructor, RegExp);
+  t.equal(regexp.__proto__.constructor, sharedRegExp);
 
-  // bare RegExp() (without 'new') was failing
+  // bare tamedRegExp() (without 'new') was failing
   // https://github.com/Agoric/SES-shim/issues/230
-  t.equal(RegExp('foo').test('bar'), false);
-  t.equal(RegExp('foo').test('foobar'), true);
+  t.equal(tamedRegExp('foo').test('bar'), false);
+  t.equal(tamedRegExp('foo').test('foobar'), true);
 
-  restore();
   t.end();
 });

--- a/packages/ses/test/whitelist-intrinsics.test.js
+++ b/packages/ses/test/whitelist-intrinsics.test.js
@@ -3,6 +3,8 @@ import tameGlobalErrorObject from '../src/tame-global-error-object.js';
 import { getIntrinsics } from '../src/intrinsics.js';
 import whitelistIntrinsics from '../src/whitelist-intrinsics.js';
 
+const { defineProperties } = Object;
+
 const { test } = tap;
 
 // eslint-disable-next-line no-eval
@@ -16,7 +18,7 @@ test('whitelistPrototypes - on', t => {
 
   // This changes the non-standard v8-only Error.prototype.stackTraceLimit
   // to an accessor which matches our whitelist. Otherwise this test fails.
-  tameGlobalErrorObject();
+  defineProperties(globalThis, tameGlobalErrorObject().start);
 
   globalThis.foo = 1;
   Object.foo = 1;

--- a/packages/ses/test262/tame-global-date-object.js
+++ b/packages/ses/test262/tame-global-date-object.js
@@ -2,28 +2,11 @@
 import test262Runner from '@agoric/test262-runner';
 import tameGlobalDateObject from '../src/tame-global-date-object.js';
 
+const { defineProperties } = Object;
+
 test262Runner({
   testDirs: ['/test/built-ins/Date'],
-  excludePaths: [
-    'test/built-ins/Date/prototype/setHours/arg-min-to-number-err.js',
-    'test/built-ins/Date/prototype/setHours/arg-ms-to-number-err.js',
-    'test/built-ins/Date/prototype/setHours/arg-sec-to-number-err.js',
-    'test/built-ins/Date/prototype/setMinutes/arg-ms-to-number-err.js',
-    'test/built-ins/Date/prototype/setMinutes/arg-sec-to-number-err.js',
-    'test/built-ins/Date/prototype/setMonth/arg-date-to-number-err.js',
-    'test/built-ins/Date/prototype/setSeconds/arg-ms-to-number-err.js',
-    'test/built-ins/Date/prototype/setTime/new-value-time-clip.js',
-    'test/built-ins/Date/prototype/toDateString/format.js',
-    'test/built-ins/Date/prototype/toISOString/15.9.5.43-0-10.js',
-    'test/built-ins/Date/prototype/toISOString/15.9.5.43-0-11.js',
-    'test/built-ins/Date/prototype/toISOString/15.9.5.43-0-12.js',
-    'test/built-ins/Date/prototype/toISOString/15.9.5.43-0-5.js',
-    'test/built-ins/Date/prototype/toISOString/15.9.5.43-0-9.js',
-    'test/built-ins/Date/prototype/toJSON/invoke-result.js',
-    'test/built-ins/Date/prototype/toString/format.js',
-    'test/built-ins/Date/prototype/toTimeString/format.js',
-    'test/built-ins/Date/prototype/toUTCString/format.js',
-  ],
+  excludePaths: [],
   excludeDescriptions: [],
   excludeFeatures: [
     'cross-realm', // TODO: Evaluator does not create realms.
@@ -35,7 +18,7 @@ test262Runner({
   sourceTextCorrections: [],
   captureGlobalObjectNames: ['Date'],
   async test(testInfo, harness) {
-    tameGlobalDateObject();
+    defineProperties(globalThis, tameGlobalDateObject('unsafe').start);
     // eslint-disable-next-line no-eval
     (0, eval)(`${harness}\n${testInfo.contents}`);
   },

--- a/packages/ses/test262/tame-global-error-object.js
+++ b/packages/ses/test262/tame-global-error-object.js
@@ -2,6 +2,8 @@
 import test262Runner from '@agoric/test262-runner';
 import tameGlobalErrorObject from '../src/tame-global-error-object.js';
 
+const { defineProperties } = Object;
+
 test262Runner({
   testDirs: ['/test/built-ins/Error'],
   excludePaths: [],
@@ -16,7 +18,7 @@ test262Runner({
   sourceTextCorrections: [],
   captureGlobalObjectNames: ['Error'],
   async test(testInfo, harness) {
-    tameGlobalErrorObject();
+    defineProperties(globalThis, tameGlobalErrorObject().start);
     // eslint-disable-next-line no-eval
     (0, eval)(`${harness}\n${testInfo.contents}`);
   },

--- a/packages/ses/test262/tame-global-math-object.js
+++ b/packages/ses/test262/tame-global-math-object.js
@@ -2,6 +2,8 @@
 import test262Runner from '@agoric/test262-runner';
 import tameGlobalMathObject from '../src/tame-global-math-object.js';
 
+const { defineProperties } = Object;
+
 test262Runner({
   testDirs: ['/test/built-ins/Math'],
   excludePaths: ['test/built-ins/Math/random/S15.8.2.14_A1.js'],
@@ -16,7 +18,7 @@ test262Runner({
   sourceTextCorrections: [],
   captureGlobalObjectNames: ['Math'],
   async test(testInfo, harness) {
-    tameGlobalMathObject();
+    defineProperties(globalThis, tameGlobalMathObject().start);
     // eslint-disable-next-line no-eval
     (0, eval)(`${harness}\n${testInfo.contents}`);
   },

--- a/packages/ses/test262/tame-global-regexp-object.js
+++ b/packages/ses/test262/tame-global-regexp-object.js
@@ -2,6 +2,8 @@
 import test262Runner from '@agoric/test262-runner';
 import tameGlobalRegExpObject from '../src/tame-global-reg-exp-object.js';
 
+const { defineProperties } = Object;
+
 test262Runner({
   testDirs: ['/test/built-ins/RegExp'],
   excludePaths: [
@@ -31,7 +33,7 @@ test262Runner({
   sourceTextCorrections: [],
   captureGlobalObjectNames: ['RegExp'],
   async test(testInfo, harness) {
-    tameGlobalRegExpObject();
+    defineProperties(globalThis, tameGlobalRegExpObject().start);
     // eslint-disable-next-line no-eval
     (0, eval)(`${harness}\n${testInfo.contents}`);
   },


### PR DESCRIPTION
Minimal subset of intrinsic reform, preparing to improve the error taming in a subsequent PR.

Each of the `tameGlobalFooObject` repair functions no longer modifies `globalThis` itself. Rather, it returns a record of the binding[s] to be added to the start compartment global, and the binding[s] to be added to the shared globals for all other compartments by default. It is up to the caller to figure out what to so with the contents of this record. This also makes unit tests more straightforward.

While fixing the repairs, there was ad-hoc partial suppression of some of the locale methods. Instead, we simply suppress all of these in the whitelist.