### PR TITLE
fix(compartment-mapper): Withdraw UMD Rollup

### DIFF
--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -7,12 +7,9 @@
   "type": "module",
   "main": "./dist/compartment-mapper.cjs",
   "module": "./src/main.js",
-  "browser": "./dist/compartment-mapper.umd.js",
-  "unpkg": "./dist/compartment-mapper.umd.js",
   "exports": {
     "import": "./src/main.js",
-    "require": "./dist/compartment-mapper.cjs",
-    "browser": "./dist/compartment-mapper.umd.js"
+    "require": "./dist/compartment-mapper.cjs"
   },
   "scripts": {
     "build": "rollup --config rollup.config.js",
@@ -33,14 +30,14 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-json": "^4.1.0",
-    "@rollup/plugin-node-resolve": "^6.1.0",
+    "@rollup/plugin-node-resolve": "^9.0.0",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-prettier": "^3.1.2",
-    "rollup-plugin-terser": "^5.1.3",
+    "rollup": "^2.0.0",
     "tap": "^14.10.5",
     "tape": "^4.12.1"
   },

--- a/packages/compartment-mapper/rollup.config.js
+++ b/packages/compartment-mapper/rollup.config.js
@@ -1,45 +1,25 @@
 import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
-import { terser } from "rollup-plugin-terser";
 import fs from "fs";
 
 const metaPath = new URL("package.json", import.meta.url).pathname;
 const meta = JSON.parse(fs.readFileSync(metaPath, "utf-8"));
 const name = meta.name.split("/").pop();
-const umd = meta.umd || name;
+
+const resolveWithBuiltins = () => resolve({ preferBuiltins: true });
+const external = ["buffer", "events", "os", "stream", "tty", "util"];
 
 export default [
   {
     input: "src/main.js",
     output: [
       {
-        file: `dist/${name}.mjs`,
-        format: "esm"
-      },
-      {
         file: `dist/${name}.cjs`,
         format: "cjs"
       }
     ],
-    plugins: [resolve(), commonjs(), json()]
-  },
-  {
-    input: "src/main.js",
-    output: {
-      file: `dist/${name}.umd.js`,
-      format: "umd",
-      name: umd
-    },
-    plugins: [resolve(), commonjs(), json()]
-  },
-  {
-    input: "src/main.js",
-    output: {
-      file: `dist/${name}.umd.min.js`,
-      format: "umd",
-      name: umd
-    },
-    plugins: [resolve(), terser(), commonjs(), json()]
+    external,
+    plugins: [resolveWithBuiltins(), commonjs(), json()]
   }
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1904,7 +1904,19 @@
     is-module "^1.0.0"
     resolve "^1.11.1"
 
-"@rollup/pluginutils@^3.0.0", "@rollup/pluginutils@^3.0.8":
+"@rollup/plugin-node-resolve@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-9.0.0.tgz#39bd0034ce9126b39c1699695f440b4b7d2b62e6"
+  integrity sha512-gPz+utFHLRrd41WMP13Jq5mqqzHL3OXrfj3/MkSyB6UBIcuNt9j60GCbarzMzdf1VHFpOxfQh/ez7wyadLMqkg==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
+    builtin-modules "^3.1.0"
+    deepmerge "^4.2.2"
+    is-module "^1.0.0"
+    resolve "^1.17.0"
+
+"@rollup/pluginutils@^3.0.0", "@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
   integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
@@ -2012,6 +2024,13 @@
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
   integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
+  dependencies:
+    "@types/node" "*"
+
+"@types/resolve@1.17.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
+  integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
   dependencies:
     "@types/node" "*"
 
@@ -4078,6 +4097,11 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
 default-require-extensions@^2.0.0:
   version "2.0.0"
@@ -9632,6 +9656,13 @@ rollup@1.31.0:
     "@types/estree" "*"
     "@types/node" "*"
     acorn "^7.1.0"
+
+rollup@^2.0.0:
+  version "2.28.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.28.1.tgz#ceedca3cdb013c2fa8f22f958a29c203368159ea"
+  integrity sha512-DOtVoqOZt3+FjPJWLU8hDIvBjUylc9s6IZvy76XklxzcLvAQLtVAG/bbhsMhcWnYxC0TKKcf1QQ/tg29zeID0Q==
+  optionalDependencies:
+    fsevents "~2.1.2"
 
 run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"


### PR DESCRIPTION
We have no coherent story for threading UMD dependencies on Node.js built-in modules.

We also have a mystery as to why Rollup feels that it needs to link any Node.js built-in modules.  The dependencies may be coming from using Babel parser and translate.