### PR TITLE
feat(ses): Add support for third-party modules

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -5,6 +5,8 @@ User-visible changes in SES:
 * Adds the `load` method to `Compartment`.
   Load allows a bundler or archiver to use the `Compartment` API to gather the
   transitive dependencies of modules without executing them.
+* Adds support for third-party implementations of a `StaticModuleRecord`
+  interface (`{imports, execute}`).
 
 ## Release 0.9.1 (16-July-2020)
 

--- a/packages/ses/README.md
+++ b/packages/ses/README.md
@@ -176,6 +176,25 @@ const c2 = new Compartment({}, {
 });
 ```
 
+### Third-party modules
+
+To incorporate modules not implemented as ECMAScript modules, third-parties may
+implement a `StaticModuleRecord` interface.
+The record must have an `imports` array and an `execute` method.
+The compartment will call `execute` with:
+
+1. the proxied `exports` namespace object,
+2. a `resolvedImports` object that maps import names (from `imports`) to their
+   corresponding resolved specifiers (through the compartment's `resolveHook`),
+   and
+3. the `compartment`, such that `importNow` can obtain any of the module's
+   specified `imports`.
+
+:warning: A future breaking version may allow the `importNow` and the `execute`
+method of third-party static module records to return promises, to support
+top-level await.
+
+
 ## Bug Disclosure
 
 Please help us practice coordinated security bug disclosure, by using the

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -202,7 +202,13 @@ const CompartmentPrototype = {
 
     assertModuleHooks(this);
 
-    const moduleInstance = link(privateFields, moduleAliases, this, specifier);
+    const moduleInstance = link(
+      privateFields,
+      moduleAnalyses,
+      moduleAliases,
+      this,
+      specifier,
+    );
     moduleInstance.execute();
     return moduleInstance.exportsProxy;
   },

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -179,7 +179,7 @@ const CompartmentPrototype = {
 
     assertModuleHooks(this);
 
-    return load(privateFields, moduleAnalyses, this, specifier).then(() => {
+    return load(privateFields, this, specifier).then(() => {
       const namespace = this.importNow(specifier);
       return { namespace };
     });

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -21,19 +21,19 @@ const q = JSON.stringify;
 // that the execution of the module instance populates.
 export const makeModuleInstance = (
   privateFields,
+  moduleAnalysis,
   moduleAliases,
   moduleRecord,
   importedInstances,
   globalObject,
 ) => {
   const {
-    compartment,
-    moduleSpecifier,
     functorSource,
     fixedExportMap,
     liveExportMap,
     exportAlls,
-  } = moduleRecord;
+  } = moduleAnalysis;
+  const { compartment, moduleSpecifier } = moduleRecord;
 
   const compartmentFields = privateFields.get(compartment);
 

--- a/packages/ses/src/module-link.js
+++ b/packages/ses/src/module-link.js
@@ -63,6 +63,13 @@ export const instantiate = (
     return instances.get(moduleSpecifier);
   }
 
+  // // Guard against invalid importHook behavior.
+  // if (!moduleAnalyses.has(staticModuleRecord)) {
+  //   throw new TypeError(
+  //     `importHook must return a StaticModuleRecord constructed within the same Compartment and Realm`,
+  //   );
+  // }
+
   const moduleAnalysis = moduleAnalyses.get(staticModuleRecord);
 
   const importedInstances = new Map();

--- a/packages/ses/src/module-link.js
+++ b/packages/ses/src/module-link.js
@@ -20,6 +20,7 @@ const q = JSON.stringify;
 // the actual `ModuleNamespace`.
 export const link = (
   compartmentPrivateFields,
+  moduleAnalyses,
   moduleAliases,
   compartment,
   moduleSpecifier,
@@ -35,15 +36,26 @@ export const link = (
   // compartment is in context: the module record may be in another
   // compartment, denoted by moduleRecord.compartment.
   // eslint-disable-next-line no-use-before-define
-  return instantiate(compartmentPrivateFields, moduleAliases, moduleRecord);
+  return instantiate(
+    compartmentPrivateFields,
+    moduleAnalyses,
+    moduleAliases,
+    moduleRecord,
+  );
 };
 
 export const instantiate = (
   compartmentPrivateFields,
+  moduleAnalyses,
   moduleAliases,
   moduleRecord,
 ) => {
-  const { compartment, moduleSpecifier, resolvedImports } = moduleRecord;
+  const {
+    compartment,
+    moduleSpecifier,
+    resolvedImports,
+    staticModuleRecord,
+  } = moduleRecord;
   const { globalObject, instances } = compartmentPrivateFields.get(compartment);
 
   // Memoize.
@@ -51,9 +63,12 @@ export const instantiate = (
     return instances.get(moduleSpecifier);
   }
 
+  const moduleAnalysis = moduleAnalyses.get(staticModuleRecord);
+
   const importedInstances = new Map();
   const moduleInstance = makeModuleInstance(
     compartmentPrivateFields,
+    moduleAnalysis,
     moduleAliases,
     moduleRecord,
     importedInstances,
@@ -67,6 +82,7 @@ export const instantiate = (
   for (const [importSpecifier, resolvedSpecifier] of entries(resolvedImports)) {
     const importedInstance = link(
       compartmentPrivateFields,
+      moduleAnalyses,
       moduleAliases,
       compartment,
       resolvedSpecifier,

--- a/packages/ses/src/module-link.js
+++ b/packages/ses/src/module-link.js
@@ -55,15 +55,23 @@ const validateStaticModuleRecord = (staticModuleRecord, moduleAnalyses) => {
 
   const hasAnalysis = moduleAnalyses.has(staticModuleRecord);
   const hasImports = Array.isArray(staticModuleRecord.imports);
-  const isThirdParty =
-    hasImports && typeof staticModuleRecord.execute === 'function';
+  const hasExports = typeof staticModuleRecord.execute === 'function';
 
-  if (!hasAnalysis && !isThirdParty) {
+  if (!hasAnalysis && !hasExports) {
     if (hasImports) {
+      // In this case, the static module record has an `imports` property, but
+      // no `execute` method.
+      // This could either be a partially implemented custom static module
+      // record or created by `StaticModuleRecord` in another realm.
       throw new TypeError(
-        `importHook must return a StaticModuleRecord constructed within the same Compartment and Realm`,
+        `importHook must return a StaticModuleRecord constructed within the same Realm, or a custom record with both imports and an execute method`,
       );
     } else {
+      // In this case, the static module record has no `imports` or `execute`
+      // property, so it could not have been created by the
+      // `StaticModuleRecord` from any realm.
+      // From this we infer the intent was to produce a valid custom static
+      // module record and clue accordingly.
       throw new TypeError(
         `importHook must return a StaticModuleRecord with both imports and an execute method`,
       );

--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -38,7 +38,6 @@ const resolveAll = (imports, resolveHook, fullReferrerSpecifier) => {
 // This graph is then ready to be synchronously linked and executed.
 export const load = async (
   compartmentPrivateFields,
-  moduleAnalyses,
   compartment,
   moduleSpecifier,
 ) => {
@@ -54,7 +53,6 @@ export const load = async (
     const alias = aliases.get(moduleSpecifier);
     const moduleRecord = await load(
       compartmentPrivateFields,
-      moduleAnalyses,
       alias.compartment,
       alias.specifier,
     );
@@ -68,13 +66,6 @@ export const load = async (
   }
 
   const staticModuleRecord = await importHook(moduleSpecifier);
-
-  // Guard against invalid importHook behavior.
-  if (!moduleAnalyses.has(staticModuleRecord)) {
-    throw new TypeError(
-      `importHook must return a StaticModuleRecord constructed within the same Compartment and Realm`,
-    );
-  }
 
   // resolve all imports relative to this referrer module.
   const resolvedImports = resolveAll(
@@ -97,7 +88,6 @@ export const load = async (
     values(resolvedImports).map(fullSpecifier =>
       load(
         compartmentPrivateFields,
-        moduleAnalyses,
         compartment,
         fullSpecifier,
       ),

--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -86,11 +86,7 @@ export const load = async (
   // Await all dependencies to load, recursively.
   await Promise.all(
     values(resolvedImports).map(fullSpecifier =>
-      load(
-        compartmentPrivateFields,
-        compartment,
-        fullSpecifier,
-      ),
+      load(compartmentPrivateFields, compartment, fullSpecifier),
     ),
   );
 

--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -76,8 +76,6 @@ export const load = async (
     );
   }
 
-  const analysis = moduleAnalyses.get(staticModuleRecord);
-
   // resolve all imports relative to this referrer module.
   const resolvedImports = resolveAll(
     staticModuleRecord.imports,
@@ -85,8 +83,8 @@ export const load = async (
     moduleSpecifier,
   );
   const moduleRecord = freeze({
-    ...analysis,
     compartment,
+    staticModuleRecord,
     moduleSpecifier,
     resolvedImports,
   });

--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -6,7 +6,7 @@
 // module's "imports" with the more specific "resolvedImports" as inferred from
 // the particular compartment's "resolveHook".
 
-import { create, keys, values, freeze } from './commons.js';
+import { create, values, freeze } from './commons.js';
 
 // `makeAlias` constructs compartment specifier tuples for the `aliases`
 // private field of compartments.
@@ -24,7 +24,7 @@ export const makeAlias = (compartment, specifier) =>
 // in which a module was loaded.
 const resolveAll = (imports, resolveHook, fullReferrerSpecifier) => {
   const resolvedImports = create(null);
-  for (const importSpecifier of keys(imports)) {
+  for (const importSpecifier of imports) {
     const fullSpecifier = resolveHook(importSpecifier, fullReferrerSpecifier);
     resolvedImports[importSpecifier] = fullSpecifier;
   }
@@ -67,20 +67,20 @@ export const load = async (
     return moduleRecords.get(moduleSpecifier);
   }
 
-  const moduleStaticRecord = await importHook(moduleSpecifier);
+  const staticModuleRecord = await importHook(moduleSpecifier);
 
   // Guard against invalid importHook behavior.
-  if (!moduleAnalyses.has(moduleStaticRecord)) {
+  if (!moduleAnalyses.has(staticModuleRecord)) {
     throw new TypeError(
       `importHook must return a StaticModuleRecord constructed within the same Compartment and Realm`,
     );
   }
 
-  const analysis = moduleAnalyses.get(moduleStaticRecord);
+  const analysis = moduleAnalyses.get(staticModuleRecord);
 
   // resolve all imports relative to this referrer module.
   const resolvedImports = resolveAll(
-    analysis.imports,
+    staticModuleRecord.imports,
     resolveHook,
     moduleSpecifier,
   );

--- a/packages/ses/test/import-cjs.test.js
+++ b/packages/ses/test/import-cjs.test.js
@@ -1,0 +1,370 @@
+/* global StaticModuleRecord, Compartment */
+
+import tap from 'tap';
+import { resolveNode } from './node.js';
+import '../src/main.js';
+import { freeze, keys } from '../src/commons.js';
+
+const { test } = tap;
+
+function heuristicRequires(moduleSource) {
+  const dependsUpon = {};
+  moduleSource.replace(
+    /(?:^|[^\w$_.])require\s*\(\s*["']([^"']*)["']\s*\)/g,
+    (_, id) => {
+      dependsUpon[id] = true;
+    },
+  );
+  return keys(dependsUpon);
+}
+
+const CjsStaticModuleRecord = (moduleSource, moduleLocation) => {
+  if (typeof moduleSource !== 'string') {
+    throw new TypeError(
+      `Cannot create CommonJS static module record, module source must be a string, got ${moduleSource}`,
+    );
+  }
+  if (typeof moduleLocation !== 'string') {
+    throw new TypeError(
+      `Cannot create CommonJS static module record, module location must be a string, got ${moduleLocation}`,
+    );
+  }
+
+  const imports = heuristicRequires(moduleSource);
+  const execute = (exports, compartment, resolvedImports) => {
+    const functor = compartment.evaluate(
+      `(function (require, exports, module, __filename, __dirname) { ${moduleSource} //*/\n})\n//# sourceURL=${moduleLocation}`,
+    );
+
+    let moduleExports = exports;
+
+    const module = {
+      get exports() {
+        return moduleExports;
+      },
+      set exports(namespace) {
+        moduleExports = namespace;
+        exports.default = namespace;
+      },
+    };
+
+    const require = importSpecifier => {
+      const namespace = compartment.importNow(resolvedImports[importSpecifier]);
+      if (namespace.default !== undefined) {
+        return namespace.default;
+      }
+      return namespace;
+    };
+
+    functor(
+      require,
+      exports,
+      module,
+      moduleLocation, // __filename
+      new URL('./', moduleLocation).toString(), // __dirname
+    );
+  };
+  return freeze({ imports, execute });
+};
+
+test('import a CommonJS module with exports assignment', async t => {
+  t.plan(2);
+
+  const resolveHook = resolveNode;
+  const importHook = async () => {
+    return CjsStaticModuleRecord(
+      `
+      exports.meaning = 42;
+    `,
+      'https://example.com/meaning.js',
+    );
+  };
+
+  const compartment = new Compartment({}, {}, { resolveHook, importHook });
+  const module = compartment.module('.');
+  const {
+    namespace: { meaning },
+  } = await compartment.import('.');
+
+  t.equal(meaning, 42, 'exports seen');
+  t.equal(module.meaning, 42, 'exports seen through deferred proxy');
+});
+
+test('import a CommonJS module with exports replacement', async t => {
+  t.plan(2);
+
+  const resolveHook = resolveNode;
+  const importHook = async () => {
+    return CjsStaticModuleRecord(
+      `
+      module.exports = 42;
+    `,
+      'https://example.com/meaning.js',
+    );
+  };
+
+  const compartment = new Compartment({}, {}, { resolveHook, importHook });
+  const module = compartment.module('.');
+  const {
+    namespace: { default: meaning },
+  } = await compartment.import('.');
+
+  t.equal(meaning, 42, 'exports seen');
+  t.equal(module.default, 42, 'exports seen through deferred proxy');
+});
+
+test('CommonJS module imports CommonJS module by name', async t => {
+  t.plan(2);
+
+  const resolveHook = resolveNode;
+  const importHook = async specifier => {
+    if (specifier === './even') {
+      return CjsStaticModuleRecord(
+        `
+        exports.even = n => n % 2 === 0;
+      `,
+        'https://example.com/even.js',
+      );
+    }
+    if (specifier === './odd') {
+      return CjsStaticModuleRecord(
+        `
+        const { even } = require('./even');
+        exports.odd = n => !even(n);
+      `,
+        'https://example.com/odd.js',
+      );
+    }
+    throw new Error(`Cannot load module ${specifier}`);
+  };
+
+  const compartment = new Compartment({}, {}, { resolveHook, importHook });
+  const {
+    namespace: { odd },
+  } = await compartment.import('./odd');
+
+  t.equal(odd(1), true);
+  t.equal(odd(2), false);
+});
+
+test('CommonJS module imports CommonJS module as default', async t => {
+  t.plan(2);
+
+  const resolveHook = resolveNode;
+  const importHook = async specifier => {
+    if (specifier === './even') {
+      return CjsStaticModuleRecord(
+        `
+        module.exports = n => n % 2 === 0;
+      `,
+        'https://example.com/even.js',
+      );
+    }
+    if (specifier === './odd') {
+      return CjsStaticModuleRecord(
+        `
+        const even = require('./even');
+        module.exports = n => !even(n);
+      `,
+        'https://example.com/odd.js',
+      );
+    }
+    throw new Error(`Cannot load module ${specifier}`);
+  };
+
+  const compartment = new Compartment({}, {}, { resolveHook, importHook });
+  const {
+    namespace: { default: odd },
+  } = await compartment.import('./odd');
+
+  t.equal(odd(1), true);
+  t.equal(odd(2), false);
+});
+
+test('ESM imports CommonJS module as default', async t => {
+  t.plan(2);
+
+  const resolveHook = resolveNode;
+  const importHook = async specifier => {
+    if (specifier === './even') {
+      return CjsStaticModuleRecord(
+        `
+        exports.default = n => n % 2 === 0;
+      `,
+        'https://example.com/even',
+      );
+    }
+    if (specifier === './odd') {
+      return StaticModuleRecord(
+        `
+        import even from './even';
+        export default n => !even(n);
+      `,
+        'https://example.com/odd',
+      );
+    }
+    throw new Error(`Cannot load module ${specifier}`);
+  };
+
+  const compartment = new Compartment({}, {}, { resolveHook, importHook });
+  const {
+    namespace: { default: odd },
+  } = await compartment.import('./odd');
+
+  t.equal(odd(1), true);
+  t.equal(odd(2), false);
+});
+
+test('ESM imports CommonJS module by name', async t => {
+  t.plan(2);
+
+  const resolveHook = resolveNode;
+  const importHook = async specifier => {
+    if (specifier === './even') {
+      return CjsStaticModuleRecord(
+        `
+        exports.even = n => n % 2 === 0;
+      `,
+        'https://example.com/even',
+      );
+    }
+    if (specifier === './odd') {
+      return StaticModuleRecord(
+        `
+        import { even } from './even';
+        export default n => !even(n);
+      `,
+        'https://example.com/odd',
+      );
+    }
+    throw new Error(`Cannot load module ${specifier}`);
+  };
+
+  const compartment = new Compartment({}, {}, { resolveHook, importHook });
+  const {
+    namespace: { default: odd },
+  } = await compartment.import('./odd');
+
+  t.equal(odd(1), true);
+  t.equal(odd(2), false);
+});
+
+test('CommonJS module imports ESM as default', async t => {
+  t.plan(2);
+
+  const resolveHook = resolveNode;
+  const importHook = async specifier => {
+    if (specifier === './even') {
+      return StaticModuleRecord(
+        `
+        export default n => n % 2 === 0;
+      `,
+        'https://example.com/even',
+      );
+    }
+    if (specifier === './odd') {
+      return CjsStaticModuleRecord(
+        `
+          const even = require('./even');
+          module.exports = n => !even(n);
+      `,
+        'https://example.com/odd',
+      );
+    }
+    throw new Error(`Cannot load module ${specifier}`);
+  };
+
+  const compartment = new Compartment({}, {}, { resolveHook, importHook });
+  const {
+    namespace: { default: odd },
+  } = await compartment.import('./odd');
+
+  t.equal(odd(1), true);
+  t.equal(odd(2), false);
+});
+
+test('CommonJS module imports ESM by name', async t => {
+  t.plan(2);
+
+  const resolveHook = resolveNode;
+  const importHook = async specifier => {
+    if (specifier === './even') {
+      return StaticModuleRecord(
+        `
+        export function even(n) {
+         return n % 2 === 0;
+        }
+      `,
+        'https://example.com/even',
+      );
+    }
+    if (specifier === './odd') {
+      return CjsStaticModuleRecord(
+        `
+          const { even } = require('./even');
+          exports.odd = n => !even(n);
+      `,
+        'https://example.com/odd',
+      );
+    }
+    throw new Error(`Cannot load module ${specifier}`);
+  };
+
+  const compartment = new Compartment({}, {}, { resolveHook, importHook });
+  const {
+    namespace: { odd },
+  } = await compartment.import('./odd');
+
+  t.equal(odd(1), true);
+  t.equal(odd(2), false);
+});
+
+test('cross import ESM and CommonJS modules', async t => {
+  t.plan(5);
+
+  const resolveHook = resolveNode;
+  const importHook = async specifier => {
+    if (specifier === './src/main.js') {
+      return CjsStaticModuleRecord(
+        `
+        const direct = require('./other.js');
+        const indirect = require("./helper.mjs");
+        t.equal(direct.a, 10);
+        t.equal(direct.b, 20);
+        t.equal(indirect.a, 10);
+        t.equal(indirect.b, 20);
+        t.equal(indirect.c, 30);
+      `,
+        'https://example.com/src/main.js',
+      );
+    }
+    if (specifier === './src/helper.mjs') {
+      return new StaticModuleRecord(`
+        export * from './other.js';
+        import d from './default.js';
+        export const c = d;
+      `);
+    }
+    if (specifier === './src/other.js') {
+      return CjsStaticModuleRecord(
+        `
+        exports.a = 10;
+        exports.b = 20;
+      `,
+        'https://example.com/src/other.js',
+      );
+    }
+    if (specifier === './src/default.js') {
+      return CjsStaticModuleRecord(
+        `
+        exports.default = 30;
+      `,
+        'https://example.com/src/default.js',
+      );
+    }
+    throw new Error(`Cannot load module for specifier ${specifier}`);
+  };
+
+  const compartment = new Compartment({ t }, {}, { resolveHook, importHook });
+  await compartment.import('./src/main.js');
+});

