### PR TITLE
refactor(compartment-mapper): Rename application execute to import

### DIFF
--- a/packages/compartment-mapper/README.md
+++ b/packages/compartment-mapper/README.md
@@ -352,7 +352,7 @@ The compartment map shape:
 // to run an application.
 type CompartmentMap = {
   tags: Tags,
-  main: CompartmentName,
+  entry: Entry,
   compartments: Object<CompartmentName, Compartment>,
   realms: Object<RealmName, Realm>, // TODO
 };
@@ -363,6 +363,9 @@ type CompartmentMap = {
 // module suitable for use in a browser environment.
 type Tags = Array<Tag>;
 type Tag = string;
+
+// Entry is a reference to the module that is the module to initially import.
+type Entry = CompartmentModule;
 
 // CompartmentName is an arbitrary string to name
 // a compartment for purposes of inter-compartment linkage.

--- a/packages/compartment-mapper/README.md
+++ b/packages/compartment-mapper/README.md
@@ -57,7 +57,7 @@ The `importLocation` function uses `loadLocation`.
 Using `loadLocation` directly allows for deferred execution or multiple runs
 with different endowments or modules in the same process.
 Calling `loadLocation` returns an `Application` object with an
-`execute(endowments?, modules?)` method.
+`import(endowments?, modules?)` method.
 
 Use `writeArchive` to capture an application in an archival format.
 Archives are `zip` files with a `compartment-map.json` manifest file.
@@ -110,7 +110,7 @@ Use `loadArchive` to defer execution or run multiple times with varying
 endowments.
 Use `parseArchive` to construct a runner from the bytes of an archive.
 The `loadArchive` and `parseArchive` functions return an `Application`
-object with an `execute(endowments?, modules?)` method.
+object with an `import(endowments?, modules?)` method.
 
 # Package Descriptors
 

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -21,7 +21,8 @@
     "lint": "eslint '**/*.js'",
     "lint-fix": "eslint --fix '**/*.js'",
     "prepublish": "yarn clean && yarn build",
-    "test": "yarn build && tap --no-esm --no-coverage --reporter spec 'test/**/*.test.js'"
+    "qt": "tap --no-esm --no-coverage --reporter spec 'test/**/*.test.js'",
+    "test": "yarn build && yarn qt"
   },
   "dependencies": {
     "@babel/parser": "^7.8.4",

--- a/packages/compartment-mapper/src/assemble.js
+++ b/packages/compartment-mapper/src/assemble.js
@@ -126,7 +126,7 @@ const makeModuleMapHook = (
 // Passes the given endowments and external modules into the root compartment
 // only.
 export const assemble = (
-  { main, compartments: compartmentDescriptors },
+  { entry, compartments: compartmentDescriptors },
   {
     makeImportHook,
     endowments = {},
@@ -134,6 +134,8 @@ export const assemble = (
     Compartment = defaultCompartment
   }
 ) => {
+  const { compartment: entryCompartmentName } = entry;
+
   const compartments = {};
   for (const [compartmentName, compartmentDescriptor] of entries(
     compartmentDescriptors
@@ -172,11 +174,11 @@ export const assemble = (
     compartments[compartmentName] = compartment;
   }
 
-  const compartment = compartments[main];
+  const compartment = compartments[entryCompartmentName];
   if (compartment === undefined) {
     throw new Error(
       `Cannot assemble compartment graph because the root compartment named ${q(
-        main
+        entryCompartmentName
       )} is missing from the compartment map`
     );
   }

--- a/packages/compartment-mapper/src/import-archive.js
+++ b/packages/compartment-mapper/src/import-archive.js
@@ -52,7 +52,7 @@ export const parseArchive = async (archiveBytes, archiveLocation) => {
     return compartment.import(moduleSpecifier);
   };
 
-  return { execute };
+  return { import: execute };
 };
 
 export const loadArchive = async (read, archiveLocation) => {
@@ -67,5 +67,5 @@ export const importArchive = async (
   modules
 ) => {
   const archive = await loadArchive(read, archiveLocation);
-  return archive.execute(endowments, modules);
+  return archive.import(endowments, modules);
 };

--- a/packages/compartment-mapper/src/import-archive.js
+++ b/packages/compartment-mapper/src/import-archive.js
@@ -39,7 +39,10 @@ export const parseArchive = async (archiveBytes, archiveLocation) => {
   const compartmentMap = json.parse(compartmentMapText, "compartment-map.json");
 
   const execute = (endowments, modules) => {
-    const { compartments, entry: moduleSpecifier } = compartmentMap;
+    const {
+      compartments,
+      entry: { module: moduleSpecifier }
+    } = compartmentMap;
     const makeImportHook = makeArchiveImportHookMaker(archive, compartments);
     const compartment = assemble(compartmentMap, {
       makeImportHook,

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -35,7 +35,7 @@ export const loadLocation = async (read, moduleLocation) => {
     return compartment.import(moduleSpecifier);
   };
 
-  return { execute };
+  return { import: execute };
 };
 
 export const importLocation = async (
@@ -45,5 +45,5 @@ export const importLocation = async (
   modules
 ) => {
   const application = await loadLocation(read, moduleLocation);
-  return application.execute(endowments, modules);
+  return application.import(endowments, modules);
 };

--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -240,7 +240,7 @@ const graphPackages = async (
 
 // translateGraph converts the graph returned by graph packages (above) into a
 // compartment map.
-const translateGraph = (mainPackagePath, graph) => {
+const translateGraph = (entryPackageLocation, entryModuleSpecifier, graph) => {
   const compartments = {};
 
   // For each package, build a map of all the external modules the package can
@@ -283,7 +283,10 @@ const translateGraph = (mainPackagePath, graph) => {
   }
 
   return {
-    main: mainPackagePath,
+    entry: {
+      compartment: entryPackageLocation,
+      module: entryModuleSpecifier
+    },
     compartments
   };
 };
@@ -292,7 +295,8 @@ export const compartmentMapForNodeModules = async (
   read,
   packageLocation,
   tags,
-  packageDescriptor
+  packageDescriptor,
+  moduleSpecifier
 ) => {
   const graph = await graphPackages(
     read,
@@ -300,5 +304,5 @@ export const compartmentMapForNodeModules = async (
     tags,
     packageDescriptor
   );
-  return translateGraph(packageLocation, graph);
+  return translateGraph(packageLocation, moduleSpecifier, graph);
 };

--- a/packages/compartment-mapper/test/main.test.js
+++ b/packages/compartment-mapper/test/main.test.js
@@ -77,7 +77,7 @@ let modules;
 
 test("create builtin", async t => {
   const utility = await loadLocation(read, builtinLocation);
-  const { namespace } = await utility.execute(endowments);
+  const { namespace } = await utility.import(endowments);
   // We pass the builtin module into the module map.
   modules = {
     builtin: namespace
@@ -89,7 +89,7 @@ test("loadLocation", async t => {
   t.plan(fixtureAssertionCount);
 
   const application = await loadLocation(read, fixture);
-  const { namespace } = await application.execute(endowments, modules);
+  const { namespace } = await application.import(endowments, modules);
   assertFixture(t, namespace);
 });
 
@@ -110,7 +110,7 @@ test("makeArchive / parseArchive", async t => {
 
   const archive = await makeArchive(read, fixture);
   const application = await parseArchive(archive);
-  const { namespace } = await application.execute(endowments, modules);
+  const { namespace } = await application.import(endowments, modules);
   assertFixture(t, namespace);
 });
 
@@ -130,7 +130,7 @@ test("writeArchive / loadArchive", async t => {
 
   await writeArchive(fakeWrite, read, "app.agar", fixture);
   const application = await loadArchive(fakeRead, "app.agar");
-  const { namespace } = await application.execute(endowments, modules);
+  const { namespace } = await application.import(endowments, modules);
   assertFixture(t, namespace);
 });
 


### PR DESCRIPTION
This change better aligns "applications" (compartments comprised of a
graph of linked peer compartments) with the Compartment type itself.