### PR TITLE
refactor(transform-module): Rename module analysis

### DIFF
--- a/packages/transform-module/README.md
+++ b/packages/transform-module/README.md
@@ -14,8 +14,8 @@ record's metadata, evaluate the functor, call the functor with linkage.
 import { makeModuleAnalyzer } from './src/main.js';
 import * as babel from '@agoric/babel-standalone';
 const analyze = makeModuleAnalyzer(babel.default);
-const moduleStaticRecord = analyze(moduleSource);
-const moduleFunctor = evaluateModuleFunctor(moduleStaticRecord.functorSource, /* ... */);
+const moduleAnalysis = analyze(moduleSource);
+const moduleFunctor = evaluateModuleFunctor(moduleAnalysis.functorSource, /* ... */);
 moduleFunctor({
   imports(importedVariableUpdaters, exportAlls) { /* ... */ },
   liveVar: exportedVariableUpdaters,
@@ -124,11 +124,11 @@ to all modules that import the value.
 ```ts
 // This is the signature of the analyze function, after composing it
 // with Babel core.
-type Analyzer = ({string: ModuleSource}) => StaticModuleRecord
+type Analyzer = ({string: ModuleSource}) => ModuleAnalysis
 
 type ModuleSource = string
 
-type StaticModuleRecord = {
+type ModuleAnalysis = {
   exportAlls: ExportAlls,
   imports: Imports,
   liveExportMap: LiveExportMap,

--- a/packages/transform-module/src/main.js
+++ b/packages/transform-module/src/main.js
@@ -154,15 +154,14 @@ const makeCreateStaticRecord = transformSource =>
 })
 //# sourceURL=${url}`;
 
-    const moduleStaticRecord = freeze({
+    const moduleAnalysis = freeze({
       exportAlls: freeze(sourceOptions.exportAlls),
       imports: freeze(sourceOptions.imports),
       liveExportMap: freeze(sourceOptions.liveExportMap),
       fixedExportMap: freeze(sourceOptions.fixedExportMap),
       functorSource,
     });
-    // console.log(moduleStaticRecord);
-    return moduleStaticRecord;
+    return moduleAnalysis;
   };
 
 export const makeModuleAnalyzer = babel => {


### PR DESCRIPTION
This change makes transform-module's `moduleAnalysis` consistent with the term used in the SES module shim, which creates a `staticModuleRecord` from this internal representation.