### PR TITLE
feat(endo): Search for .js or /.index.js

### DIFF
--- a/packages/endo/README.md
+++ b/packages/endo/README.md
@@ -226,15 +226,9 @@ should be vended out to applications.
 The file set implicitly includes all `**.js`, `**.mjs`, and `**.cjs` files.
 The file set implicitly excludes anything under `node_modules`.
 
-> TODO
->
-> In Node.js, a module specifier that corresponds to a directory implicitly
-> redirects to the underlying `index.js` file.
-> Capturing a full list of `files` in a browser compartment map would allow
-> a compartment to follow these redirects without chancing a wasted round trip
-> to get a File not Found error.
-> This could alternately be solved by inferring the redirect when an internal
-> module specifier has no extension.
+With Endo just as in Node.js, a module specifier that has no extension may
+refer either to the file with the `js` extension, or if that file does not
+exist, to the `index.js` file in the directory with the same name.
 
 > TODO
 >

--- a/packages/endo/src/archive.js
+++ b/packages/endo/src/archive.js
@@ -24,26 +24,31 @@ const makeRecordingImportHookMaker = (read, baseLocation, manifest, errors) => {
     packageLocation = resolveLocation(packageLocation, baseLocation);
     const importHook = async moduleSpecifier => {
       // per-module:
-      const moduleLocation = new URL(
-        moduleSpecifier,
-        packageLocation
-      ).toString();
-      const moduleBytes = await read(moduleLocation).catch(_error => undefined);
-      if (moduleBytes === undefined) {
-        errors.push(
-          `missing ${q(moduleSpecifier)} needed for package ${q(
-            packageLocation
-          )}`
-        );
-        return new StaticModuleRecord("// Module not found", moduleLocation);
+      const candidates = [moduleSpecifier];
+      if (parseExtension(moduleSpecifier) === "") {
+        candidates.push(`${moduleSpecifier}.js`, `${moduleSpecifier}/index.js`);
       }
-      const moduleSource = decoder.decode(moduleBytes);
+      for (const candidate of candidates) {
+        const moduleLocation = new URL(candidate, packageLocation).toString();
+        // eslint-disable-next-line no-await-in-loop
+        const moduleBytes = await read(moduleLocation).catch(
+          _error => undefined
+        );
+        if (moduleBytes === undefined) {
+          errors.push(
+            `missing ${q(candidate)} needed for package ${q(packageLocation)}`
+          );
+        } else {
+          const moduleSource = decoder.decode(moduleBytes);
 
-      const packageManifest = manifest[packageLocation] || {};
-      manifest[packageLocation] = packageManifest;
-      packageManifest[moduleSpecifier] = moduleBytes;
+          const packageManifest = manifest[packageLocation] || {};
+          manifest[packageLocation] = packageManifest;
+          packageManifest[moduleSpecifier] = moduleBytes;
 
-      return parse(moduleSource, moduleLocation);
+          return parse(moduleSource, moduleLocation);
+        }
+      }
+      return new StaticModuleRecord("// Module not found", moduleSpecifier);
     };
     return importHook;
   };

--- a/packages/endo/src/archive.js
+++ b/packages/endo/src/archive.js
@@ -3,6 +3,7 @@
 
 import { writeZip } from "./zip.js";
 import { resolve, join } from "./node-module-specifier.js";
+import { parseExtension } from "./extension.js";
 import { compartmentMapForNodeModules } from "./compartmap.js";
 import { search } from "./search.js";
 import { assemble } from "./assemble.js";

--- a/packages/endo/src/lockdown.js
+++ b/packages/endo/src/lockdown.js
@@ -1,0 +1,6 @@
+/* global lockdown */
+import "ses";
+
+lockdown({
+  errorTaming: "unsafe"
+});


### PR DESCRIPTION
When a module imports `./alice`, this implies either `./alice.js` or `./alice/index.js`. This change scans for a matching module.

Ideally we would not need to do this, but it is required for Node.js parity. In a subsequent change, it may be possible to rewrite the “compartment map” into a more detailed “module map”, with details for every module in an archives working set, so this probing only occurs when running an application outside of an archive or constructing an archive, not running an archived application.