### PR TITLE
ses(fix): Repair defineProperty internally

### DIFF
--- a/packages/ses/src/check-anon-intrinsics.js
+++ b/packages/ses/src/check-anon-intrinsics.js
@@ -1,6 +1,5 @@
 import { assert } from './assert.js';
-
-const { getPrototypeOf } = Object;
+import { getPrototypeOf } from './commons.js';
 
 /**
  * checkAnonIntrinsics()

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -11,14 +11,19 @@
 
 export const {
   assign,
+  create,
   defineProperties,
+  entries,
+  freeze,
   freeze: objectFreeze,
   getOwnPropertyDescriptor,
   getOwnPropertyDescriptors,
   getOwnPropertyNames,
   getPrototypeOf,
-  setPrototypeOf,
+  keys,
   prototype: objectPrototype,
+  setPrototypeOf,
+  values,
 } = Object;
 
 export const defineProperty = (object, prop, descriptor) => {

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -11,16 +11,21 @@
 
 export const {
   assign,
-  freeze: objectFreeze,
-  // Object.defineProperty is allowed to fail silentlty
-  // so we use Object.defineProperties instead.
   defineProperties,
+  freeze: objectFreeze,
   getOwnPropertyDescriptor,
+  getOwnPropertyDescriptors,
   getOwnPropertyNames,
   getPrototypeOf,
   setPrototypeOf,
   prototype: objectPrototype,
 } = Object;
+
+export const defineProperty = (object, prop, descriptor) => {
+  // Object.defineProperty is allowed to fail silently so we use
+  // Object.defineProperties instead.
+  return defineProperties(object, { [prop]: descriptor });
+};
 
 export const { apply, get: reflectGet, set: reflectSet } = Reflect;
 

--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -15,7 +15,6 @@ export const {
   defineProperties,
   entries,
   freeze,
-  freeze: objectFreeze,
   getOwnPropertyDescriptor,
   getOwnPropertyDescriptors,
   getOwnPropertyNames,
@@ -88,4 +87,4 @@ export const getConstructorOf = fn =>
  * immutableObject
  * An immutable (frozen) exotic object and is safe to share.
  */
-export const immutableObject = objectFreeze({ __proto__: null });
+export const immutableObject = freeze({ __proto__: null });

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -13,7 +13,7 @@ import * as babel from '@agoric/babel-standalone';
 // Both produce:
 //   Error: 'default' is not exported by .../@agoric/babel-standalone/babel.js
 import { makeModuleAnalyzer } from '@agoric/transform-module';
-import { assign } from './commons.js';
+import { assign, entries } from './commons.js';
 import { createGlobalObject } from './global-object.js';
 import { performEval } from './evaluate.js';
 import { getCurrentRealmRec } from './realm-rec.js';
@@ -23,7 +23,6 @@ import { getDeferredExports } from './module-proxy.js';
 
 // q, for quoting strings.
 const q = JSON.stringify;
-const { entries } = Object;
 
 const analyzeModule = makeModuleAnalyzer(babel.default);
 

--- a/packages/ses/src/enable-property-overrides.js
+++ b/packages/ses/src/enable-property-overrides.js
@@ -1,15 +1,16 @@
 // Adapted from SES/Caja
 // Copyright (C) 2011 Google Inc.
-// https://github.com/google/caja/blob/master/src/com/google/caja/ses/startSES.js
-// https://github.com/google/caja/blob/master/src/com/google/caja/ses/repairES5.js
-import enablements from './enablements.js';
 
-const {
-  defineProperties,
+import {
+  defineProperty,
   getOwnPropertyNames,
   getOwnPropertyDescriptor,
   getOwnPropertyDescriptors,
-} = Object;
+} from './commons.js';
+
+// https://github.com/google/caja/blob/master/src/com/google/caja/ses/startSES.js
+// https://github.com/google/caja/blob/master/src/com/google/caja/ses/repairES5.js
+import enablements from './enablements.js';
 
 const { ownKeys } = Reflect;
 
