### PR TITLE
fix: Move NativeErrors list to whitelist.js

### DIFF
--- a/packages/ses/src/tame-error-constructor.js
+++ b/packages/ses/src/tame-error-constructor.js
@@ -5,16 +5,7 @@ import {
   setPrototypeOf,
 } from './commons.js';
 import { tameV8ErrorConstructor } from './tame-v8-error-constructor.js';
-
-// TODO where should this go?
-export const NativeErrors = [
-  EvalError,
-  RangeError,
-  ReferenceError,
-  SyntaxError,
-  TypeError,
-  URIError,
-];
+import { NativeErrors } from './whitelist.js';
 
 // Use concise methods to obtain named functions without constructors.
 const tamedMethods = {

--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -167,6 +167,17 @@ export const uniqueGlobalPropertyNames = {
   // 'Realm',
 };
 
+// All the "subclasses" of Error. These are collectively represented in the
+// EcmaScript spec by the meta variable NativeError.
+export const NativeErrors = [
+  EvalError,
+  RangeError,
+  ReferenceError,
+  SyntaxError,
+  TypeError,
+  URIError,
+];
+
 /**
  * <p>Each JSON record enumerates the disposition of the properties on
  *    some corresponding intrinsic object.


### PR DESCRIPTION
A more natural home for this list, especially if anything else reuses it. 

For example
https://github.com/Agoric/agoric-sdk/blob/c43a08fb1733596172a7dc5ca89353d837033e23/packages/marshal/marshal.js#L136-L144
duplicates this list. Once we move marshal.js into the SES-shim monorepo we should have it import NativeErrors to build this map.