### PR TITLE
fix(error-stack-shim): Address version limit for harden

### DIFF
--- a/packages/error-stack-shim/package.json
+++ b/packages/error-stack-shim/package.json
@@ -14,7 +14,7 @@
     "test": "tap --no-esm --no-coverage --reporter spec 'test/**/*.test.js'"
   },
   "dependencies": {
-    "@agoric/harden": "0.1.0",
+    "@agoric/harden": "0.0.4",
     "@agoric/nat": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This addresses an error introduced in the release of harden@0.1.0 where
the version was concurrently bumped for error-stack-shim, to a version
that no longer works.