### PR TITLE
refactor(endo): Consolidate archive and import hooks

### DIFF
--- a/packages/endo/src/archive.js
+++ b/packages/endo/src/archive.js
@@ -2,90 +2,17 @@
 
 import { writeZip } from "./zip.js";
 import { resolve } from "./node-module-specifier.js";
-import { parseExtension } from "./extension.js";
 import { compartmentMapForNodeModules } from "./compartmap.js";
 import { search } from "./search.js";
 import { assemble } from "./assemble.js";
+import { makeImportHookMaker } from "./import-hook.js";
 import * as json from "./json.js";
 
-const { entries, freeze, fromEntries, values } = Object;
-
-// q, as in quote, for quoted strings in error messages.
-const q = JSON.stringify;
-
 const encoder = new TextEncoder();
-const decoder = new TextDecoder();
 
 const resolveLocation = (rel, abs) => new URL(rel, abs).toString();
 
-const makeRecordingImportHookMaker = (read, baseLocation, sources) => {
-  // per-assembly:
-  const makeImportHook = (packageLocation, parse) => {
-    // per-compartment:
-    packageLocation = resolveLocation(packageLocation, baseLocation);
-    const packageSources = sources[packageLocation] || {};
-    sources[packageLocation] = packageSources;
-
-    const importHook = async moduleSpecifier => {
-      // per-module:
-
-      // In Node.js, an absolute specifier always indicates a built-in or
-      // third-party dependency.
-      // The `moduleMapHook` captures all third-party dependencies.
-      if (moduleSpecifier !== "." && !moduleSpecifier.startsWith("./")) {
-        packageSources[moduleSpecifier] = {
-          exit: moduleSpecifier
-        };
-        // Return a place-holder.
-        // Archived compartments are not executed.
-        return freeze({ imports: [], execute() {} });
-      }
-
-      const candidates = [moduleSpecifier];
-      if (parseExtension(moduleSpecifier) === "") {
-        candidates.push(`${moduleSpecifier}.js`, `${moduleSpecifier}/index.js`);
-      }
-      for (const candidate of candidates) {
-        const moduleLocation = resolveLocation(candidate, packageLocation);
-        // eslint-disable-next-line no-await-in-loop
-        const moduleBytes = await read(moduleLocation).catch(
-          _error => undefined
-        );
-        if (moduleBytes !== undefined) {
-          const moduleSource = decoder.decode(moduleBytes);
-
-          const { record, parser } = parse(
-            moduleSource,
-            moduleSpecifier,
-            moduleLocation
-          );
-
-          const packageRelativeLocation = moduleLocation.slice(
-            packageLocation.length
-          );
-          packageSources[moduleSpecifier] = {
-            location: packageRelativeLocation,
-            parser,
-            bytes: moduleBytes
-          };
-
-          return record;
-        }
-      }
-
-      // TODO offer breadcrumbs in the error message, or how to construct breadcrumbs with another tool.
-      throw new Error(
-        `Cannot find file for internal module ${q(
-          moduleSpecifier
-        )} (with candidates ${candidates
-          .map(q)
-          .join(", ")}) in package ${packageLocation}`
-      );
-    };
-    return importHook;
-  };
-  return makeImportHook;
-};
+const { entries, fromEntries, values } = Object;
 
 const renameCompartments = compartments => {
   const renames = {};
@@ -182,11 +109,7 @@ export const makeArchive = async (read, moduleLocation) => {
   );
 
   const sources = {};
-  const makeImportHook = makeRecordingImportHookMaker(
-    read,
-    packageLocation,
-    sources
-  );
+  const makeImportHook = makeImportHookMaker(read, packageLocation, sources);
 
   // Induce importHook to record all the necessary modules to import the given module specifier.
   const compartment = assemble(compartmentMap, {

--- a/packages/endo/src/import-hook.js
+++ b/packages/endo/src/import-hook.js
@@ -1,0 +1,90 @@
+import { parseExtension } from "./extension.js";
+
+// q, as in quote, for quoting strings in error messages.
+const q = JSON.stringify;
+
+const decoder = new TextDecoder();
+
+const { freeze } = Object;
+
+const resolveLocation = (rel, abs) => new URL(rel, abs).toString();
+
+export const makeImportHookMaker = (read, baseLocation, sources = {}) => {
+  // per-assembly:
+  const makeImportHook = (packageLocation, parse) => {
+    // per-compartment:
+    packageLocation = resolveLocation(packageLocation, baseLocation);
+    const packageSources = sources[packageLocation] || {};
+    sources[packageLocation] = packageSources;
+
+    const importHook = async moduleSpecifier => {
+      // per-module:
+
+      // In Node.js, an absolute specifier always indicates a built-in or
+      // third-party dependency.
+      // The `moduleMapHook` captures all third-party dependencies.
+      if (moduleSpecifier !== "." && !moduleSpecifier.startsWith("./")) {
+        packageSources[moduleSpecifier] = {
+          exit: moduleSpecifier
+        };
+        // Return a place-holder.
+        // Archived compartments are not executed.
+        return freeze({ imports: [], execute() {} });
+      }
+
+      // Collate candidate locations for the moduleSpecifier per Node.js
+      // conventions.
+      const candidates = [];
+      if (moduleSpecifier === ".") {
+        candidates.push("index.js");
+      } else {
+        candidates.push(moduleSpecifier);
+        if (parseExtension(moduleSpecifier) === "") {
+          candidates.push(
+            `${moduleSpecifier}.js`,
+            `${moduleSpecifier}/index.js`
+          );
+        }
+      }
+
+      for (const candidate of candidates) {
+        const moduleLocation = resolveLocation(candidate, packageLocation);
+        // eslint-disable-next-line no-await-in-loop
+        const moduleBytes = await read(moduleLocation).catch(
+          _error => undefined
+        );
+        if (moduleBytes !== undefined) {
+          const moduleSource = decoder.decode(moduleBytes);
+
+          const { record, parser } = parse(
+            moduleSource,
+            moduleSpecifier,
+            moduleLocation,
+            packageLocation
+          );
+
+          const packageRelativeLocation = moduleLocation.slice(
+            packageLocation.length
+          );
+          packageSources[moduleSpecifier] = {
+            location: packageRelativeLocation,
+            parser,
+            bytes: moduleBytes
+          };
+          return record;
+        }
+      }
+
+      // TODO offer breadcrumbs in the error message, or how to construct breadcrumbs with another tool.
+      throw new Error(
+        `Cannot find file for internal module ${q(
+          moduleSpecifier
+        )} (with candidates ${candidates
+          .map(q)
+          .join(", ")}) in package ${packageLocation}`
+      );
+    };
+    return importHook;
+  };
+  return makeImportHook;
+};

--- a/packages/endo/src/import.js
+++ b/packages/endo/src/import.js
@@ -3,71 +3,8 @@
 import { compartmentMapForNodeModules } from "./compartmap.js";
 import { search } from "./search.js";
 import { assemble } from "./assemble.js";
-import { parseExtension } from "./extension.js";
+import { makeImportHookMaker } from "./import-hook.js";
 import * as json from "./json.js";
-
-const decoder = new TextDecoder();
-
-// q, as in quote, for quoting strings in error messages.
-const q = JSON.stringify;
-
-const resolveLocation = (rel, abs) => new URL(rel, abs).toString();
-
-const makeImportHookMaker = (read, baseLocation) => {
-  // per-assembly:
-  const makeImportHook = (packageLocation, parse) => {
-    // per-compartment:
-    packageLocation = resolveLocation(packageLocation, baseLocation);
-    const importHook = async moduleSpecifier => {
-      // per-module:
-
-      // Collate candidate locations for the moduleSpecifier per Node.js
-      // conventions.
-      const candidates = [];
-      if (moduleSpecifier === ".") {
-        candidates.push("index.js");
-      } else {
-        candidates.push(moduleSpecifier);
-        if (parseExtension(moduleSpecifier) === "") {
-          candidates.push(
-            `${moduleSpecifier}.js`,
-            `${moduleSpecifier}/index.js`
-          );
-        }
-      }
-
-      for (const candidate of candidates) {
-        const moduleLocation = resolveLocation(candidate, packageLocation);
-        // eslint-disable-next-line no-await-in-loop
-        const moduleBytes = await read(moduleLocation).catch(
-          _error => undefined
-        );
-        if (moduleBytes !== undefined) {
-          const moduleSource = decoder.decode(moduleBytes);
-
-          const { record } = parse(
-            moduleSource,
-            moduleSpecifier,
-            moduleLocation,
-            packageLocation
-          );
-          return record;
-        }
-      }
-
-      // TODO offer breadcrumbs in the error message, or how to construct breadcrumbs with another tool.
-      throw new Error(
-        `Cannot find file for internal module ${q(
-          moduleSpecifier
-        )} (with candidates ${candidates
-          .map(q)
-          .join(", ")}) in package ${packageLocation}`
-      );
-    };
-    return importHook;
-  };
-  return makeImportHook;
-};
 
 export const loadLocation = async (read, moduleLocation) => {
   const {


### PR DESCRIPTION
This change observes considerable duplication between the import hook for loading off the file system and recording a load off the file system for archives. This was conscionable when they were small, but searching for `index.js` complicates these. The side-effect of recording some metadata on the fly is okay for now. The records are immediately eligible for GC when running off the filesystem. This could be transformed to a system of hooks within hooks if it becomes problematic.