### PR TITLE
feat(endo): Search for index.js and implied package exports

### DIFF
--- a/packages/endo/DESIGN.md
+++ b/packages/endo/DESIGN.md
@@ -245,13 +245,13 @@ type FileLocation = string
 // search the filesystem for candidate module files and infer the type from the
 // extension when necessary.
 type FileModule = {
-   location: FileLocation
-   parser: Parser
+   location: FileLocation,
+   parser: Parser,
 };
 
 // ExitName is the name of a built-in module, to be threaded in from the
 // modules passed to the module executor.
-type ExitName string;
+type ExitName = string;
 
 // ExitModule refers to a module that comes from outside the compartment map.
 type ExitModule = {
@@ -260,11 +260,11 @@ type ExitModule = {
 
 // InternalModuleSpecifier is the module specifier
 // in the namespace of the native compartment.
-type InternalModuleSpecifier string;
+type InternalModuleSpecifier = string;
 
 // ExternalModuleSpecifier is the module specifier
 // in the namespace of the foreign compartment.
-type ExternalModuleSpecifier string;
+type ExternalModuleSpecifier = string;
 
 // ParserMap indicates which parser to use to construct static module records
 // from sources, for each supported file extension.
@@ -293,7 +293,7 @@ type Parser = "mjs" | "cjs" | "json";
 // Node.js allows the "module" property in package.json to denote
 // a file that is an ECMAScript module, regardless of its extension.
 // This is the mechanism that allows Endo to respect that behavior.
-type ModuleParserMap = Object<InternalModuleSpecifier, Parser>
+type ModuleParserMap = Object<InternalModuleSpecifier, Parser>;
 
 // ScopeMap is a map from internal module specifier prefixes
 // like "dependency" or "@organization/dependency" to another
@@ -305,13 +305,13 @@ type ModuleParserMap = Object<InternalModuleSpecifier, Parser>
 // to a link into some internal module of the foreign compartment.
 // When Endo creates an archive, it captures all of the Modules
 // explicitly and erases the scopes entry.
-type ScopeMap = Object<InternalModuleSpecifier, Scope>
+type ScopeMap = Object<InternalModuleSpecifier, Scope>;
 
 // Scope describes the compartment to use for all ad-hoc
 // entries in the compartment's module map.
 type Scope = {
   compartment: CompartmentName
-}
+};
 
 
 // TODO everything hereafter...
@@ -327,7 +327,7 @@ type Realm = {
 // RealmName is an arbitrary identifier for realms
 // for reference from any Compartment description.
 // No names are reserved; the default realm has no name.
-type RealmName string;
+type RealmName = string;
 
 // ModuleParameter indicates that the module does not come from
 // another compartment but must be passed expressly into the
@@ -337,7 +337,7 @@ type RealmName string;
 // and may be attenuated or limited by Endo on behalf of the user.
 // The string value is the name of the module to be provided
 // in the application's given module map.
-type ModuleParameter string;
+type ModuleParameter = string;
 ```
 
 

--- a/packages/endo/src/archive.js
+++ b/packages/endo/src/archive.js
@@ -1,15 +1,15 @@
-/* global StaticModuleRecord */
 /* eslint no-shadow: 0 */
 
 import { writeZip } from "./zip.js";
-import { resolve, join } from "./node-module-specifier.js";
+import { resolve } from "./node-module-specifier.js";
 import { parseExtension } from "./extension.js";
 import { compartmentMapForNodeModules } from "./compartmap.js";
 import { search } from "./search.js";
 import { assemble } from "./assemble.js";
 
-const { entries, fromEntries } = Object;
+const { entries, freeze, fromEntries, values } = Object;
 
+// q, as in quote, for quoted strings in error messages.
 const q = JSON.stringify;
 
 const encoder = new TextEncoder();
@@ -17,38 +17,69 @@ const decoder = new TextDecoder();
 
 const resolveLocation = (rel, abs) => new URL(rel, abs).toString();
 
-const makeRecordingImportHookMaker = (read, baseLocation, manifest, errors) => {
+const makeRecordingImportHookMaker = (read, baseLocation, sources) => {
   // per-assembly:
   const makeImportHook = (packageLocation, parse) => {
     // per-compartment:
     packageLocation = resolveLocation(packageLocation, baseLocation);
+    const packageSources = sources[packageLocation] || {};
+    sources[packageLocation] = packageSources;
+
     const importHook = async moduleSpecifier => {
       // per-module:
+
+      // In Node.js, an absolute specifier always indicates a built-in or
+      // third-party dependency.
+      // The `moduleMapHook` captures all third-party dependencies.
+      if (moduleSpecifier !== "." && !moduleSpecifier.startsWith("./")) {
+        packageSources[moduleSpecifier] = {
+          exit: moduleSpecifier
+        };
+        // Return a place-holder.
+        // Archived compartments are not executed.
+        return freeze({ imports: [], execute() {} });
+      }
+
       const candidates = [moduleSpecifier];
       if (parseExtension(moduleSpecifier) === "") {
         candidates.push(`${moduleSpecifier}.js`, `${moduleSpecifier}/index.js`);
       }
       for (const candidate of candidates) {
-        const moduleLocation = new URL(candidate, packageLocation).toString();
+        const moduleLocation = resolveLocation(candidate, packageLocation);
         // eslint-disable-next-line no-await-in-loop
         const moduleBytes = await read(moduleLocation).catch(
           _error => undefined
         );
-        if (moduleBytes === undefined) {
-          errors.push(
-            `missing ${q(candidate)} needed for package ${q(packageLocation)}`
-          );
-        } else {
+        if (moduleBytes !== undefined) {
           const moduleSource = decoder.decode(moduleBytes);
 
-          const packageManifest = manifest[packageLocation] || {};
-          manifest[packageLocation] = packageManifest;
-          packageManifest[moduleSpecifier] = moduleBytes;
+          const { record, parser } = parse(
+            moduleSource,
+            moduleSpecifier,
+            moduleLocation
+          );
 
-          return parse(moduleSource, moduleSpecifier, moduleLocation);
+          const packageRelativeLocation = moduleLocation.slice(
+            packageLocation.length
+          );
+          packageSources[moduleSpecifier] = {
+            location: packageRelativeLocation,
+            parser,
+            bytes: moduleBytes
+          };
+
+          return record;
         }
       }
-      return new StaticModuleRecord("// Module not found", moduleSpecifier);
+
+      // TODO offer breadcrumbs in the error message, or how to construct breadcrumbs with another tool.
+      throw new Error(
+        `Cannot find file for internal module ${q(
+          moduleSpecifier
+        )} (with candidates ${candidates
+          .map(q)
+          .join(", ")}) in package ${packageLocation}`
+      );
     };
     return importHook;
   };
@@ -60,16 +91,18 @@ const renameCompartments = compartments => {
   let n = 0;
   for (const [name, compartment] of entries(compartments)) {
     const { label } = compartment;
-    renames[name] = `${label}#${n}`;
+    renames[name] = `${label}-n${n}`;
     n += 1;
   }
   return renames;
 };
 
