### PR TITLE
refactor(ses): Detangle shims from modules

### DIFF
--- a/packages/ses/lockdown.js
+++ b/packages/ses/lockdown.js
@@ -15,12 +15,23 @@
 // Importing the lower-layer "./lockdown.js" ensures that we run later and
 // replace its global lockdown if an application elects to import both.
 import { assign } from './src/commons.js';
+import { tameFunctionToString } from './src/tame-function-tostring.js';
+import { getGlobalIntrinsics } from './src/intrinsics.js';
 import { makeLockdown, harden } from './src/lockdown-shim.js';
 import {
   makeCompartmentConstructor,
   CompartmentPrototype,
-  Compartment,
 } from './src/compartment-shim.js';
+
+// TODO wasteful to do it twice, once before lockdown and again during
+// lockdown. The second is doubly indirect. We should at least flatten that.
+const nativeBrander = tameFunctionToString();
+
+const Compartment = makeCompartmentConstructor(
+  makeCompartmentConstructor,
+  getGlobalIntrinsics(globalThis),
+  nativeBrander,
+);
 
 assign(globalThis, {
   harden,

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -10,8 +10,6 @@ import { initGlobalObject } from './global-object.js';
 import { performEval } from './evaluate.js';
 import { isValidIdentifierName } from './scope-constants.js';
 import { sharedGlobalPropertyNames } from './whitelist.js';
-import { getGlobalIntrinsics } from './intrinsics.js';
-import { tameFunctionToString } from './tame-function-tostring.js';
 import { InertCompartment } from './inert.js';
 
 // privateFields captures the private state for each compartment.
@@ -153,13 +151,3 @@ export const makeCompartmentConstructor = (
 
   return Compartment;
 };
-
-// TODO wasteful to do it twice, once before lockdown and again during
-// lockdown. The second is doubly indirect. We should at least flatten that.
-const nativeBrander = tameFunctionToString();
-
-export const Compartment = makeCompartmentConstructor(
-  makeCompartmentConstructor,
-  getGlobalIntrinsics(globalThis),
-  nativeBrander,
-);

--- a/packages/ses/src/module-shim.js
+++ b/packages/ses/src/module-shim.js
@@ -13,8 +13,6 @@ import {
 import { load } from './module-load.js';
 import { link } from './module-link.js';
 import { getDeferredExports } from './module-proxy.js';
-import { getGlobalIntrinsics } from './intrinsics.js';
-import { tameFunctionToString } from './tame-function-tostring.js';
 import { InertCompartment, InertStaticModuleRecord } from './inert.js';
 import {
   CompartmentPrototype,
@@ -167,6 +165,8 @@ defineProperties(
   getOwnPropertyDescriptors(ModularCompartmentPrototypeExtension),
 );
 
+export { CompartmentPrototype };
+
 export const makeModularCompartmentConstructor = (
   targetMakeCompartmentConstructor,
   intrinsics,
@@ -247,20 +247,4 @@ export const makeModularCompartmentConstructor = (
   ModularCompartment.prototype = CompartmentPrototype;
 
   return ModularCompartment;
-};
-
-// TODO wasteful to do it twice, once before lockdown and again during
-// lockdown. The second is doubly indirect. We should at least flatten that.
-const nativeBrander = tameFunctionToString();
-
-export const ModularCompartment = makeModularCompartmentConstructor(
-  makeModularCompartmentConstructor,
-  getGlobalIntrinsics(globalThis),
-  nativeBrander,
-);
-
-export {
-  ModularCompartment as Compartment,
-  CompartmentPrototype,
-  makeModularCompartmentConstructor as makeCompartmentConstructor,
 };

--- a/packages/ses/test/break-function-eval.test.js
+++ b/packages/ses/test/break-function-eval.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import { Compartment } from '../src/compartment-shim.js';
+import '../lockdown.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/compartment-instance.test.js
+++ b/packages/ses/test/compartment-instance.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import { Compartment } from '../src/compartment-shim.js';
+import '../lockdown.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/compartment-prototype.test.js
+++ b/packages/ses/test/compartment-prototype.test.js
@@ -1,5 +1,5 @@
 import tap from 'tap';
-import { Compartment } from '../src/compartment-shim.js';
+import '../lockdown.js';
 
 const { test } = tap;
 

--- a/packages/ses/test/confinement.test.js
+++ b/packages/ses/test/confinement.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import { Compartment } from '../src/compartment-shim.js';
+import '../lockdown.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/global-object-mutability.test.js
+++ b/packages/ses/test/global-object-mutability.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import { Compartment } from '../src/compartment-shim.js';
+import '../lockdown.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;
@@ -10,8 +10,6 @@ test('globalObject properties mutable', t => {
 
   // Mimic repairFunctions.
   stubFunctionConstructors(sinon);
-
-  globalThis.Compartment = Compartment;
 
   const c = new Compartment();
 
@@ -27,7 +25,6 @@ test('globalObject properties mutable', t => {
   c.evaluate('Function = function() { this.extra = "extra" }');
   t.equal(c.evaluate('new Function().extra'), 'extra');
 
-  delete globalThis.Compartment;
   sinon.restore();
 });
 

--- a/packages/ses/test/global-object-properties.test.js
+++ b/packages/ses/test/global-object-properties.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import { Compartment } from '../src/compartment-shim.js';
+import '../lockdown.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/identity-continuity.test.js
+++ b/packages/ses/test/identity-continuity.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import { Compartment } from '../src/compartment-shim.js';
+import '../ses.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;
@@ -11,8 +11,6 @@ test('identity Array', t => {
 
   // Mimic repairFunctions.
   stubFunctionConstructors(sinon);
-
-  globalThis.Compartment = Compartment;
 
   const c1 = new Compartment();
   const c2 = new c1.globalThis.Compartment();
@@ -27,7 +25,6 @@ test('identity Array', t => {
   t.ok(a2 instanceof c1.globalThis.Array);
   t.ok(a2 instanceof c2.globalThis.Array);
 
-  delete globalThis.Compartment;
   sinon.restore();
 });
 
@@ -37,8 +34,6 @@ test('identity Compartment', t => {
 
   // Mimic repairFunctions.
   stubFunctionConstructors(sinon);
-
-  globalThis.Compartment = Compartment;
 
   const c1 = new Compartment();
   const c2 = new c1.globalThis.Compartment();
@@ -57,7 +52,6 @@ test('identity Compartment', t => {
   t.ok(e3 instanceof c1.globalThis.Compartment);
   t.ok(e3 instanceof c2.globalThis.Compartment);
 
-  delete globalThis.Compartment;
   sinon.restore();
   t.end();
 });
@@ -68,8 +62,6 @@ test('identity eval', t => {
 
   // Mimic repairFunctions.
   stubFunctionConstructors(sinon);
-
-  globalThis.Compartment = Compartment;
 
   const c1 = new Compartment();
   const c2 = new c1.globalThis.Compartment();
@@ -85,7 +77,6 @@ test('identity eval', t => {
   t.notEqual(c2.evaluate('eval'), eval);
   t.notEqual(c2.evaluate('eval'), c1.evaluate('eval'));
 
-  delete globalThis.Compartment;
   sinon.restore();
 });
 
@@ -95,8 +86,6 @@ test('identity Function', t => {
 
   // Mimic repairFunctions.
   stubFunctionConstructors(sinon);
-
-  globalThis.Compartment = Compartment;
 
   const c1 = new Compartment();
   const c2 = new c1.globalThis.Compartment();
@@ -117,6 +106,5 @@ test('identity Function', t => {
   t.ok(f2 instanceof c2.globalThis.Function);
   t.ok(f2 instanceof c3.globalThis.Function);
 
-  delete globalThis.Compartment;
   sinon.restore();
 });

--- a/packages/ses/test/import-gauntlet.test.js
+++ b/packages/ses/test/import-gauntlet.test.js
@@ -2,7 +2,7 @@
 // modules using a single Compartment.
 
 import tap from 'tap';
-import { Compartment } from '../src/module-shim.js';
+import '../ses.js';
 import { resolveNode, makeNodeImporter } from './node.js';
 
 const { test } = tap;

--- a/packages/ses/test/import-stack-traces.test.js
+++ b/packages/ses/test/import-stack-traces.test.js
@@ -1,5 +1,5 @@
 import tap from 'tap';
-import { Compartment } from '../src/module-shim.js';
+import '../ses.js';
 import { resolveNode, makeNodeImporter } from './node.js';
 
 const { test } = tap;

--- a/packages/ses/test/import.test.js
+++ b/packages/ses/test/import.test.js
@@ -4,7 +4,7 @@
 /* eslint max-lines: 0 */
 
 import tap from 'tap';
-import { Compartment } from '../src/module-shim.js';
+import '../ses.js';
 import { resolveNode, makeNodeImporter } from './node.js';
 import { makeImporter, makeStaticRetriever } from './import-commons.js';
 

--- a/packages/ses/test/module-compartment-instance.test.js
+++ b/packages/ses/test/module-compartment-instance.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import { Compartment } from '../src/module-shim.js';
+import '../ses.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/module-compartment-prototype.test.js
+++ b/packages/ses/test/module-compartment-prototype.test.js
@@ -1,5 +1,5 @@
 import tap from 'tap';
-import { Compartment } from '../src/module-shim.js';
+import '../ses.js';
 
 const { test } = tap;
 

--- a/packages/ses/test/reject-direct-eval.test.js
+++ b/packages/ses/test/reject-direct-eval.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import { Compartment } from '../src/compartment-shim.js';
+import '../lockdown.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/reject-html-comment.test.js
+++ b/packages/ses/test/reject-html-comment.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import { Compartment } from '../src/compartment-shim.js';
+import '../lockdown.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/reject-import-expression.test.js
+++ b/packages/ses/test/reject-import-expression.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import { Compartment } from '../src/compartment-shim.js';
+import '../lockdown.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test/typeof.test.js
+++ b/packages/ses/test/typeof.test.js
@@ -1,6 +1,6 @@
 import tap from 'tap';
 import sinon from 'sinon';
-import { Compartment } from '../src/compartment-shim.js';
+import '../lockdown.js';
 import stubFunctionConstructors from './stub-function-constructors.js';
 
 const { test } = tap;

--- a/packages/ses/test262/compartment-shim.js
+++ b/packages/ses/test262/compartment-shim.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import test262Runner from '@agoric/test262-runner';
-import { Compartment } from '../src/module-shim.js';
+import '../ses.js';
 
 export default function patchFunctionConstructors() {
   /* eslint-disable no-proto */


### PR DESCRIPTION
Following on the SES-lite change, this is a smaller change that moves code that modifies the environment out of `src` and into the two shim entry-points, to make the separation between these layers more clear.