### PR TITLE
fix: consolidate honorary native function printing

### DIFF
--- a/packages/ses/src/global-object.js
+++ b/packages/ses/src/global-object.js
@@ -16,7 +16,7 @@ export function initGlobalObject(
   globalObject,
   intrinsics,
   newGlobalPropertyNames,
-  { globalTransforms },
+  { globalTransforms, nativeBrander },
 ) {
   for (const [name, constant] of entries(constantProperties)) {
     defineProperty(globalObject, name, {
@@ -57,7 +57,7 @@ export function initGlobalObject(
     Function: makeFunctionConstructor(globalObject, {
       globalTransforms,
     }),
-    Compartment: makeCompartmentConstructor(intrinsics),
+    Compartment: makeCompartmentConstructor(intrinsics, nativeBrander),
   };
 
   // TODO These should still be tamed according to the whitelist before
@@ -69,5 +69,8 @@ export function initGlobalObject(
       enumerable: false,
       configurable: true,
     });
+    if (typeof value === 'function') {
+      nativeBrander(value);
+    }
   }
 }

--- a/packages/ses/src/make-eval-function.js
+++ b/packages/ses/src/make-eval-function.js
@@ -1,4 +1,3 @@
-import { defineProperties } from './commons.js';
 import { performEval } from './evaluate.js';
 
 /**
@@ -23,15 +22,6 @@ export const makeEvalFunction = (globalObject, options = {}) => {
       return performEval(source, globalObject, {}, options);
     },
   }.eval;
-
-  defineProperties(newEval, {
-    toString: {
-      value: () => `function eval() { [native code] }`,
-      writable: false,
-      enumerable: false,
-      configurable: true,
-    },
-  });
 
   return newEval;
 };

--- a/packages/ses/src/make-function-constructor.js
+++ b/packages/ses/src/make-function-constructor.js
@@ -51,16 +51,6 @@ export function makeFunctionConstructor(globaObject, options = {}) {
       enumerable: false,
       configurable: false,
     },
-
-    // Provide a custom output without overwriting
-    // Function.prototype.toString which is called by some third-party
-    // libraries.
-    toString: {
-      value: () => 'function Function() { [native code] }',
-      writable: false,
-      enumerable: false,
-      configurable: true,
-    },
   });
 
   // Assert identity of Function.__proto__ accross all compartments

--- a/packages/ses/src/tame-function-constructors.js
+++ b/packages/ses/src/tame-function-constructors.js
@@ -85,12 +85,6 @@ export default function tameFunctionConstructors() {
         enumerable: false,
         configurable: true,
       },
-      toString: {
-        value: () => `function ${name}() { [native code] }`,
-        writable: false,
-        enumerable: false,
-        configurable: true,
-      },
     });
 
     defineProperties(FunctionPrototype, {

--- a/packages/ses/src/tame-function-tostring.js
+++ b/packages/ses/src/tame-function-tostring.js
@@ -1,0 +1,25 @@
+import { defineProperty, apply } from './commons.js';
+
+const nativeSuffix = ') { [native code] }';
+
+export function tameFunctionToString() {
+  const nativeBrand = new WeakSet();
+
+  const originalFunctionToString = Function.prototype.toString;
+
+  const tamingMethods = {
+    toString() {
+      const str = apply(originalFunctionToString, this, []);
+      if (str.endsWith(nativeSuffix) || !nativeBrand.has(this)) {
+        return str;
+      }
+      return `function ${this.name}() { [native code] }`;
+    },
+  };
+
+  defineProperty(Function.prototype, 'toString', {
+    value: tamingMethods.toString,
+  });
+
+  return func => nativeBrand.add(func);
+}

--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -227,15 +227,7 @@ export const FunctionInstance = {
 const AsyncFunctionInstance = {
   // This property is not mentioned in ECMA 262, but is present in V8 and
   // necessary for lockdown to succeed.
-  // TODO Have `subPermit` check both direct and indirect inheritance
-  // from %FunctionPrototype%, so `subPermit` will also honor instance
-  // properties object that inherit from `%AsyncFunctionPrototype%`
-
   '[[Proto]]': '%AsyncFunctionPrototype%',
-  // 25.7.4.1 length
-  length: 'number',
-  // 25.7.4.2 name
-  name: 'string',
 };
 
 // Aliases
@@ -270,14 +262,6 @@ function NativeError(prototype) {
 
     // 19.5.6.2.1 NativeError.prototype
     prototype,
-
-    // TODO Have `subPermit` check both direct and indirect inheritance
-    // from %FunctionPrototype%, and then omit all these redundant
-    // occurrences of `length` and `name`
-    // 19.2.4.1 length
-    length: 'number',
-    // 19.2.4.2 name
-    name: 'string',
   };
 }
 
@@ -301,15 +285,6 @@ function TypedArray(prototype) {
   return {
     // 22.2.5 Properties of the TypedArray Constructors
     '[[Proto]]': '%TypedArray%',
-
-    // TODO Have `subPermit` check both direct and indirect inheritance
-    // from %FunctionPrototype%, and then omit all these redundant
-    // occurrences of `length` and `name`
-    // Add function instance properties
-    // 19.2.4.1 length
-    length: 'number',
-    // 19.2.4.2 name
-    name: 'string',
 
     // 22.2.5.1 TypedArray.BYTES_PER_ELEMENT
     BYTES_PER_ELEMENT: 'number',
@@ -547,22 +522,16 @@ export const whitelist = {
   '%UniqueFunction%': {
     // 19.2.2 Properties of the Function Constructor
     '[[Proto]]': '%FunctionPrototype%',
-    // 19.2.2.1 Function.length
-    length: 'number',
     // 19.2.2.2 Function.prototype
     prototype: '%FunctionPrototype%',
   },
 
   '%InertFunction%': {
     '[[Proto]]': '%FunctionPrototype%',
-    length: 'number',
     prototype: '%FunctionPrototype%',
   },
 
   '%FunctionPrototype%': {
-    // 19.2.3 Properties of the Function Prototype Object
-    length: 'number',
-    name: 'string',
     // 19.2.3.1 Function.prototype.apply
     apply: fn,
     // 19.2.3.2 Function.prototype.bind
@@ -1612,13 +1581,8 @@ export const whitelist = {
   '%InertGeneratorFunction%': {
     // 25.2.2 Properties of the GeneratorFunction Constructor
     '[[Proto]]': '%InertFunction%',
-    name: 'string',
-    // 25.2.2.1 GeneratorFunction.length
-    length: 'number',
     // 25.2.2.2 GeneratorFunction.prototype
     prototype: '%Generator%',
-    // Non-standard but seen on v8. Probably harmless, but useless.
-    toString: false,
   },
 
   '%Generator%': {
@@ -1635,13 +1599,8 @@ export const whitelist = {
   '%InertAsyncGeneratorFunction%': {
     // 25.3.2 Properties of the AsyncGeneratorFunction Constructor
     '[[Proto]]': '%InertFunction%',
-    name: 'string',
-    // 25.3.2.1 AsyncGeneratorFunction.length
-    length: 'number',
     // 25.3.2.2 AsyncGeneratorFunction.prototype
     prototype: '%AsyncGenerator%',
-    // Non-standard but seen on v8. Probably harmless, but useless.
-    toString: false,
   },
 
   '%AsyncGenerator%': {
@@ -1721,13 +1680,8 @@ export const whitelist = {
   '%InertAsyncFunction%': {
     // 25.7.2 Properties of the AsyncFunction Constructor
     '[[Proto]]': '%InertFunction%',
-    name: 'string',
-    // 25.7.2.1 AsyncFunction.length
-    length: 'number',
     // 25.7.2.2 AsyncFunction.prototype
     prototype: '%AsyncFunctionPrototype%',
-    // Non-standard but seen on v8. Probably harmless, but useless.
-    toString: false,
   },
 
   '%AsyncFunctionPrototype%': {

--- a/packages/ses/test/compartment-constructor.test.js
+++ b/packages/ses/test/compartment-constructor.test.js
@@ -1,21 +1,19 @@
+/* global lockdown Compartment */
 import tap from 'tap';
-import sinon from 'sinon';
-import { Compartment } from '../src/compartment-shim.js';
-import stubFunctionConstructors from './stub-function-constructors.js';
+import '../src/main.js';
 
 const { test } = tap;
 
+lockdown();
+
 test('Compartment class', t => {
   t.plan(8);
-
-  // Mimic repairFunctions.
-  stubFunctionConstructors(sinon);
 
   t.equals(typeof Compartment, 'function', 'typeof');
   t.ok(Compartment instanceof Function, 'instanceof');
   t.equals(Compartment.name, 'Compartment', 'Constructor "name" property');
 
-  t.equals(Compartment.toString(), 'function Compartment() { [shim code] }');
+  t.equals(Compartment.toString(), 'function Compartment() { [native code] }');
   t.equals(
     Compartment[Symbol.toStringTag],
     undefined,
@@ -24,7 +22,7 @@ test('Compartment class', t => {
 
   t.deepEqual(
     Reflect.ownKeys(Compartment).sort(),
-    ['length', 'name', 'prototype', 'toString'].sort(),
+    ['length', 'name', 'prototype'].sort(),
     'static properties',
   );
 
@@ -38,6 +36,4 @@ test('Compartment class', t => {
     TypeError,
     'Compartment must support the [[Construct]] method',
   );
-
-  sinon.restore();
 });

--- a/packages/ses/test/compartment-instance.test.js
+++ b/packages/ses/test/compartment-instance.test.js
@@ -18,7 +18,7 @@ test('Compartment instance', t => {
   t.notEquals(
     c.constructor,
     Compartment,
-    'function Compartment() { [shim code] }',
+    'function Compartment() { [native code] }',
   );
 
   t.equals(

--- a/packages/ses/test/global-object.test.js
+++ b/packages/ses/test/global-object.test.js
@@ -18,7 +18,9 @@ test('globalObject', t => {
   };
 
   const globalObject = {};
-  initGlobalObject(globalObject, intrinsics, sharedGlobalPropertyNames, {});
+  initGlobalObject(globalObject, intrinsics, sharedGlobalPropertyNames, {
+    nativeBrander(_) {},
+  });
 
   t.ok(globalObject instanceof Object);
   t.equal(Object.getPrototypeOf(globalObject), Object.prototype);

--- a/packages/ses/test/module-static-record.test.js
+++ b/packages/ses/test/module-static-record.test.js
@@ -1,7 +1,10 @@
+/* global lockdown StaticModuleRecord */
 import tap from 'tap';
-import { StaticModuleRecord } from '../src/compartment-shim.js';
+import '../src/main.js';
 
 const { test } = tap;
+
+lockdown();
 
 test('static module record constructor', t => {
   const msr = new StaticModuleRecord(`
@@ -28,7 +31,7 @@ test('static module record constructor', t => {
     'instance string representation should be fixed',
   );
   t.equal(
-    'function StaticModuleRecord() { [shim code] }',
+    'function StaticModuleRecord() { [native code] }',
     StaticModuleRecord.toString(),
     'constructor string representation should be fixed',
   );


### PR DESCRIPTION
Rather than add a bunch of add hoc `toString` methods to try to make shimmed methods appear native, instead tame `Function.prototype.toString` to do a brand check on whether a function is an honorary native function. Have the whitelisting machinery apply this brand to every surviving function encountered during whitelisting.