--- a/packages/ses/test/import-non-esm.js
+++ b/packages/ses/test/import-non-esm.js
@@ -1,0 +1,286 @@
+/* global StaticModuleRecord, Compartment */
+
+import tap from 'tap';
+import { resolveNode } from './node.js';
+import '../src/main.js';
+
+const { test } = tap;
+
+test('import a non-ESM', async t => {
+  t.plan(2);
+
+  const resolveHook = resolveNode;
+  const importHook = async () => {
+    return {
+      imports: [],
+      execute(exports) {
+        exports.meaning = 42;
+      },
+    };
+  };
+
+  const compartment = new Compartment({}, {}, { resolveHook, importHook });
+  const module = compartment.module('.');
+  const {
+    namespace: { meaning },
+  } = await compartment.import('.');
+
+  t.equal(meaning, 42, 'exports seen');
+  t.equal(module.meaning, 42, 'exports seen through deferred proxy');
+});
+
+test('non-ESM imports non-ESM by name', async t => {
+  t.plan(2);
+
+  const resolveHook = resolveNode;
+  const importHook = async specifier => {
+    if (specifier === './even') {
+      return {
+        imports: ['./odd'],
+        execute(exports) {
+          exports.even = n => n % 2 === 0;
+        },
+      };
+    }
+    if (specifier === './odd') {
+      return {
+        imports: ['./even'],
+        execute(exports, compartment) {
+          const { even } = compartment.importNow('./even');
+          exports.odd = n => !even(n);
+        },
+      };
+    }
+    throw new Error(`Cannot load module ${specifier}`);
+  };
+
+  const compartment = new Compartment({}, {}, { resolveHook, importHook });
+  const {
+    namespace: { odd },
+  } = await compartment.import('./odd');
+
+  t.equal(odd(1), true);
+  t.equal(odd(2), false);
+});
+
+test('non-ESM imports non-ESM as default', async t => {
+  t.plan(2);
+
+  const resolveHook = resolveNode;
+  const importHook = async specifier => {
+    if (specifier === './even') {
+      return {
+        imports: ['./odd'],
+        execute(exports) {
+          exports.default = n => n % 2 === 0;
+        },
+      };
+    }
+    if (specifier === './odd') {
+      return {
+        imports: ['./even'],
+        execute(exports, compartment) {
+          const { default: even } = compartment.importNow('./even');
+          exports.default = n => !even(n);
+        },
+      };
+    }
+    throw new Error(`Cannot load module ${specifier}`);
+  };
+
+  const compartment = new Compartment({}, {}, { resolveHook, importHook });
+  const {
+    namespace: { default: odd },
+  } = await compartment.import('./odd');
+
+  t.equal(odd(1), true);
+  t.equal(odd(2), false);
+});
+
+test('ESM imports non-ESM as default', async t => {
+  t.plan(2);
+
+  const resolveHook = resolveNode;
+  const importHook = async specifier => {
+    if (specifier === './even') {
+      return {
+        imports: ['./odd'],
+        execute(exports) {
+          exports.default = n => n % 2 === 0;
+        },
+      };
+    }
+    if (specifier === './odd') {
+      return StaticModuleRecord(
+        `
+        import even from './even';
+        export default n => !even(n);
+      `,
+        'https://example.com/odd',
+      );
+    }
+    throw new Error(`Cannot load module ${specifier}`);
+  };
+
+  const compartment = new Compartment({}, {}, { resolveHook, importHook });
+  const {
+    namespace: { default: odd },
+  } = await compartment.import('./odd');
+
+  t.equal(odd(1), true);
+  t.equal(odd(2), false);
+});
+
+test('ESM imports non-ESM by name', async t => {
+  t.plan(2);
+
+  const resolveHook = resolveNode;
+  const importHook = async specifier => {
+    if (specifier === './even') {
+      return {
+        imports: ['./odd'],
+        execute(exports) {
+          exports.even = n => n % 2 === 0;
+        },
+      };
+    }
+    if (specifier === './odd') {
+      return StaticModuleRecord(
+        `
+        import { even } from './even';
+        export const odd = n => !even(n);
+      `,
+        'https://example.com/odd',
+      );
+    }
+    throw new Error(`Cannot load module ${specifier}`);
+  };
+
+  const compartment = new Compartment({}, {}, { resolveHook, importHook });
+  const {
+    namespace: { odd },
+  } = await compartment.import('./odd');
+
+  t.equal(odd(1), true);
+  t.equal(odd(2), false);
+});
+
+test('non-ESM imports ESM as default', async t => {
+  t.plan(2);
+
+  const resolveHook = resolveNode;
+  const importHook = async specifier => {
+    if (specifier === './even') {
+      return StaticModuleRecord(
+        `
+        export default n => n % 2 === 0;
+      `,
+        'https://example.com/even',
+      );
+    }
+    if (specifier === './odd') {
+      return {
+        imports: ['./even'],
+        execute(exports, compartment) {
+          const { default: even } = compartment.importNow('./even');
+          exports.default = n => !even(n);
+        },
+      };
+    }
+    throw new Error(`Cannot load module ${specifier}`);
+  };
+
+  const compartment = new Compartment({}, {}, { resolveHook, importHook });
+  const {
+    namespace: { default: odd },
+  } = await compartment.import('./odd');
+
+  t.equal(odd(1), true);
+  t.equal(odd(2), false);
+});
+
+test('non-ESM imports ESM by name', async t => {
+  t.plan(2);
+
+  const resolveHook = resolveNode;
+  const importHook = async specifier => {
+    if (specifier === './even') {
+      return StaticModuleRecord(
+        `
+        export const even = n => n % 2 === 0;
+      `,
+        'https://example.com/even',
+      );
+    }
+    if (specifier === './odd') {
+      return {
+        imports: ['./even'],
+        execute(exports, compartment) {
+          const { even } = compartment.importNow('./even');
+          exports.odd = n => !even(n);
+        },
+      };
+    }
+    throw new Error(`Cannot load module ${specifier}`);
+  };
+
+  const compartment = new Compartment({}, {}, { resolveHook, importHook });
+  const {
+    namespace: { odd },
+  } = await compartment.import('./odd');
+
+  t.equal(odd(1), true);
+  t.equal(odd(2), false);
+});
+
+test('cross import ESM and non-ESMs', async t => {
+  t.plan(5);
+
+  const resolveHook = resolveNode;
+  const importHook = async specifier => {
+    if (specifier === './src/main.js') {
+      return {
+        imports: ['./other.js', './helper.mjs'],
+        execute(_exports, compartment, resolvedImports) {
+          const direct = compartment.importNow(resolvedImports['./other.js']);
+          const indirect = compartment.importNow(
+            resolvedImports['./helper.mjs'],
+          );
+          t.equal(direct.a, 10);
+          t.equal(direct.b, 20);
+          t.equal(indirect.a, 10);
+          t.equal(indirect.b, 20);
+          t.equal(indirect.c, 30);
+        },
+      };
+    }
+    if (specifier === './src/helper.mjs') {
+      return new StaticModuleRecord(`
+        export * from './other.js';
+        import d from './default.js';
+        export const c = d;
+      `);
+    }
+    if (specifier === './src/other.js') {
+      return {
+        imports: [],
+        execute(exports) {
+          exports.a = 10;
+          exports.b = 20;
+        },
+      };
+    }
+    if (specifier === './src/default.js') {
+      return {
+        imports: [],
+        execute(exports) {
+          exports.default = 30;
+        },
+      };
+    }
+    throw new Error(`Cannot load module for specifier ${specifier}`);
+  };
+
+  const compartment = new Compartment({}, {}, { resolveHook, importHook });
+  await compartment.import('./src/main.js');
+});


