### PR TITLE
fix: towards reconciling lint rules with agoric-sdk

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,25 +17,39 @@
     "BigInt": true
   },
   "rules": {
-    "complexity": ["error", 20],
     "implicit-arrow-linebreak": "off",
     "function-paren-newline": "off",
     "arrow-parens": "off",
     "strict": "off",
+    "prefer-destructuring": "off",
+    "no-else-return": "off",
+    "no-console": "off",
+    "no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
+      }
+    ],
+    "no-return-assign": "off",
+    "no-param-reassign": "off",
+    "no-restricted-syntax": [
+      "off",
+      "ForOfStatement"
+    ],
+    "no-unused-expressions": "off",
+    "no-loop-func": "off",
+    "no-inner-declarations": "off",
+    "import/prefer-default-export": "off",
+    "complexity": ["error", 20],
+    "max-classes-per-file": ["error", 5],
     "max-depth": ["error", { "max": 5 }],
     "max-lines": ["error", 400],
     "max-nested-callbacks": ["error", 4],
     "max-statements": ["error", 40],
-    "max-statements-per-line": ["error", { "max": 1 }],    "no-console": "off",
-    "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
-    "no-return-assign": "off",
-    "no-param-reassign": "off",
-    "no-restricted-syntax": ["off", "ForOfStatement"],
-    "no-unused-expressions": "off",
-    "no-loop-func": "off",
+    "max-statements-per-line": ["error", { "max": 1 }],
     "import/no-unresolved": "off",
     "import/extensions": "off",
-    "import/prefer-default-export": "off",
     "eslint-comments/no-unused-disable": "error"
   },
   "ignorePatterns": [

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -1,3 +1,5 @@
+// This module exports both Compartment and StaticModuleRecord because they
+// communicate through the moduleAnalyses private side-table.
 import {
   assign,
   create,

--- a/packages/ses/src/enable-property-overrides.js
+++ b/packages/ses/src/enable-property-overrides.js
@@ -43,12 +43,10 @@ export default function enablePropertyOverrides(intrinsics) {
 
       detachedProperties[path] = value;
 
-      // eslint-disable-next-line no-inner-declarations
       function getter() {
         return value;
       }
 
-      // eslint-disable-next-line no-inner-declarations
       function setter(newValue) {
         if (obj === this) {
           throw new TypeError(

--- a/packages/ses/src/tame-math-object.js
+++ b/packages/ses/src/tame-math-object.js
@@ -7,9 +7,6 @@ export default function tameMathObject(mathTaming = 'safe') {
   const originalMath = Math;
   const initialMath = originalMath; // to follow the naming pattern
 
-  // TODO I shouldn't need this eslint-disable for an ignored _ or variable
-  // name beginning with underbar.
-  // eslint-disable-next-line no-unused-vars
   const { random: _, ...otherDescriptors } = getOwnPropertyDescriptors(
     originalMath,
   );

--- a/packages/ses/test/property-override.test.js
+++ b/packages/ses/test/property-override.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable max-classes-per-file, no-inner-declarations */
 import test from 'tape';
 import '../ses.js';
 
@@ -139,5 +138,3 @@ test('packages in-the-wild', t => {
     t.end();
   }
 });
-
-/* eslint-enable max-classes-per-file, no-inner-declarations */


### PR DESCRIPTION
Added to SES-shim all lint rules it was missing from agoric-sdk.

Did not yet remove any lint rules that are only in SES-shim. We might want to propagate some of these back to agoric-sdk.