### PR TITLE
Declare global lockdown and Compartment in TypeScript declaration

### DIFF
--- a/packages/ses/index.d.ts
+++ b/packages/ses/index.d.ts
@@ -5,6 +5,9 @@ type Harden = <T>(x: T) => T;
 
 declare var harden: Harden;
 
-namespace global {
-  declare var harden: Harden;
+declare function lockdown(): void;
+
+declare class Compartment {
+  constructor(intrinsics?: Record<string, any>);
+  evaluate<A = any>(code: string): A;
 }


### PR DESCRIPTION
Also, current `namespace global` declaration breaks TypeScript compilation. This one works all right.