### PR TITLE
expose more callSite properties, put them on the prototype

### DIFF
--- a/packages/ses/src/tame-global-error-object.js
+++ b/packages/ses/src/tame-global-error-object.js
@@ -43,7 +43,8 @@ const safeV8CallSiteMethodNames = [
 // Before that matters, we should switch to a reasonable representation.
 const safeV8CallSiteFacet = callSite => {
   const methodEntry = name => [name, () => callSite[name]()];
-  return Object.fromEntries(safeV8CallSiteMethodNames.map(methodEntry));
+  const o = Object.fromEntries(safeV8CallSiteMethodNames.map(methodEntry));
+  return Object.create(o, {});
 };
 
 const safeV8SST = sst => sst.map(safeV8CallSiteFacet);

--- a/packages/ses/src/tame-global-error-object.js
+++ b/packages/ses/src/tame-global-error-object.js
@@ -23,9 +23,9 @@ const safeV8CallSiteMethodNames = [
   'getLineNumber',
   'getColumnNumber',
   'getEvalOrigin',
-  // suppress 'isTopLevel' for now
+  'isToplevel',
   'isEval',
-  // suppress 'isNative' for now
+  'isNative',
   'isConstructor',
   'isAsync',
   // suppress 'isPromiseAll' for now
@@ -33,9 +33,9 @@ const safeV8CallSiteMethodNames = [
 
   // Additional names found by experiment, absent from
   // https://v8.dev/docs/stack-trace-api
+  'getPosition',
+  'getScriptNameOrSourceURL',
 
-  // suppress 'getPosition' for now
-  // suppress 'getScriptNameOrSourceURL' for now
   'toString', // TODO replace to use only whitelisted info
 ];
 

--- a/packages/ses/test/callsite-properties.test.js
+++ b/packages/ses/test/callsite-properties.test.js
@@ -37,29 +37,5 @@ test('callSite properties', t => {
   t.equal(typeof top.getPosition(), 'number');
   t.equal(typeof top.getScriptNameOrSourceURL(), 'string');
 
-  // v8 puts these properties on the callSite's prototype, not the callSite
-  // itself. Some libraries (like source-map-support) rely upon this
-  // placement.
-  t.deepEqual(Object.getOwnPropertyNames(top), []);
-  const topP = Object.getPrototypeOf(top);
-  const names = Object.getOwnPropertyNames(topP).sort();
-  t.deepEqual(names, [
-    'getColumnNumber',
-    'getEvalOrigin',
-    'getFileName',
-    'getFunctionName',
-    'getLineNumber',
-    'getMethodName',
-    'getPosition',
-    'getScriptNameOrSourceURL',
-    'getTypeName',
-    'isAsync',
-    'isConstructor',
-    'isEval',
-    'isNative',
-    'isToplevel',
-    'toString',
-  ]);
-
   t.end();
 });

--- a/packages/ses/test/callsite-properties.test.js
+++ b/packages/ses/test/callsite-properties.test.js
@@ -1,0 +1,65 @@
+/* global lockdown */
+import test from 'tape';
+import '../src/main.js';
+
+lockdown({ errorTaming: 'unsafe' });
+
+test('callSite properties', t => {
+  let sst;
+  const orig = Error.prepareStackTrace;
+  try {
+    const pst = (_err, sst0) => sst0;
+    Error.prepareStackTrace = pst;
+    const e = Error();
+    sst = e.stack;
+  } finally {
+    Error.prepareStackTrace = orig;
+  }
+  // TODO: if we're not under v8, 'sst' will be undefined or an empty
+  // string, and we shouldn't look for these properties. This test checks
+  // what happens if we *are* under v8.
+  const top = sst[0];
+
+  // We currently expect unsafe-tamed Error to allow prepareStackTrace to
+  // see the following properties, most of which violate confidentiality of
+  // the code that threw the exception and everybody on the stack below
+  // them. But we hide the properties that would violate integrity, like
+  // `getThis` and `getFunction`.
+  t.equal(top.getTypeName(), null);
+  t.equal(top.getFunctionName(), 'Error');
+  t.equal(top.getMethodName(), null);
+  t.equal(typeof top.getFileName(), 'string');
+  t.equal(typeof top.getLineNumber(), 'number');
+  t.equal(typeof top.getColumnNumber(), 'number');
+  t.equal(top.getEvalOrigin(), undefined);
+  t.equal(top.isToplevel(), true);
+  t.equal(top.isNative(), false);
+  t.equal(typeof top.getPosition(), 'number');
+  t.equal(typeof top.getScriptNameOrSourceURL(), 'string');
+
+  // v8 puts these properties on the callSite's prototype, not the callSite
+  // itself. Some libraries (like source-map-support) rely upon this
+  // placement.
+  t.deepEqual(Object.getOwnPropertyNames(top), []);
+  const topP = Object.getPrototypeOf(top);
+  const names = Object.getOwnPropertyNames(topP).sort();
+  t.deepEqual(names, [
+    'getColumnNumber',
+    'getEvalOrigin',
+    'getFileName',
+    'getFunctionName',
+    'getLineNumber',
+    'getMethodName',
+    'getPosition',
+    'getScriptNameOrSourceURL',
+    'getTypeName',
+    'isAsync',
+    'isConstructor',
+    'isEval',
+    'isNative',
+    'isToplevel',
+    'toString',
+  ]);
+
+  t.end();
+});

--- a/packages/ses/test/install-ses-safe.js
+++ b/packages/ses/test/install-ses-safe.js
@@ -1,0 +1,4 @@
+/* global lockdown */
+import '../src/main.js';
+
+lockdown();

--- a/packages/ses/test/install-ses-unsafe.js
+++ b/packages/ses/test/install-ses-unsafe.js
@@ -1,0 +1,8 @@
+/* global lockdown */
+import '../src/main.js';
+
+lockdown({
+  dateTaming: 'unsafe',
+  mathTaming: 'unsafe',
+  errorTaming: 'unsafe',
+});

--- a/packages/ses/test/tap-after-safe-lockdown.test.js
+++ b/packages/ses/test/tap-after-safe-lockdown.test.js
@@ -1,0 +1,28 @@
+import './install-ses-safe.js';
+import tap from 'tap';
+
+// Confirm that tap can be imported after a safe-Error lockdown, and exercise
+// enough of tap to make sure the success cases still work. Unfortunately we
+// can't exercise the failure cases (e.g. `t.equal(1, 2)`) without causing
+// the SES test suite to fail, and it is the failure cases that are the most
+// interesting. Many of the problems listed in bug #367 are triggered when a
+// tap assertion fails, and tap attempts to display the stack trace of the
+// failing assertion call. We can, however, at least provoke Error and
+// err.stack, which provides *some* coverage.
+
+function boom() {
+  throw Error('kaboom');
+}
+
+tap.test('tap-after-unsafe-lockdown basic test works', t => {
+  t.equal(1, 1);
+  // boom();
+  t.throws(() => boom(), /kaboom/);
+  try {
+    boom();
+  } catch (e) {
+    // eslint-disable-next-line no-unused-vars
+    const frames = e.stack;
+  }
+  t.end();
+});

--- a/packages/ses/test/tap-after-unsafe-lockdown.test.js
+++ b/packages/ses/test/tap-after-unsafe-lockdown.test.js
@@ -1,0 +1,28 @@
+import './install-ses-unsafe.js';
+import tap from 'tap';
+
+// Confirm that tap can be imported after an unsafe-Error lockdown, and
+// exercise enough of tap to make sure the success cases still work.
+// Unfortunately we can't exercise the failure cases (e.g. `t.equal(1, 2)`)
+// without causing the SES test suite to fail, and it is the failure cases
+// that are the most interesting. Many of the problems listed in bug #367 are
+// triggered when a tap assertion fails, and tap attempts to display the
+// stack trace of the failing assertion call. We can, however, at least
+// provoke Error and err.stack, which provides *some* coverage.
+
+function boom() {
+  throw Error('kaboom');
+}
+
+tap.test('tap-after-unsafe-lockdown basic test works', t => {
+  t.equal(1, 1);
+  // boom();
+  t.throws(() => boom(), /kaboom/);
+  try {
+    boom();
+  } catch (e) {
+    // eslint-disable-next-line no-unused-vars
+    const frames = e.stack;
+  }
+  t.end();
+});


### PR DESCRIPTION
As explored in #367, the `source-map-support` library (used by the same `tap` test framework we use here in SES-shim) relies upon some `callSite` behavior that we were not providing when in `errorTaming: 'unsafe'` mode.

This PR exposes more properties in the `callSite` objects that we give to the user's `Error.prepareStackTrace` replacement function. `isToplevel`, `isNative`, `getPosition`, and `getScriptNameOrSourceURL` are now revealed. I believe these only violate confidentiality (just like the previous `getFileName`, etc), and will not violate integrity.

It also puts all these properties on the callSite's prototype, not on the callSite object itself. `source-map-support` enumerates the prototype's properties to see what it should copy in the wrapper that *it* makes, and it wasn't able to see anything when they were directly on the callSite we provided.

refs #367 
