### PR TITLE
fix: correct fix for override mistake

### DIFF
--- a/packages/ses/src/enable-property-overrides.js
+++ b/packages/ses/src/enable-property-overrides.js
@@ -61,8 +61,8 @@ export default function enablePropertyOverrides(intrinsics) {
           defineProperty(this, prop, {
             value: newValue,
             writable: true,
-            enumerable: desc.enumerable,
-            configurable: desc.configurable,
+            enumerable: true,
+            configurable: true,
           });
         }
       }


### PR DESCRIPTION
The override mistake is supposed to emulate the way assignment should have worked in the absence of the override mistake. Before this PR, when an assignment would have created a new property, the emulated assignment creates a property that inherits the enumerability and configurability of the property being overridden. But new properties actually created by assignment don't do that. They start with `writable`, `enumerable`, and `configurable` all true.

This PR still needs tests.