### PR TITLE
Workaround v8 debugger bug

### DIFF
--- a/packages/ses/src/scope-handler.js
+++ b/packages/ses/src/scope-handler.js
@@ -153,5 +153,13 @@ export function createScopeHandler(
     getPrototypeOf() {
       return null;
     },
+
+    // Chip has seen this happen single stepping under the Chrome/v8 debugger.
+    // TODO record how to reliably reproduce, and to test if this fix helps.
+    // TODO report as bug to v8 or Chrome, and record issue link here.
+
+    getOwnPropertyDescriptor() {
+      return undefined;
+    },
   };
 }

--- a/packages/ses/src/scope-handler.js
+++ b/packages/ses/src/scope-handler.js
@@ -158,7 +158,13 @@ export function createScopeHandler(
     // TODO record how to reliably reproduce, and to test if this fix helps.
     // TODO report as bug to v8 or Chrome, and record issue link here.
 
-    getOwnPropertyDescriptor() {
+    getOwnPropertyDescriptor(_target, prop) {
+      // Coerce with `String` in case prop is a symbol.
+      const quotedProp = JSON.stringify(String(prop));
+      console.warn(
+        `getOwnPropertyDescriptor trap on scopeHandler for ${quotedProp}`,
+        new Error().stack,
+      );
       return undefined;
     },
   };


### PR DESCRIPTION
@FUDCo  has seen the `getOwnPropertyDescriptor` trap happen on the scopeHandler under the v8/Chrome debugger, but not otherwise. This PR adds the same kind of workaround we did for the `getPrototypeOf` trap for a Safari bug --- immediately above the code for this new one.

Until we know how to reproduce, we cannot test if this PR helps. @FUDCo , if you could give feedback as part of review? Thanks.