### PR TITLE
chore: update package.jsons to allow import of themselves

### DIFF
--- a/packages/harden/package.json
+++ b/packages/harden/package.json
@@ -34,9 +34,12 @@
   "module": "./src/main.js",
   "types": "index.d.ts",
   "exports": {
-    "import": "./src/main.js",
-    "require": "./dist/harden.cjs",
-    "browser": "./dist/harden.umd.js"
+    "./package.json": "./package.json",
+    ".": {
+      "import": "./src/main.js",
+      "require": "./dist/harden.cjs",
+      "browser": "./dist/harden.umd.js"
+    }
   },
   "scripts": {
     "prepublish": "yarn clean && yarn build",

--- a/packages/make-hardener/package.json
+++ b/packages/make-hardener/package.json
@@ -32,9 +32,12 @@
   "browser": "./dist/make-hardener.umd.js",
   "unpkg": "./dist/make-hardener.umd.js",
   "exports": {
-    "import": "./src/main.js",
-    "require": "./dist/make-hardener.cjs",
-    "browser": "./dist/make-hardener.umd.js"
+    "./package.json": "./package.json",
+    ".": {
+      "import": "./src/main.js",
+      "require": "./dist/make-hardener.cjs",
+      "browser": "./dist/make-hardener.umd.js"
+    }
   },
   "scripts": {
     "prepublish": "yarn clean && yarn build",

--- a/packages/make-importer/package.json
+++ b/packages/make-importer/package.json
@@ -8,9 +8,12 @@
   "module": "./dist/make-importer.esm.js",
   "unpkg": "./dist/make-importer.umd.js",
   "exports": {
-    "import": "./src/main.js",
-    "require": "./dist/make-importer.cjs",
-    "browser": "./dist/make-importer.umd.js"
+    "./package.json": "./package.json",
+    ".": {
+      "import": "./src/main.js",
+      "require": "./dist/make-importer.cjs",
+      "browser": "./dist/make-importer.umd.js"
+    }
   },
   "files": [
     "src",

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -12,9 +12,12 @@
   "types": "./index.d.ts",
   "unpkg": "./dist/ses.umd.js",
   "exports": {
-    "import": "./src/main.js",
-    "require": "./dist/ses.cjs",
-    "browser": "./dist/ses.umd.js"
+    "./package.json": "./package.json",
+    ".": {
+      "import": "./src/main.js",
+      "require": "./dist/ses.cjs",
+      "browser": "./dist/ses.umd.js"
+    }
   },
   "scripts": {
     "prepublish": "yarn clean && yarn build",

--- a/packages/transform-module/package.json
+++ b/packages/transform-module/package.json
@@ -11,9 +11,12 @@
   "browser": "./dist/transform-module.umd.js",
   "unpkg": "./dist/transform-module.umd.js",
   "exports": {
-    "import": "./src/main.js",
-    "require": "./dist/transform-module.cjs",
-    "browser": "./dist/transform-module.umd.js"
+    "./package.json": "./package.json",
+    ".": {
+      "import": "./src/main.js",
+      "require": "./dist/transform-module.cjs",
+      "browser": "./dist/transform-module.umd.js"
+    }
   },
   "scripts": {
     "clean": "rm -rf dist",


### PR DESCRIPTION
This is needed by tooling like Rollup, when used in conjunction
with the latest Node 12.x and 14.x branches.

Without this PR, we get failures of the following form:
```
$ rollup -c

src/main.js → public/build/bundle.js...
[!] (plugin svelte) Error: Package subpath './package.json' is not defined by "exports" in /Users/michael/agoric/agoric-sdk/packages/simple-wallet/node_modules/@agoric/harden/package.json
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './package.json' is not defined by "exports" in /Users/michael/agoric/agoric-sdk/packages/simple-wallet/node_modules/@agoric/harden/package.json
    at applyExports (internal/modules/cjs/loader.js:490:9)
    at resolveExports (internal/modules/cjs/loader.js:506:23)
    at Function.Module._findPath (internal/modules/cjs/loader.js:634:31)
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:952:27)
    at Function.requireRelative.resolve (/Users/michael/agoric/agoric-sdk/node_modules/require-relative/index.js:30:17)
    at tryResolve (/Users/michael/agoric/agoric-sdk/packages/simple-wallet/node_modules/rollup-plugin-svelte/index.js:50:19)
    at Object.resolveId (/Users/michael/agoric/agoric-sdk/packages/simple-wallet/node_modules/rollup-plugin-svelte/index.js:177:21)
    at /Users/michael/agoric/agoric-sdk/packages/simple-wallet/node_modules/rollup/dist/shared/rollup.js:18269:25
```
