### PR TITLE
refactor: improve types for assert/console

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "useWorkspaces": true,
   "workspaces": ["packages/*"],
   "engines": {
-    "node": ">=13"
+    "node": ">=12.17.0"
   },
   "devDependencies": {
     "lerna": "^3.19.0",

--- a/packages/assert/exported.js
+++ b/packages/assert/exported.js
@@ -1,0 +1,1 @@
+import './src/types.js';

--- a/packages/assert/jsconfig.json
+++ b/packages/assert/jsconfig.json
@@ -1,0 +1,18 @@
+// This file can contain .js-specific Typescript compiler config.
+{
+  "compilerOptions": {
+    "target": "esnext",
+
+    "noEmit": true,
+/*
+    // The following flags are for creating .d.ts files:
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+*/
+    "downlevelIteration": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node",
+  },
+  "include": ["src/**/*.js", "exports.js"],
+}

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -11,6 +11,9 @@
   "unpkg": "./dist/assert.umd.js",
   "exports": {
     "./package.json": "./package.json",
+    "./src/assert": {
+      "import": "./src/assert.js"
+    },
     ".": {
       "import": "./src/assert.js",
       "require": "./dist/assert.cjs",

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -6,13 +6,17 @@
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/assert.cjs",
-  "module": "./src/main.js",
+  "module": "./src/assert.js",
   "browser": "./dist/assert.umd.js",
   "unpkg": "./dist/assert.umd.js",
   "exports": {
-    "import": "./src/main.js",
-    "require": "./dist/assert.cjs",
-    "browser": "./dist/assert.umd.js"
+    "./package.json": "./package.json",
+    ".": {
+      "import": "./src/assert.js",
+      "require": "./dist/assert.cjs",
+      "browser": "./dist/assert.umd.js"
+    },
+    "./exported": "./exported.js"
   },
   "scripts": {
     "build": "rollup --config rollup.config.js",

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -18,8 +18,9 @@
     "build": "rollup --config rollup.config.js",
     "clean": "rm -rf dist",
     "depcheck": "depcheck",
-    "lint": "eslint '**/*.js'",
-    "lint-fix": "eslint --fix '**/*.js'",
+    "lint": "yarn lint:types&&eslint '**/*.js'",
+    "lint:types": "tsc -p jsconfig.json",
+    "lint-fix": "yarn lint:types&&eslint --fix '**/*.js'",
     "prepublish": "yarn clean && yarn build",
     "test": "yarn build && tap --no-esm --no-coverage --reporter spec test/**/*.test.js"
   },

--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -27,7 +27,7 @@
     "depcheck": "depcheck",
     "lint": "yarn lint:types&&eslint '**/*.js'",
     "lint:types": "tsc -p jsconfig.json",
-    "lint-fix": "yarn lint:types&&eslint --fix '**/*.js'",
+    "lint-fix": "eslint --fix '**/*.js'&&yarn lint:types",
     "prepublish": "yarn clean && yarn build",
     "test": "yarn build && tap --no-esm --no-coverage --reporter spec test/**/*.test.js"
   },

--- a/packages/assert/rollup.config.js
+++ b/packages/assert/rollup.config.js
@@ -9,7 +9,7 @@ const umd = meta.umd || name;
 
 export default [
   {
-    input: 'src/main.js',
+    input: 'src/assert.js',
     output: [
       {
         file: `dist/${name}.mjs`,
@@ -23,7 +23,7 @@ export default [
     plugins: [resolve()],
   },
   {
-    input: 'src/main.js',
+    input: 'src/assert.js',
     output: {
       file: `dist/${name}.umd.js`,
       format: 'umd',
@@ -32,7 +32,7 @@ export default [
     plugins: [resolve()],
   },
   {
-    input: 'src/main.js',
+    input: 'src/assert.js',
     output: {
       file: `dist/${name}.umd.min.js`,
       format: 'umd',

--- a/packages/assert/src/assert.js
+++ b/packages/assert/src/assert.js
@@ -101,12 +101,10 @@ export { q };
 // /////////////////////////////////////////////////////////////////////////////
 
 /**
- * @enum {ErrorInfoKind}
+ * @type {ErrorInfo}
  */
 const ErrorInfo = {
-  // @ts-ignore TODO Why doesn't this type check?
   NOTE: 'ERROR_NOTE:',
-  // @ts-ignore TODO Why doesn't this type check?
   MESSAGE: 'ERROR_MESSAGE:',
 };
 freeze(ErrorInfo);
@@ -221,6 +219,10 @@ const details = (template, ...args) => {
     }
     return parts.join('');
   };
+  /**
+   * @param {Error} error
+   * @param {ErrorInfoKind} [errorInfoKind=ErrorInfo.NOTE]
+   */
   const annotate = (error, errorInfoKind = ErrorInfo.NOTE) => {
     logErrorInfoToConsole(console, error, errorInfoKind, getLogArgs);
   };

--- a/packages/assert/src/main.js
+++ b/packages/assert/src/main.js
@@ -1,5 +1,0 @@
-// TODO How do I export ./types.js ?
-// See TODO at top of console.js
-// import '@agoric/src/types';
-
-export * from './assert.js';

--- a/packages/assert/src/types.js
+++ b/packages/assert/src/types.js
@@ -1,7 +1,11 @@
 /// <reference types="ses"/>
 
 /**
- * @typedef { 'ERROR_NOTE:' | 'ERROR_MESSAGE:' } ErrorInfoKind
+ * @typedef {{ NOTE: 'ERROR_NOTE:', MESSAGE: 'ERROR_MESSAGE:' }} ErrorInfo
+ */
+
+/**
+ * @typedef {ErrorInfo[keyof ErrorInfo]} ErrorInfoKind
  */
 
 /**

--- a/packages/console/jsconfig.json
+++ b/packages/console/jsconfig.json
@@ -1,0 +1,18 @@
+// This file can contain .js-specific Typescript compiler config.
+{
+  "compilerOptions": {
+    "target": "esnext",
+
+    "noEmit": true,
+/*
+    // The following flags are for creating .d.ts files:
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+*/
+    "downlevelIteration": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node",
+  },
+  "include": ["src/**/*.js", "exports.js"],
+}

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "yarn lint:types&&eslint '**/*.js'",
     "lint:types": "tsc -p jsconfig.json",
-    "lint-fix": "eslint --fix '**/*.js'",
+    "lint-fix": "eslint --fix '**/*.js'&&yarn lint:types",
     "test": "tap --no-esm --no-coverage --reporter spec test/**/*.test.js"
   },
   "dependencies": {

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@agoric/console",
-  "private": true,
   "version": "0.1.0+1-dev",
   "description": "Virtualize the console to track causality.",
   "author": "Agoric",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -8,12 +8,13 @@
   "type": "module",
   "main": "./src/main.js",
   "scripts": {
-    "lint": "eslint '**/*.js'",
+    "lint": "yarn lint:types&&eslint '**/*.js'",
+    "lint:types": "tsc -p jsconfig.json",
     "lint-fix": "eslint --fix '**/*.js'",
     "test": "tap --no-esm --no-coverage --reporter spec test/**/*.test.js"
   },
   "dependencies": {
-    "@agoric/assert": "0.1.0"
+    "@agoric/assert": "^0.1.0"
   },
   "devDependencies": {
     "tap": "14.10.5",

--- a/packages/console/src/console.js
+++ b/packages/console/src/console.js
@@ -2,7 +2,6 @@
 
 import { ErrorInfo } from '@agoric/assert';
 
-// @ts-ignore fromEntries missing from Object type
 const { defineProperty, freeze, fromEntries } = Object;
 
 // For our internal debugging purposes, uncomment

--- a/packages/console/src/console.js
+++ b/packages/console/src/console.js
@@ -1,7 +1,12 @@
 // @ts-check
 
+// FIXME: We currently need to deep-link to the ESM version of the module.
+// Typescript ignores the package.json exports['.'].import and so uses "main",
+// which points to CJS.  That prevents Typescript from loading '@agoric/assert'
+// correctly.
 import { ErrorInfo } from '@agoric/assert/src/assert';
 import '@agoric/assert/exported';
+import './types.js';
 
 const { defineProperty, freeze, fromEntries } = Object;
 
@@ -92,7 +97,7 @@ export const consoleOmittedProperties = freeze([
  * @typedef {readonly [string, ...any[]]} LogRecord
  *
  * @typedef {Object} LoggingConsoleKit
- * @property {Partial<Console>} loggingConsole
+ * @property {LoggingConsole} loggingConsole
  * @property {() => readonly LogRecord[]} takeLog
  */
 
@@ -141,7 +146,9 @@ const makeLoggingConsoleKit = () => {
   };
   freeze(takeLog);
 
-  return freeze({ loggingConsole, takeLog });
+  const typedLoggingConsole = /** @type {LoggingConsole} */ (loggingConsole);
+
+  return freeze({ loggingConsole: typedLoggingConsole, takeLog });
 };
 freeze(makeLoggingConsoleKit);
 export { makeLoggingConsoleKit };

--- a/packages/console/src/console.js
+++ b/packages/console/src/console.js
@@ -1,6 +1,7 @@
 // @ts-check
 
-import { ErrorInfo } from '@agoric/assert';
+import { ErrorInfo } from '@agoric/assert/src/assert';
+import '@agoric/assert/exported';
 
 const { defineProperty, freeze, fromEntries } = Object;
 
@@ -91,7 +92,7 @@ export const consoleOmittedProperties = freeze([
  * @typedef {readonly [string, ...any[]]} LogRecord
  *
  * @typedef {Object} LoggingConsoleKit
- * @property {Console} loggingConsole
+ * @property {Partial<Console>} loggingConsole
  * @property {() => readonly LogRecord[]} takeLog
  */
 
@@ -205,8 +206,8 @@ const makeCausalConsole = (
    * @returns {ErrorInfoRecord[]}
    */
   const takeErrorInfos = error => {
-    if (errorInfos.has(error)) {
-      const result = errorInfos.get(error);
+    const result = errorInfos.get(error);
+    if (result) {
       errorInfos.delete(error);
       return result;
     }
@@ -320,8 +321,9 @@ const makeCausalConsole = (
       return;
     }
     const infoRecord = { kind, getLogArgs };
-    if (errorInfos.has(error)) {
-      errorInfos.get(error).push(infoRecord);
+    const ei = errorInfos.get(error);
+    if (ei) {
+      ei.push(infoRecord);
     } else {
       errorInfos.set(error, [infoRecord]);
     }

--- a/packages/console/src/types.js
+++ b/packages/console/src/types.js
@@ -1,0 +1,25 @@
+/**
+ * @typedef {Object} LoggingConsole
+ * @property {Console['debug']} debug
+ * @property {Console['error']} error
+ * @property {Console['info']} info
+ * @property {Console['log']} log
+ * @property {Console['warn']} warn
+ * @property {Console['assert']} assert
+ * @property {Console['clear']} clear
+ * @property {Console['table']} table
+ * @property {Console['trace']} trace
+ * @property {Console['dir']} dir
+ * @property {Console['dirxml']} dirxml
+ * @property {Console['count']} count
+ * @property {Console['countReset']} countReset
+ * @property {Console['group']} group
+ * @property {Console['groupCollapsed']} groupCollapsed
+ * @property {Console['groupEnd']} groupEnd
+ * @property {Console['time']} time
+ * @property {Console['timeLog']} timeLog
+ * @property {Console['timeEnd']} timeEnd
+ * @property {Console['profile']} profile
+ * @property {Console['profileEnd']} profileEnd
+ * @property {Console['timeStamp']} timeStamp
+ */

--- a/yarn.lock
+++ b/yarn.lock
@@ -11064,11 +11064,6 @@ typescript@^3.7.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
-typescript@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
-  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
-
 uglify-js@^3.1.4:
   version "3.10.3"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.10.3.tgz#f0d2f99736c14de46d2d24649ba328be3e71c3bf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9777,7 +9777,9 @@ serve-static@^1.12.4:
 "ses@file:packages/ses":
   version "0.10.2"
   dependencies:
+    "@agoric/assert" "0.1.0"
     "@agoric/babel-standalone" "^7.9.5"
+    "@agoric/console" "~0.1.0"
     "@agoric/make-hardener" "^0.1.0"
     "@agoric/transform-module" "^0.4.1"
 
@@ -11061,6 +11063,11 @@ typescript@^3.7.2:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+
+typescript@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 uglify-js@^3.1.4:
   version "3.10.3"


### PR DESCRIPTION
This contains several fixes to avoid `@ts-ignore`s.

Merging with #447.
