### PR TITLE
docs: add typings for SES's global harden()

### DIFF
--- a/packages/ses/index.d.ts
+++ b/packages/ses/index.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Transitively freeze an object.
+ */
+type Harden = <T>(x: T) => T;
+
+declare var harden: Harden;
+
+namespace global {
+  declare var harden: Harden;
+}

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -9,6 +9,7 @@
   "main": "./dist/ses.cjs",
   "module": "./src/main.js",
   "browser": "./dist/ses.umd.js",
+  "types": "./index.d.ts",
   "unpkg": "./dist/ses.umd.js",
   "exports": {
     "import": "./src/main.js",


### PR DESCRIPTION
Simple little hack to get `harden` well-typed in source files that contain:

```js
/// <reference types="ses"/>
```
