### PR TITLE
feat(ses): Carry compartment names in error messages

### DIFF
--- a/packages/endo/src/assemble.js
+++ b/packages/endo/src/assemble.js
@@ -161,7 +161,8 @@ export const assemble = (
     const compartment = new Compartment(endowments, exitModules, {
       resolveHook,
       importHook,
-      moduleMapHook
+      moduleMapHook,
+      name: location
     });
 
     compartments[compartmentName] = compartment;

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -2,7 +2,10 @@ User-visible changes in SES:
 
 ## Next release
 
-* No changes yet.
+* Adds the `name` option to the `Compartment` constructor and `name` accessor
+  to the `Compartment` prototype.
+  Errors that pass through a compartment may be annotated with the compartment
+  name.
 
 ## Release 0.10.2 (20-August-2020)
 

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -4,8 +4,10 @@ User-visible changes in SES:
 
 * Adds the `name` option to the `Compartment` constructor and `name` accessor
   to the `Compartment` prototype.
-  Errors that pass through a compartment may be annotated with the compartment
-  name.
+  Errors that propagate through the module loader will be rethrown anew with
+  the name of the module and compartment so they can be traced.
+  At this time, the intermediate stacks of the causal chain are lost.
+  https://github.com/Agoric/SES-shim/issues/440
 
 ## Release 0.10.2 (20-August-2020)
 

--- a/packages/ses/README.md
+++ b/packages/ses/README.md
@@ -149,6 +149,7 @@ The `importHook` accepts a full specifier and asynchronously returns a
 import 'ses';
 
 const c1 = new Compartment({}, {}, {
+  name: "first compartment",
   resolveHook: (moduleSpecifier, moduleReferrer) => {
     return resolve(moduleSpecifier, moduleReferrer);
   },
@@ -171,6 +172,7 @@ module map of another Compartment, creating a link.
 const c2 = new Compartment({}, {
   'c1': c1.module('./main.js'),
 }, {
+  name: "second compartment",
   resolveHook,
   importHook,
 });

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -94,8 +94,13 @@ const assertModuleHooks = compartment => {
 
 const CompartmentPrototype = {
   constructor: InertCompartment,
+
   get globalThis() {
     return privateFields.get(this).globalObject;
+  },
+
+  get name() {
+    return privateFields.get(this).name;
   },
 
   /**
@@ -204,6 +209,7 @@ export const makeCompartmentConstructor = (intrinsics, nativeBrander) => {
   function Compartment(endowments = {}, moduleMap = {}, options = {}) {
     // Extract options, and shallow-clone transforms.
     const {
+      name = '<unknown>',
       transforms = [],
       globalLexicals = {},
       resolveHook,
@@ -253,7 +259,7 @@ export const makeCompartmentConstructor = (intrinsics, nativeBrander) => {
     }
 
     const invalidNames = getOwnPropertyNames(globalLexicals).filter(
-      name => !isValidIdentifierName(name),
+      identifier => !isValidIdentifierName(identifier),
     );
     if (invalidNames.length) {
       throw new Error(
@@ -264,6 +270,7 @@ export const makeCompartmentConstructor = (intrinsics, nativeBrander) => {
     }
 
     privateFields.set(this, {
+      name,
       resolveHook,
       importHook,
       moduleMap,

--- a/packages/ses/src/module-load.js
+++ b/packages/ses/src/module-load.js
@@ -133,7 +133,10 @@ export const load = async (
     moduleSpecifier,
   ).catch(error => {
     const { name } = compartmentPrivateFields.get(compartment);
-    throw new Error(
+    // TODO The following drops the causes' stacks.
+    // In the future, we should capture the causal chain.
+    // https://github.com/Agoric/SES-shim/issues/440
+    throw new error.constructor(
       `${error.message}, loading ${q(moduleSpecifier)} in compartment ${q(
         name,
       )}`,

--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -1782,6 +1782,7 @@ export const whitelist = {
     constructor: '%InertCompartment%',
     evaluate: fn,
     globalThis: getter,
+    name: getter,
     import: asyncFn,
     load: asyncFn,
     importNow: fn,

--- a/packages/ses/test/compartment-instance.test.js
+++ b/packages/ses/test/compartment-instance.test.js
@@ -45,6 +45,7 @@ test('Compartment instance', t => {
       'importNow',
       'load',
       'module',
+      'name',
       'globalThis',
       'toString',
     ].sort(),

--- a/packages/ses/test/compartment-prototype.test.js
+++ b/packages/ses/test/compartment-prototype.test.js
@@ -21,6 +21,7 @@ test('Compartment prototype', t => {
       'importNow',
       'load',
       'module',
+      'name',
       'globalThis',
       'toString',
     ].sort(),


### PR DESCRIPTION
This is a follow-on from #431 which was accidentally reported as merged by Github, on the perception that it had merged into its feature branch, not onto the main branch. Review feedback captured in the second commit.