### PR TITLE
fix: remove extra stackframe

### DIFF
--- a/packages/ses/src/commons.js
+++ b/packages/ses/src/commons.js
@@ -31,7 +31,7 @@ export const defineProperty = (object, prop, descriptor) => {
   return defineProperties(object, { [prop]: descriptor });
 };
 
-export const { apply, get: reflectGet, set: reflectSet } = Reflect;
+export const { apply, construct, get: reflectGet, set: reflectSet } = Reflect;
 
 export const { isArray, prototype: arrayPrototype } = Array;
 export const { symbolUnscopables } = Symbol;

--- a/packages/ses/test/v8-callsite-properties.test.js
+++ b/packages/ses/test/v8-callsite-properties.test.js
@@ -5,20 +5,23 @@ import '../src/main.js';
 lockdown({ errorTaming: 'unsafe' });
 
 test('callSite properties', t => {
-  let sst;
-  const orig = Error.prepareStackTrace;
-  try {
-    const pst = (_err, sst0) => sst0;
-    Error.prepareStackTrace = pst;
-    const e = Error();
-    sst = e.stack;
-  } finally {
-    Error.prepareStackTrace = orig;
+  function topFrame() {
+    let sst;
+    const orig = Error.prepareStackTrace;
+    try {
+      const pst = (_err, sst0) => sst0;
+      Error.prepareStackTrace = pst;
+      const e = Error();
+      sst = e.stack;
+    } finally {
+      Error.prepareStackTrace = orig;
+    }
+    // TODO: if we're not under v8, 'sst' will be undefined or an empty
+    // string, and we shouldn't look for these properties. This test checks
+    // what happens if we *are* under v8.
+    return sst[0];
   }
-  // TODO: if we're not under v8, 'sst' will be undefined or an empty
-  // string, and we shouldn't look for these properties. This test checks
-  // what happens if we *are* under v8.
-  const top = sst[0];
+  const top = topFrame();
 
   // We currently expect unsafe-tamed Error to allow prepareStackTrace to
   // see the following properties, most of which violate confidentiality of
@@ -26,7 +29,7 @@ test('callSite properties', t => {
   // them. But we hide the properties that would violate integrity, like
   // `getThis` and `getFunction`.
   t.equal(top.getTypeName(), null);
-  t.equal(top.getFunctionName(), 'Error');
+  t.equal(top.getFunctionName(), 'topFrame');
   t.equal(top.getMethodName(), null);
   t.equal(typeof top.getFileName(), 'string');
   t.equal(typeof top.getLineNumber(), 'number');


### PR DESCRIPTION
Fixes #370 

When we make an error by calling `new` on either of our replacement `Error` constructors, it calls the original `Error` constructor to make the error. Thus, the replacement `Error` constructor is on the stack above the creation of the new error object. This is exactly the problem that v8 designed `Error.captureStackTrace` to solve, and we solve it using their suggested pattern. The price of this pattern is that the stack trace is reified into a structured-stack-trace (sst) immediately rather than on demand. However, rendering the sst as a string is still on demand as intended.