### PR TITLE
fix: tolerate whitelist absence better

### DIFF
--- a/packages/ses/src/intrinsics.js
+++ b/packages/ses/src/intrinsics.js
@@ -53,7 +53,9 @@ function initProperties(obj, descs) {
 function sampleGlobals(globalObject, newPropertyNames) {
   const newIntrinsics = { __proto__: null };
   for (const [globalName, intrinsicName] of entries(newPropertyNames)) {
-    newIntrinsics[intrinsicName] = globalObject[globalName];
+    if (objectHasOwnProperty(globalObject, globalName)) {
+      newIntrinsics[intrinsicName] = globalObject[globalName];
+    }
   }
   return newIntrinsics;
 }


### PR DESCRIPTION
Follow up to #407

Because `StaticModuleRecord` was listed in the whitelist's `universalPropertyNames` but was absence from the global, the old

```js
newIntrinsics[intrinsicName] = globalObject[globalName];
```
was creating a property on `newIntrinsics` named `StaticModuleRecord` with value `undefined`. This PR adds a check so that absent properties on `globalObject` skip the above assignment.
