### PR TITLE
fix(endo): Do not URL encode compartment and path within archives

### DIFF
--- a/packages/endo/src/archive.js
+++ b/packages/endo/src/archive.js
@@ -73,15 +73,9 @@ const renameSources = (sources, renames) => {
 
 const addSourcesToArchive = async (archive, sources) => {
   for (const [compartment, modules] of entries(sources)) {
-    const compartmentLocation = resolveLocation(
-      `${encodeURIComponent(compartment)}/`,
-      "file:///"
-    );
+    const compartmentLocation = resolveLocation(`${compartment}/`, "file:///");
     for (const { location, bytes } of values(modules)) {
-      const moduleLocation = resolveLocation(
-        encodeURIComponent(location),
-        compartmentLocation
-      );
+      const moduleLocation = resolveLocation(location, compartmentLocation);
       const path = new URL(moduleLocation).pathname.slice(1); // elide initial "/"
       // eslint-disable-next-line no-await-in-loop
       await archive.write(path, bytes);


### PR DESCRIPTION
This broke the correspondence between locations in compartmap.json and what actually existed in a zip file. The cost of this change is the possibility of ambiguity for some special symbols in path components.