### PR TITLE
Make the whitelist tolerant of the absence of expected things

### DIFF
--- a/packages/ses/src/whitelist-intrinsics.js
+++ b/packages/ses/src/whitelist-intrinsics.js
@@ -205,6 +205,10 @@ export default function whitelistIntrinsics(intrinsics, nativeBrander) {
    * Whitelist all properties against a permit.
    */
   function whitelistProperties(path, obj, permit) {
+    if (obj === undefined) {
+      return;
+    }
+
     const protoName = permit['[[Proto]]'];
     whitelistPrototype(path, obj, protoName);
 


### PR DESCRIPTION
Actual author @kriskowal , repairing a bug reported by @michaelfig .

I (@erights) am surprised this fix is needed. I thought the whitelist already did this.