### PR TITLE
fix(ses): Generally import "ses/lockdown"

### DIFF
--- a/packages/ses/lockdown.js
+++ b/packages/ses/lockdown.js
@@ -1,0 +1,7 @@
+import { assign } from './src/commons.js';
+import { makeLockdown, harden } from './src/lockdown-shim.js';
+
+assign(globalThis, {
+  harden,
+  lockdown: makeLockdown(),
+});

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,25 +1,24 @@
 {
   "name": "ses",
-  "umd": "SES",
   "version": "0.9.1+1-dev",
   "description": "Secure ECMAScript",
   "author": "Agoric",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/ses.cjs",
-  "module": "./src/main.js",
+  "module": "./ses.js",
   "browser": "./dist/ses.umd.js",
   "types": "./index.d.ts",
   "unpkg": "./dist/ses.umd.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./src/main.js",
+      "import": "./ses.js",
       "require": "./dist/ses.cjs",
       "browser": "./dist/ses.umd.js"
     },
     "./lockdown": {
-      "import": "./src/lockdown-main.js",
+      "import": "./lockdown.js",
       "require": "./dist/lockdown.cjs",
       "browser": "./dist/lockdown.umd.js"
     }

--- a/packages/ses/rollup.config.js
+++ b/packages/ses/rollup.config.js
@@ -1,30 +1,24 @@
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import { terser } from 'rollup-plugin-terser';
-import fs from 'fs';
-
-const metaPath = new URL('package.json', import.meta.url).pathname;
-const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
-const name = meta.name.split('/').pop();
-const umd = meta.umd || name;
 
 export default [
   {
-    input: 'src/main.js',
+    input: 'ses.js',
     output: [
       {
-        file: `dist/${name}.mjs`,
+        file: `dist/ses.mjs`,
         format: 'esm',
       },
       {
-        file: `dist/${name}.cjs`,
+        file: `dist/ses.cjs`,
         format: 'cjs',
       },
     ],
     plugins: [resolve(), commonjs()],
   },
   {
-    input: 'src/lockdown-main.js',
+    input: 'lockdown.js',
     output: [
       {
         file: `dist/lockdown.cjs`,
@@ -34,38 +28,38 @@ export default [
     plugins: [resolve(), commonjs()],
   },
   {
-    input: 'src/main.js',
+    input: 'ses.js',
     output: {
-      file: `dist/${name}.umd.js`,
+      file: `dist/ses.umd.js`,
       format: 'umd',
-      name: umd,
+      name: 'SES',
     },
     plugins: [resolve(), commonjs()],
   },
   {
-    input: 'src/lockdown-main.js',
+    input: 'lockdown.js',
     output: {
       file: `dist/lockdown.umd.js`,
       format: 'umd',
-      name: umd,
+      name: 'SES',
     },
     plugins: [resolve(), commonjs()],
   },
   {
-    input: 'src/main.js',
+    input: 'ses.js',
     output: {
-      file: `dist/${name}.umd.min.js`,
+      file: `dist/ses.umd.min.js`,
       format: 'umd',
-      name: umd,
+      name: 'SES',
     },
     plugins: [resolve(), commonjs(), terser()],
   },
   {
-    input: 'src/lockdown-main.js',
+    input: 'lockdown.js',
     output: {
       file: `dist/lockdown.umd.min.js`,
       format: 'umd',
-      name: umd,
+      name: 'SES',
     },
     plugins: [resolve(), commonjs(), terser()],
   },

--- a/packages/ses/ses.js
+++ b/packages/ses/ses.js
@@ -14,14 +14,14 @@
 
 // Importing the lower-layer "./lockdown.js" ensures that we run later and
 // replace its global lockdown if an application elects to import both.
-import './lockdown-main.js';
-import { assign } from './commons.js';
-import { makeLockdown } from './lockdown-shim.js';
+import './lockdown.js';
+import { assign } from './src/commons.js';
+import { makeLockdown } from './src/lockdown-shim.js';
 import {
   makeCompartmentConstructor,
   Compartment,
   StaticModuleRecord,
-} from './compartment-shim.js';
+} from './src/compartment-shim.js';
 
 assign(globalThis, {
   lockdown: makeLockdown(makeCompartmentConstructor),

--- a/packages/ses/src/lockdown-main.js
+++ b/packages/ses/src/lockdown-main.js
@@ -1,7 +1,0 @@
-import { assign } from './commons.js';
-import { makeLockdown, harden } from './lockdown-shim.js';
-
-assign(globalThis, {
-  harden,
-  lockdown: makeLockdown(),
-});

--- a/packages/ses/test/compartment-constructor.test.js
+++ b/packages/ses/test/compartment-constructor.test.js
@@ -1,6 +1,6 @@
 /* global lockdown Compartment */
 import tap from 'tap';
-import '../src/main.js';
+import '../ses.js';
 
 const { test } = tap;
 

--- a/packages/ses/test/compartment.test.js
+++ b/packages/ses/test/compartment.test.js
@@ -1,6 +1,6 @@
 /* global Compartment, lockdown */
 import test from 'tape';
-import '../src/main.js';
+import '../ses.js';
 
 lockdown();
 

--- a/packages/ses/test/global-lexicals-evaluate.test.js
+++ b/packages/ses/test/global-lexicals-evaluate.test.js
@@ -1,6 +1,6 @@
 /* global Compartment */
 import test from 'tape';
-import '../src/main.js';
+import '../ses.js';
 
 test('endowments own properties are mentionable', t => {
   t.plan(1);

--- a/packages/ses/test/global-lexicals-modules.test.js
+++ b/packages/ses/test/global-lexicals-modules.test.js
@@ -1,6 +1,6 @@
 /* global Compartment */
 
-import '../src/main.js';
+import '../ses.js';
 import test from 'tape';
 import { resolveNode, makeNodeImporter } from './node.js';
 

--- a/packages/ses/test/harden.test.js
+++ b/packages/ses/test/harden.test.js
@@ -1,6 +1,6 @@
 /* global Compartment, lockdown */
 import test from 'tape';
-import '../src/main.js';
+import '../ses.js';
 
 lockdown();
 

--- a/packages/ses/test/import-cjs.test.js
+++ b/packages/ses/test/import-cjs.test.js
@@ -2,7 +2,7 @@
 
 import tap from 'tap';
 import { resolveNode } from './node.js';
-import '../src/main.js';
+import '../ses.js';
 import { freeze, keys } from '../src/commons.js';
 
 const { test } = tap;

--- a/packages/ses/test/import-non-esm.js
+++ b/packages/ses/test/import-non-esm.js
@@ -2,7 +2,7 @@
 
 import tap from 'tap';
 import { resolveNode } from './node.js';
-import '../src/main.js';
+import '../ses.js';
 
 const { test } = tap;
 

--- a/packages/ses/test/install-ses-safe.js
+++ b/packages/ses/test/install-ses-safe.js
@@ -1,4 +1,4 @@
 /* global lockdown */
-import '../src/main.js';
+import '../ses.js';
 
 lockdown();

--- a/packages/ses/test/install-ses-unsafe.js
+++ b/packages/ses/test/install-ses-unsafe.js
@@ -1,5 +1,5 @@
 /* global lockdown */
-import '../src/main.js';
+import '../ses.js';
 
 lockdown({
   dateTaming: 'unsafe',

--- a/packages/ses/test/lockdown-allow.test.js
+++ b/packages/ses/test/lockdown-allow.test.js
@@ -1,6 +1,6 @@
 /* global lockdown */
 import test from 'tape';
-import '../src/main.js';
+import '../ses.js';
 
 test('lockdown returns boolean or throws in downgraded SES', t => {
   t.plan(6);

--- a/packages/ses/test/lockdown.test.js
+++ b/packages/ses/test/lockdown.test.js
@@ -1,6 +1,6 @@
 /* global Compartment, lockdown */
 import test from 'tape';
-import '../src/main.js';
+import '../ses.js';
 
 test('lockdown returns boolean or throws in SES', t => {
   // Compartment constructor does not throw before lockdown.

--- a/packages/ses/test/module-static-record.test.js
+++ b/packages/ses/test/module-static-record.test.js
@@ -1,6 +1,6 @@
 /* global lockdown StaticModuleRecord */
 import tap from 'tap';
-import '../src/main.js';
+import '../ses.js';
 
 const { test } = tap;
 

--- a/packages/ses/test/nesting.test.js
+++ b/packages/ses/test/nesting.test.js
@@ -1,6 +1,6 @@
 /* global Compartment, lockdown */
 import test from 'tape';
-import '../src/main.js';
+import '../ses.js';
 
 lockdown();
 

--- a/packages/ses/test/property-override.test.js
+++ b/packages/ses/test/property-override.test.js
@@ -1,7 +1,7 @@
 /* global Compartment, lockdown */
 /* eslint-disable max-classes-per-file, no-inner-declarations */
 import test from 'tape';
-import '../src/main.js';
+import '../ses.js';
 
 lockdown();
 

--- a/packages/ses/test/ses.test.js
+++ b/packages/ses/test/ses.test.js
@@ -1,6 +1,6 @@
 /* global Compartment, lockdown, harden */
 import test from 'tape';
-import '../src/main.js';
+import '../ses.js';
 
 const originalConsole = console;
 

--- a/packages/ses/test/tame-date.test.js
+++ b/packages/ses/test/tame-date.test.js
@@ -1,6 +1,6 @@
 /* global Compartment, lockdown */
 import test from 'tape';
-import '../src/main.js';
+import '../ses.js';
 
 lockdown();
 

--- a/packages/ses/test/tame-locale-methods-unsafe.test.js
+++ b/packages/ses/test/tame-locale-methods-unsafe.test.js
@@ -1,6 +1,6 @@
 /* global lockdown BigInt */
 import test from 'tape';
-import '../src/main.js';
+import '../ses.js';
 
 lockdown({ localeTaming: 'unsafe' });
 

--- a/packages/ses/test/tame-locale-methods.test.js
+++ b/packages/ses/test/tame-locale-methods.test.js
@@ -1,6 +1,6 @@
 /* global lockdown BigInt */
 import test from 'tape';
-import '../src/main.js';
+import '../ses.js';
 
 lockdown();
 

--- a/packages/ses/test/tame-math.test.js
+++ b/packages/ses/test/tame-math.test.js
@@ -1,6 +1,6 @@
 /* global Compartment, lockdown */
 import test from 'tape';
-import '../src/main.js';
+import '../ses.js';
 
 lockdown();
 

--- a/packages/ses/test/tame-rexexp.test.js
+++ b/packages/ses/test/tame-rexexp.test.js
@@ -1,6 +1,6 @@
 /* global Compartment, lockdown */
 import test from 'tape';
-import '../src/main.js';
+import '../ses.js';
 
 const allowedProperties = new Set([
   'length',

--- a/packages/ses/test/tame-v8-error-unsafe.test.js
+++ b/packages/ses/test/tame-v8-error-unsafe.test.js
@@ -1,6 +1,6 @@
 /* global lockdown */
 import test from 'tape';
-import '../src/main.js';
+import '../ses.js';
 
 // TODO test Error API in
 //    * non - start compartments

--- a/packages/ses/test/tame-v8-error.test.js
+++ b/packages/ses/test/tame-v8-error.test.js
@@ -1,6 +1,6 @@
 /* global Compartment, lockdown */
 import test from 'tape';
-import '../src/main.js';
+import '../ses.js';
 
 lockdown();
 

--- a/packages/ses/test/v8-callsite-properties.test.js
+++ b/packages/ses/test/v8-callsite-properties.test.js
@@ -1,6 +1,6 @@
 /* global lockdown */
 import test from 'tape';
-import '../src/main.js';
+import '../ses.js';
 
 lockdown({ errorTaming: 'unsafe' });
 

--- a/packages/ses/test/whitelist-intrinsics.test.js
+++ b/packages/ses/test/whitelist-intrinsics.test.js
@@ -1,5 +1,5 @@
 import tap from 'tap';
-import '../src/main.js';
+import '../ses.js';
 import { repairIntrinsics } from '../src/lockdown-shim.js';
 
 const { test } = tap;

--- a/packages/ses/test/whitelist.test.js
+++ b/packages/ses/test/whitelist.test.js
@@ -1,6 +1,6 @@
 /* global Compartment, lockdown */
 import test from 'tape';
-import '../src/main.js';
+import '../ses.js';
 
 lockdown();
 


### PR DESCRIPTION
This change moves the entry points for `ses` to the top-level such that systems that do not recognize the `exports` property in `package.json` will still be able to `import "ses/lockdown"` as if they did.  This makes our guidance for importing the lockdown layer more universal.