### PR TITLE
chore: test with same Node.js as agoric-sdk (supported for AVA)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.17.0, 12.x, 14.x]
 
     steps:
 
@@ -113,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.17.0, 12.x, 14.x]
 
     steps:
 
@@ -158,7 +158,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.17.0, 12.x, 14.x]
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [13.x]
+        node-version: [12.x]
 
     steps:
 
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [13.x]
+        node-version: [12.x, 14.x]
 
     steps:
 
@@ -113,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [13.x]
+        node-version: [12.x, 14.x]
 
     steps:
 
@@ -158,7 +158,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [13.x]
+        node-version: [12.x, 14.x]
 
     steps:
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "name": "SES",
   "private": true,
   "useWorkspaces": true,
-  "workspaces": ["packages/*"],
+  "workspaces": [
+    "packages/*"
+  ],
   "engines": {
-    "node": ">=13"
+    "node": ">=12.14.1"
   },
   "devDependencies": {
     "lerna": "^3.19.0",
@@ -20,5 +22,8 @@
     "test": "lerna run test",
     "test262": "lerna run test262",
     "build": "lerna run build"
+  },
+  "dependencies": {
+    "typescript": "^4.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "packages/*"
   ],
   "engines": {
-    "node": ">=12.14.1"
+    "node": ">=12.17.0"
   },
   "devDependencies": {
     "lerna": "^3.19.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "devDependencies": {
     "lerna": "^3.19.0",
-    "lerna-update-wizard": "^0.17.5"
+    "lerna-update-wizard": "^0.17.5",
+    "typescript": "^4.0.2"
   },
   "scripts": {
     "clean": "lerna clean",
@@ -22,8 +23,5 @@
     "test": "lerna run test",
     "test262": "lerna run test262",
     "build": "lerna run build"
-  },
-  "dependencies": {
-    "typescript": "^4.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10918,6 +10918,11 @@ typescript@^3.7.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
+typescript@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
+
 uglify-js@^3.1.4:
   version "3.10.3"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.10.3.tgz#f0d2f99736c14de46d2d24649ba328be3e71c3bf"


### PR DESCRIPTION
@kriskowal is there a reason why the `"engine"` field was set to `">13.0.0"`?

We should not be gratuitously incompatible.