-const renameCompartmentMap = (compartments, renames) => {
+const translateCompartmentMap = (compartments, sources, renames) => {
   const result = {};
   for (const [name, compartment] of entries(compartments)) {
-    const { label, parsers, types } = compartment;
+    const { label } = compartment;
+
+    // rename module compartments
     const modules = {};
     for (const [name, module] of entries(compartment.modules || {})) {
       const compartment = module.compartment
@@ -80,14 +113,27 @@ const renameCompartmentMap = (compartments, renames) => {
         compartment
       };
     }
+
+    // integrate sources into modules
+    const compartmentSources = sources[name];
+    for (const [name, source] of entries(compartmentSources || {})) {
+      const { location, parser, exit } = source;
+      modules[name] = {
+        location,
+        parser,
+        exit
+      };
+    }
+
     result[renames[name]] = {
       label,
       location: renames[name],
-      modules,
-      parsers,
-      types
+      modules
+      // `scopes`, `types`, and `parsers` are not necessary since every
+      // loadable module is captured in `modules`.
     };
   }
+
   return result;
 };
 
@@ -99,10 +145,18 @@ const renameSources = (sources, renames) => {
 
 const addSourcesToArchive = async (archive, sources) => {
   for (const [compartment, modules] of entries(sources)) {
-    for (const [module, content] of entries(modules)) {
-      const path = join(compartment, module);
+    const compartmentLocation = resolveLocation(
+      `${encodeURIComponent(compartment)}/`,
+      "file:///"
+    );
+    for (const { location, bytes } of values(modules)) {
+      const moduleLocation = resolveLocation(
+        encodeURIComponent(location),
+        compartmentLocation
+      );
+      const path = new URL(moduleLocation).pathname.slice(1); // elide initial "/"
       // eslint-disable-next-line no-await-in-loop
-      await archive.write(path, content);
+      await archive.write(path, bytes);
     }
   }
 };
@@ -125,21 +179,11 @@ export const makeArchive = async (read, moduleLocation) => {
   const { compartments, main } = compartmentMap;
 
   const sources = {};
-  const errors = [];
   const makeImportHook = makeRecordingImportHookMaker(
     read,
     packageLocation,
-    sources,
-    errors
+    sources
   );
-
-  if (errors.length > 0) {
-    throw new Error(
-      `Cannot assemble compartment for ${errors.length} reasons: ${errors.join(
-        ", "
-      )}`
-    );
-  }
 
   // Induce importHook to record all the necessary modules to import the given module specifier.
   const compartment = assemble({
@@ -151,7 +195,11 @@ export const makeArchive = async (read, moduleLocation) => {
   await compartment.load(moduleSpecifier);
 
   const renames = renameCompartments(compartments);
-  const renamedCompartments = renameCompartmentMap(compartments, renames);
+  const renamedCompartments = translateCompartmentMap(
+    compartments,
+    sources,
+    renames
+  );
   const renamedSources = renameSources(sources, renames);
 
   const manifest = {

--- a/packages/endo/src/import.js
+++ b/packages/endo/src/import.js
@@ -3,8 +3,12 @@
 import { compartmentMapForNodeModules } from "./compartmap.js";
 import { search } from "./search.js";
 import { assemble } from "./assemble.js";
+import { parseExtension } from "./extension.js";
 
 const decoder = new TextDecoder();
+
+// q, as in quote, for quoting strings in error messages.
+const q = JSON.stringify;
 
 const resolveLocation = (rel, abs) => new URL(rel, abs).toString();
 
@@ -15,14 +19,47 @@ const makeImportHookMaker = (read, baseLocation) => {
     packageLocation = resolveLocation(packageLocation, baseLocation);
     const importHook = async moduleSpecifier => {
       // per-module:
-      const moduleLocation = resolveLocation(moduleSpecifier, packageLocation);
-      const moduleBytes = await read(moduleLocation);
-      const moduleSource = decoder.decode(moduleBytes);
-      return parse(
-        moduleSource,
-        moduleSpecifier,
-        moduleLocation,
-        packageLocation
+
+      // Collate candidate locations for the moduleSpecifier per Node.js
+      // conventions.
+      const candidates = [];
+      if (moduleSpecifier === ".") {
+        candidates.push("index.js");
+      } else {
+        candidates.push(moduleSpecifier);
+        if (parseExtension(moduleSpecifier) === "") {
+          candidates.push(
+            `${moduleSpecifier}.js`,
+            `${moduleSpecifier}/index.js`
+          );
+        }
+      }
+
+      for (const candidate of candidates) {
+        const moduleLocation = resolveLocation(candidate, packageLocation);
+        // eslint-disable-next-line no-await-in-loop
+        const moduleBytes = await read(moduleLocation).catch(
+          _error => undefined
+        );
+        if (moduleBytes !== undefined) {
+          const moduleSource = decoder.decode(moduleBytes);
+
+          return parse(
+            moduleSource,
+            moduleSpecifier,
+            moduleLocation,
+            packageLocation
+          ).record;
+        }
+      }
+
+      // TODO offer breadcrumbs in the error message, or how to construct breadcrumbs with another tool.
+      throw new Error(
+        `Cannot find file for internal module ${q(
+          moduleSpecifier
+        )} (with candidates ${candidates
+          .map(q)
+          .join(", ")}) in package ${packageLocation}`
       );
     };
     return importHook;

--- a/packages/endo/src/module-map-hook.js
+++ b/packages/endo/src/module-map-hook.js
@@ -1,0 +1,58 @@
+const { entries } = Object;
+
+// For a full, absolute module specifier like "dependency",
+// produce the module specifier in the dependency, like ".".
+// For a deeper path like "@org/dep/aux" and a prefix like "@org/dep", produce
+// "./aux".
+const trimModuleSpecifierPrefix = (moduleSpecifier, prefix) => {
+  if (moduleSpecifier === prefix) {
+    return ".";
+  }
+  if (moduleSpecifier.startsWith(`${prefix}/`)) {
+    return `./${moduleSpecifier.slice(prefix.length + 1)}`;
+  }
+  return undefined;
+};
+
+// `makeModuleMapHook` generates a `moduleMapHook` for the `Compartment`
+// constructor, suitable for Node.js style packages where any module in the
+// package might be imported.
+// Since searching for all of these modules up front is either needlessly
+// costly (on a file system) or impossible (from a web service), we
+// let the import graph guide our search.
+// Any module specifier with an absolute prefix should be captured by
+// the `moduleMap` or `moduleMapHook`.
+export const makeModuleMapHook = (scopes, modules) => {
+  const moduleMapHook = moduleSpecifier => {
+    // Search for a scope that shares a prefix with the requested module
+    // specifier.
+    // This might be better with a trie, but only a benchmark on real-world
+    // data would tell us whether the additional complexity would translate to
+    // better performance, so this is left readable and presumed slow for now.
+    for (const [prefix, { compartment, compartmentName }] of entries(scopes)) {
+      const remainder = trimModuleSpecifierPrefix(moduleSpecifier, prefix);
+      if (remainder) {
+        // The following line is weird.
+        // Information is flowing backward.
+        // This moduleMapHook writes back to the `modules` descriptor, from the
+        // original compartment map.
+        // So the compartment map that was used to create the compartment
+        // assembly, can then be captured in an archive, obviating the need for
+        // a moduleMapHook when we assemble compartments from the resulting
+        // archiev.
+        modules[moduleSpecifier] = {
+          compartment: compartmentName,
+          module: remainder
+        };
+
+        return compartment.module(remainder);
+      }
+    }
+
+    // No entry in the module map.
+    // Compartments will fall through to their `importHook`.
+    return undefined;
+  };
+
+  return moduleMapHook;
+};

--- a/packages/endo/src/parse.js
+++ b/packages/endo/src/parse.js
@@ -12,7 +12,10 @@ const q = JSON.stringify;
 // verification.
 
 export const parseMjs = (source, _specifier, location, _packageLocation) => {
-  return new StaticModuleRecord(source, location);
+  return {
+    parser: "mjs",
+    record: new StaticModuleRecord(source, location)
+  };
 };
 
 export const parseCjs = (source, _specifier, location, packageLocation) => {
@@ -61,7 +64,10 @@ export const parseCjs = (source, _specifier, location, packageLocation) => {
       new URL("./", location).toString() // __dirname
     );
   };
-  return freeze({ imports, execute });
+  return {
+    parser: "cjs",
+    record: freeze({ imports, execute })
+  };
 };
 
 export const parseJson = (source, _specifier, location, _packageLocation) => {
@@ -75,7 +81,10 @@ export const parseJson = (source, _specifier, location, _packageLocation) => {
       );
     }
   };
-  return freeze({ imports, execute });
+  return {
+    parser: "json",
+    record: freeze({ imports, execute })
+  };
 };
 
 export const makeExtensionParser = (extensions, types) => {
@@ -96,7 +105,7 @@ export const makeExtensionParser = (extensions, types) => {
   };
 };
 
-const parserForLanguage = {
+export const parserForLanguage = {
   mjs: parseMjs,
   cjs: parseCjs,
   json: parseJson

--- a/packages/endo/src/zip.js
+++ b/packages/endo/src/zip.js
@@ -7,9 +7,9 @@ export const readZip = async (data, location) => {
   await zip.loadAsync(data);
   const read = async path => {
     const file = zip.file(path);
-    if (file === undefined) {
+    if (file === undefined || file === null) {
       throw new Error(
-        `Cannot find file to read ${path} in archive ${location}`
+        `Cannot find file to read ${path} in archive ${location || "<unknown>"}`
       );
     }
     return file.async("uint8array");

--- a/packages/endo/src/zip.js
+++ b/packages/endo/src/zip.js
@@ -7,7 +7,7 @@ export const readZip = async (data, location) => {
   await zip.loadAsync(data);
   const read = async path => {
     const file = zip.file(path);
-    if (file === undefined || file === null) {
+    if (!file) {
       throw new Error(
         `Cannot find file to read ${path} in archive ${location || "<unknown>"}`
       );

--- a/packages/endo/test/main.test.js
+++ b/packages/endo/test/main.test.js
@@ -29,6 +29,7 @@ const assertFixture = (t, namespace) => {
   const {
     avery,
     brooke,
+    clarke,
     builtin,
     endowed,
     typecommon,
@@ -38,6 +39,7 @@ const assertFixture = (t, namespace) => {
   } = namespace;
   t.equal(avery, "Avery", "exports avery");
   t.equal(brooke, "Brooke", "exports brooke");
+  t.equal(clarke, "Clarke", "exports clarke");
   t.equal(builtin, "builtin", "exports builtin");
   t.equal(endowed, endowments.endowment, "exports endowment");
   t.deepEqual(
@@ -58,7 +60,7 @@ const assertFixture = (t, namespace) => {
   t.equal(typehybrid, 42, "type=module and module= package carries exports");
 };
 
-const fixtureAssertionCount = 8;
+const fixtureAssertionCount = 9;
 
 // The "create builtin" test prepares a builtin module namespace object that
 // gets threaded into all subsequent tests to satisfy the "builtin" module

--- a/packages/endo/test/node_modules/clarke/TODO
+++ b/packages/endo/test/node_modules/clarke/TODO
@@ -1,2 +1,0 @@
-This case is not yet covered because the ability to infer ./index.js from an
-extensionless module specifier has not yet been implemented.

--- a/packages/endo/test/node_modules/danny/main.js
+++ b/packages/endo/test/node_modules/danny/main.js
@@ -9,5 +9,6 @@ export { typemodule, typecommon, typehybrid, typeparsers };
 
 export { avery } from 'avery';
 export { brooke } from 'brooke';
+export { clarke } from 'clarke';
 export { builtin } from 'builtin';
 export const endowed = endowment;

--- a/packages/endo/test/node_modules/danny/package.json
+++ b/packages/endo/test/node_modules/danny/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "avery": "^1.0.0",
     "brooke": "^1.0.0",
+    "clarke": "^1.0.0",
     "typecommon": "^1.0.0",
     "typemodule": "^1.0.0",
     "typehybrid": "^1.0.0",


### PR DESCRIPTION
When asked for a module named "x", Node.js will search for "x.js" then "x/index.js".

For packages that do not supply an "exports" property in their "package.json", any module contained by that package is a valid exported module.

To achieve parity with these two features, Endo uses different techniques when loading from the file system and loading from an archive.

When reading from the file system, Endo will search for a satsifactory candidate in each compartment's asynchronous importHook.  Endo also uses the compartment's new moduleMapHook to search for dependency compartments in the "scope" of a module identifier prefix.  These allow Endo to operate from an incomplete compartment map for the initial load.

The Endo archiver instead creates a more complete compartment map, with every discovered module.  This introduces a new kind of module to the compartment map module descriptor type union: modules with known locations and corresponding parsers.  The archiver erases the "scopes", "types", and "parsers" on each compartment description since they are no longer necessary.

When reading from an archive, Endo uses an importHook that consults the compartment map directly for the locations of all contained modules, and creates a complete moduleMap up front.