@@ -57,24 +58,20 @@ export default function enablePropertyOverrides(intrinsics) {
         if (hasOwnProperty.call(this, prop)) {
           this[prop] = newValue;
         } else {
-          defineProperties(this, {
-            [prop]: {
-              value: newValue,
-              writable: true,
-              enumerable: desc.enumerable,
-              configurable: desc.configurable,
-            },
+          defineProperty(this, prop, {
+            value: newValue,
+            writable: true,
+            enumerable: desc.enumerable,
+            configurable: desc.configurable,
           });
         }
       }
 
-      defineProperties(obj, {
-        [prop]: {
-          get: getter,
-          set: setter,
-          enumerable: desc.enumerable,
-          configurable: desc.configurable,
-        },
+      defineProperty(obj, prop, {
+        get: getter,
+        set: setter,
+        enumerable: desc.enumerable,
+        configurable: desc.configurable,
       });
     }
   }

--- a/packages/ses/src/get-anonymous-intrinsics.js
+++ b/packages/ses/src/get-anonymous-intrinsics.js
@@ -1,4 +1,4 @@
-const { getOwnPropertyDescriptor, getPrototypeOf } = Object;
+import { getOwnPropertyDescriptor, getPrototypeOf } from './commons.js';
 
 /**
  * Object.getConstructorOf()

--- a/packages/ses/src/get-named-intrinsic.js
+++ b/packages/ses/src/get-named-intrinsic.js
@@ -1,6 +1,5 @@
 import { assert } from './assert.js';
-
-const { getOwnPropertyDescriptor } = Object;
+import { getOwnPropertyDescriptor } from './commons.js';
 
 /**
  * getNamedIntrinsic()

--- a/packages/ses/src/intrinsics-global.js
+++ b/packages/ses/src/intrinsics-global.js
@@ -16,7 +16,7 @@
 // Assumptions
 //
 // The intrinsic names correspond to the object names with "%" added as prefix and suffix, i.e. the intrinsic "%Object%" is equal to the global object property "Object".
-const { getOwnPropertyDescriptor } = Object;
+import { getOwnPropertyDescriptor } from './commons.js';
 
 /**
  * globalIntrinsicNames

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -15,6 +15,7 @@
 import makeHardener from '@agoric/make-hardener';
 
 import { assert } from './assert.js';
+import { defineProperties } from './commons.js';
 import { getIntrinsics } from './intrinsics.js';
 import whitelistIntrinsics from './whitelist-intrinsics.js';
 import repairLegacyAccessors from './repair-legacy-accessors.js';
@@ -25,8 +26,6 @@ import tameGlobalErrorObject from './tame-global-error-object.js';
 import tameGlobalMathObject from './tame-global-math-object.js';
 import tameGlobalRegExpObject from './tame-global-reg-exp-object.js';
 import enablePropertyOverrides from './enable-property-overrides.js';
-
-const { defineProperties } = Object;
 
 let firstOptions;
 

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -1,8 +1,7 @@
 import { performEval } from './evaluate.js';
 import { getCurrentRealmRec } from './realm-rec.js';
 import { getDeferredExports } from './module-proxy.js';
-
-const { create, entries, keys, freeze, defineProperty: defProp } = Object;
+import { create, entries, keys, freeze, defineProperty } from './commons.js';
 
 // q, for enquoting strings in error messages.
 const q = JSON.stringify;
@@ -199,7 +198,7 @@ export const makeModuleInstance = (
 
         localGetNotify[localName] = liveGetNotify;
         if (setProxyTrap) {
-          defProp(trappers, localName, {
+          defineProperty(trappers, localName, {
             get,
             set,
             enumerable: true,
@@ -295,7 +294,7 @@ export const makeModuleInstance = (
     // properties works for this specific case.
     keys(exportsProps)
       .sort()
-      .forEach(k => defProp(proxiedExports, k, exportsProps[k]));
+      .forEach(k => defineProperty(proxiedExports, k, exportsProps[k]));
 
     freeze(proxiedExports);
     activate();

--- a/packages/ses/src/module-link.js
+++ b/packages/ses/src/module-link.js
@@ -7,8 +7,8 @@
 // the particular compartment's "resolveHook".
 
 import { makeModuleInstance } from './module-instance.js';
+import { entries } from './commons.js';
 
-const { entries } = Object;
 // q, as in quote, for quoting strings in error messages.
 const q = JSON.stringify;
 

--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -6,7 +6,7 @@
 // module's "imports" with the more specific "resolvedImports" as inferred from
 // the particular compartment's "resolveHook".
 
-const { create, keys, values, freeze } = Object;
+import { create, keys, values, freeze } from './commons.js';
 
 // `makeAlias` constructs compartment specifier tuples for the `aliases`
 // private field of compartments.

--- a/packages/ses/src/module-proxy.js
+++ b/packages/ses/src/module-proxy.js
@@ -11,8 +11,8 @@
 // and eventually connecting it to to the proxied exports.
 
 import { makeAlias } from './module-load.js';
+import { create, freeze } from './commons.js';
 
-const { create, freeze } = Object;
 // q, as in quote, for error messages.
 const q = JSON.stringify;
 

--- a/packages/ses/src/realm-rec.js
+++ b/packages/ses/src/realm-rec.js
@@ -1,5 +1,5 @@
 import { getGlobalIntrinsics } from './intrinsics-global.js';
-import { objectFreeze } from './commons.js';
+import { freeze } from './commons.js';
 
 // Note: Instead of using a  safe*/unsafe* naming convention as a label to
 // indentify sources of power, we simply use realmRec as the powerful object,
@@ -28,5 +28,5 @@ export function getCurrentRealmRec() {
   };
 
   // However, we freeze the realm record for safety.
-  return objectFreeze(realmRec);
+  return freeze(realmRec);
 }

--- a/packages/ses/src/repair-legacy-accessors.js
+++ b/packages/ses/src/repair-legacy-accessors.js
@@ -1,6 +1,13 @@
 // Adapted from SES/Caja - Copyright (C) 2011 Google Inc.
 // https://github.com/google/caja/blob/master/src/com/google/caja/ses/startSES.js
 // https://github.com/google/caja/blob/master/src/com/google/caja/ses/repairES5.js
+import {
+  defineProperty,
+  defineProperties,
+  getOwnPropertyDescriptor,
+  getPrototypeOf,
+  objectPrototype,
+} from './commons.js';
 
 /**
  * Replace the legacy accessors of Object to comply with strict mode
@@ -24,14 +31,6 @@ export default function repairLegacyAccessors() {
     // Throws, no need to patch.
     return;
   }
-
-  const {
-    defineProperty,
-    defineProperties,
-    getOwnPropertyDescriptor,
-    getPrototypeOf,
-    prototype: objectPrototype,
-  } = Object;
 
   // On some platforms, the implementation of these functions act as
   // if they are in sloppy mode: if they're invoked badly, they will

--- a/packages/ses/src/tame-function-constructors.js
+++ b/packages/ses/src/tame-function-constructors.js
@@ -1,4 +1,4 @@
-const { defineProperties, getPrototypeOf, setPrototypeOf } = Object;
+import { defineProperties, getPrototypeOf, setPrototypeOf } from './commons.js';
 
 // This module replaces the original `Function` constructor, and the original
 // `%GeneratorFunction%`, `%AsyncFunction%` and `%AsyncGeneratorFunction%`,

--- a/packages/ses/src/tame-global-date-object.js
+++ b/packages/ses/src/tame-global-date-object.js
@@ -1,4 +1,4 @@
-const { defineProperties } = Object;
+import { defineProperties } from './commons.js';
 
 export default function tameGlobalDateObject(dateTaming = 'safe') {
   if (dateTaming !== 'safe' && dateTaming !== 'unsafe') {

--- a/packages/ses/src/tame-global-error-object.js
+++ b/packages/ses/src/tame-global-error-object.js
@@ -1,4 +1,4 @@
-const { defineProperties, setPrototypeOf } = Object;
+import { defineProperties, setPrototypeOf } from './commons.js';
 
 // TODO where should this go?
 export const NativeErrors = [

--- a/packages/ses/src/tame-global-math-object.js
+++ b/packages/ses/src/tame-global-math-object.js
@@ -1,4 +1,4 @@
-const { create, getOwnPropertyDescriptors } = Object;
+import { create, getOwnPropertyDescriptors } from './commons.js';
 
 export default function tameGlobalMathObject(mathTaming = 'safe') {
   if (mathTaming !== 'safe' && mathTaming !== 'unsafe') {

--- a/packages/ses/src/tame-global-reg-exp-object.js
+++ b/packages/ses/src/tame-global-reg-exp-object.js
@@ -1,4 +1,4 @@
-const { defineProperties, getOwnPropertyDescriptor } = Object;
+import { defineProperties, getOwnPropertyDescriptor } from './commons.js';
 
 export default function tameGlobalRegExpObject(regExpTaming = 'safe') {
   if (regExpTaming !== 'safe' && regExpTaming !== 'unsafe') {

--- a/packages/ses/src/whitelist-intrinsics.js
+++ b/packages/ses/src/whitelist-intrinsics.js
@@ -51,8 +51,7 @@
 // 5. In debug mode, all removed properties are listed to the console.
 
 import whitelist, { FunctionInstance } from './whitelist.js';
-
-const { getPrototypeOf, getOwnPropertyDescriptor } = Object;
+import { getPrototypeOf, getOwnPropertyDescriptor } from './commons.js';
 
 const { apply, ownKeys } = Reflect;
 const uncurryThis = fn => (thisArg, ...args) => apply(fn, thisArg, args);


### PR DESCRIPTION
The first commit downsizes the use of defineProperties to defineProperty in enablements because this is more clearly appropriate.

The second commit ensures that all modules use commons.js as the source of Object functions, ensuring that we always use the patched defineProperty as a matter of style and for other possible knock-on benefits.