### PR TITLE
feat(ses): Support importHook alias returns

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -2,6 +2,8 @@ User-visible changes in SES:
 
 ## Next release
 
+* Allows a compartment's `importHook` to return an "alias" if the returned
+  static module record has a different specifier than requested.
 * Adds the `name` option to the `Compartment` constructor and `name` accessor
   to the `Compartment` prototype.
   Errors that pass through a compartment may be annotated with the compartment


### PR DESCRIPTION
This change enables importHook to return a record for a module that has a different specifier than the requested module specifier.  This enables the Node.js pattern of redirecting `name` to `name/index.js` and respecting the latter name as the referrer for its own imports.