### PR TITLE
fix(ses): Add HandledPromise to the whitelist

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -2,7 +2,9 @@ User-visible changes in SES:
 
 ## Next release
 
-* No changes yet.
+* Updates the whitelist to allow a `HandledPromise` global, which is provided
+  by `@agoric/eventual-send`, an early implementation of
+  https://github.com/tc39/proposal-eventual-send.
 
 ## Release 0.10.0 (8-August-2020)
 

--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -59,7 +59,6 @@ export const universalPropertyNames = {
   Map: 'Map',
   Number: 'Number',
   Object: 'Object',
-  HandledPromise: 'HandledPromise', // TODO: Until Promise.delegate (see below).
   Promise: 'Promise',
   Proxy: 'Proxy',
   RangeError: 'RangeError',
@@ -91,6 +90,7 @@ export const universalPropertyNames = {
 
   lockdown: 'lockdown',
   harden: 'harden',
+  HandledPromise: 'HandledPromise', // TODO: Until Promise.delegate (see below).
   StaticModuleRecord: 'StaticModuleRecord',
 };
 

--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -59,6 +59,7 @@ export const universalPropertyNames = {
   Map: 'Map',
   Number: 'Number',
   Object: 'Object',
+  HandledPromise: 'HandledPromise', // TODO: Until Promise.delegate.
   Promise: 'Promise',
   Proxy: 'Proxy',
   RangeError: 'RangeError',
@@ -1642,6 +1643,19 @@ export const whitelist = {
     throw: fn,
     // 25.5.1.5 AsyncGenerator.prototype [ @@toStringTag ]
     '@@toStringTag': 'string',
+  },
+
+  // TODO: To be replaced with Promise.delegate
+  HandledPromise: {
+    '[[Proto]]': 'Promise',
+    applyMethod: fn,
+    applyFunction: fn,
+    applyMethodSendOnly: fn,
+    applyFunctionSendOnly: fn,
+    get: fn,
+    getSendOnly: fn,
+    resolve: fn,
+    prototype: '%PromisePrototype%',
   },
 
   Promise: {

--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -59,7 +59,7 @@ export const universalPropertyNames = {
   Map: 'Map',
   Number: 'Number',
   Object: 'Object',
-  HandledPromise: 'HandledPromise', // TODO: Until Promise.delegate.
+  HandledPromise: 'HandledPromise', // TODO: Until Promise.delegate (see below).
   Promise: 'Promise',
   Proxy: 'Proxy',
   RangeError: 'RangeError',
@@ -1646,16 +1646,24 @@ export const whitelist = {
   },
 
   // TODO: To be replaced with Promise.delegate
+  //
+  // The HandledPromise global variable shimmed by `@agoric/eventual-send/shim`
+  // implements an initial version of the eventual send specification at:
+  // https://github.com/tc39/proposal-eventual-send
+  //
+  // We will likely change this to add a property to Promise called
+  // Promise.delegate and put static methods on it, which will necessitate
+  // another whitelist change to update to the current proposed standard.
   HandledPromise: {
     '[[Proto]]': 'Promise',
-    applyMethod: fn,
     applyFunction: fn,
-    applyMethodSendOnly: fn,
     applyFunctionSendOnly: fn,
+    applyMethod: fn,
+    applyMethodSendOnly: fn,
     get: fn,
     getSendOnly: fn,
-    resolve: fn,
     prototype: '%PromisePrototype%',
+    resolve: fn,
   },
 
   Promise: {


### PR DESCRIPTION
This is a temporary fix until lockdown gets a more disciplined way of updating the whitelist with vetted shims.  In any event, it is a step toward `Promise.delegate`, but that standard hasn't yet been implemented in `@agoric/eventual-send/shim`.

@kriskowal Please update and release a new patch version of `ses`, so that we can use this in agoric-sdk.