### PR DESCRIPTION
This change includes a sequence of refactoring commits that fully decouple the `load` and `execute` phases of importing modules. The `load` phase only considers the superficial `imports` field of a static module record, which is the same for both first-party ESM and third-party static module records. The `execute` phase then treats these types of static module record according to their type.

In validating a static module record, we take care to provide the most informative error message, particularly to distinguish the case where a `StaticModuleRecord` may have crossed realms and the SES-shim could not see its “internal” fields. This is distinguishable because such records have `imports` and no `execute` method, implying that there *should* be internal fields associated with the record.

non-ESM modules do not support late/live binding, as this is not required for WASM and very unlikely to be necessary for CommonJS modules. This change slightly complicates ESM module instance implementation to take into account importing and exporting names from modules that do not have notifiers and whose exports must be observed by enumerating the properties of the exports object after the module runs to completion. After executing a third-party module, mutations to its exports namespace are not observable from any ESM modules that import them. Those mutations are however observable on the exports namespace object (as returned by dynamic `import`, `module`, and `importNow`) and in other third-party modules that retain that reference directly.

This change includes two layers of tests. The first layer verifies the static module record interface usage directly, using mock static module records. The second layer considers the case of a CommonJS static module record and covers its special treatment of the default export. This leaves open the possibility of misbehavior in the supremely unlikely chance of a CommonJS module that assigns an export to `exports.default` directly.