### PR TITLE
feat(ses): Add moduleMapHook

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -2,7 +2,11 @@ User-visible changes in SES:
 
 ## Next release
 
-* No changes yet.
+* Adds a `moduleMapHook` option to the `Compartment` constructor options.
+  The module map hook can return values for the `moduleMap` for
+  any given module specifier, or return `undefined` to fall back to the
+  `importHook`.
+  This allows for wildcard linkage to other compartments.
 
 ## Release 0.10.1 (13-August-2020)
 

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -208,6 +208,7 @@ export const makeCompartmentConstructor = (intrinsics, nativeBrander) => {
       globalLexicals = {},
       resolveHook,
       importHook,
+      moduleMapHook,
     } = options;
     const globalTransforms = [...transforms];
 
@@ -266,6 +267,7 @@ export const makeCompartmentConstructor = (intrinsics, nativeBrander) => {
       resolveHook,
       importHook,
       moduleMap,
+      moduleMapHook,
       moduleRecords,
       deferredExports,
       instances,

--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -49,11 +49,15 @@ export const load = async (
     resolveHook,
     importHook,
     moduleMap,
+    moduleMapHook,
     moduleRecords,
   } = compartmentPrivateFields.get(compartment);
 
-  // Follow moduleMap.
-  const aliasNamespace = moduleMap[moduleSpecifier];
+  // Follow moduleMap, or moduleMapHook if present.
+  let aliasNamespace = moduleMap[moduleSpecifier];
+  if (aliasNamespace === undefined && moduleMapHook !== undefined) {
+    aliasNamespace = moduleMapHook(moduleSpecifier);
+  }
   if (typeof aliasNamespace === 'string') {
     throw new TypeError(
       `Cannot map module ${q(moduleSpecifier)} to ${q(


### PR DESCRIPTION
Adds a `moduleMapHook` option to the `Compartment` constructor options.  The module map hook can return values for the `moduleMap` for any given module specifier, or return `undefined` to fall back to the `importHook`.  This allows for wildcard linkage to other compartments.