### PR TITLE
chore: update ses/NEWS with properties removed in 0.9.0

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -13,6 +13,11 @@ User-visible changes in SES:
   each evaluation will need a fresh `Compartment`.
 * BREAKING CHANGE: The `lockdown` function's deprecated `noTame*` options have
   been removed in favor of the `*Taming` options introduced in version 0.8.0.
+* BREAKING CHANGE: The `.toLocale*` methods of
+  Object/Number/BigInt/Date/String/Array/%TypedArray% were removed from SES
+  environments. This includes methods named `toLocaleString`,
+  `toLocaleDateString`, `toLocaleTimeString`, `toLocaleLowerCase`,
+  `toLocaleUpperCase`, and `localeCompare`.
 * The way `lockdown()` tames the `Error` constructor now cooperates
   with the V8 stack trace API to a degree that is permissible without
   breaking the integrity of applications that use it.

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -17,7 +17,8 @@ User-visible changes in SES:
   Object/Number/BigInt/Date/String/Array/%TypedArray% were removed from SES
   environments. This includes methods named `toLocaleString`,
   `toLocaleDateString`, `toLocaleTimeString`, `toLocaleLowerCase`,
-  `toLocaleUpperCase`, and `localeCompare`.
+  `toLocaleUpperCase`, and `localeCompare`. These may be restored (in a
+  modified form) in a future release.
 * The way `lockdown()` tames the `Error` constructor now cooperates
   with the V8 stack trace API to a degree that is permissible without
   breaking the integrity of applications that use it.


### PR DESCRIPTION
closes #379