### PR TITLE
fix(ses): Fix lockdown layer pollution from module layer

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -2,7 +2,8 @@ User-visible changes in SES:
 
 ## Next release
 
-* No changes yet.
+* Fixes an exception thrown when calling `lockdown` after just importing
+  `ses/lockdown` in all environments.
 
 ## Release 0.10.3 (8-September-2020)
 

--- a/packages/ses/lockdown.js
+++ b/packages/ses/lockdown.js
@@ -17,6 +17,7 @@
 import { assign } from './src/commons.js';
 import { tameFunctionToString } from './src/tame-function-tostring.js';
 import { getGlobalIntrinsics } from './src/intrinsics.js';
+import { getAnonymousIntrinsics } from './src/get-anonymous-intrinsics.js';
 import { makeLockdown, harden } from './src/lockdown-shim.js';
 import {
   makeCompartmentConstructor,
@@ -35,6 +36,10 @@ const Compartment = makeCompartmentConstructor(
 
 assign(globalThis, {
   harden,
-  lockdown: makeLockdown(makeCompartmentConstructor, CompartmentPrototype),
+  lockdown: makeLockdown(
+    makeCompartmentConstructor,
+    CompartmentPrototype,
+    getAnonymousIntrinsics,
+  ),
   Compartment,
 });

--- a/packages/ses/ses.js
+++ b/packages/ses/ses.js
@@ -15,6 +15,7 @@
 import { assign } from './src/commons.js';
 import { tameFunctionToString } from './src/tame-function-tostring.js';
 import { getGlobalIntrinsics } from './src/intrinsics.js';
+import { getModularAnonymousIntrinsics } from './src/get-anonymous-intrinsics.js';
 import { makeLockdown, harden } from './src/lockdown-shim.js';
 import { whitelist, modulesWhitelist } from './src/whitelist.js';
 import {
@@ -40,6 +41,7 @@ assign(globalThis, {
   lockdown: makeLockdown(
     makeModularCompartmentConstructor,
     CompartmentPrototype,
+    getModularAnonymousIntrinsics,
   ),
   Compartment: ModularCompartment,
   StaticModuleRecord,

--- a/packages/ses/src/get-anonymous-intrinsics.js
+++ b/packages/ses/src/get-anonymous-intrinsics.js
@@ -108,8 +108,14 @@ export function getAnonymousIntrinsics() {
     '%ThrowTypeError%': ThrowTypeError,
     '%TypedArray%': TypedArray,
     '%InertCompartment%': InertCompartment,
-    '%InertStaticModuleRecord%': InertStaticModuleRecord,
   };
 
   return intrinsics;
+}
+
+export function getModularAnonymousIntrinsics() {
+  return {
+    ...getAnonymousIntrinsics(),
+    '%InertStaticModuleRecord%': InertStaticModuleRecord,
+  };
 }

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -27,7 +27,6 @@ import tameMathObject from './tame-math-object.js';
 import tameRegExpConstructor from './tame-regexp-constructor.js';
 import enablePropertyOverrides from './enable-property-overrides.js';
 import tameLocaleMethods from './tame-locale-methods.js';
-import { getAnonymousIntrinsics } from './get-anonymous-intrinsics.js';
 import { initGlobalObject } from './global-object.js';
 import { initialGlobalPropertyNames } from './whitelist.js';
 import { tameFunctionToString } from './tame-function-tostring.js';
@@ -52,6 +51,7 @@ const alreadyHardenedIntrinsics = () => false;
 export function repairIntrinsics(
   makeCompartmentConstructor,
   compartmentPrototype,
+  getAnonymousIntrinsics,
   options = {},
 ) {
   // First time, absent options default to 'safe'.
@@ -176,11 +176,13 @@ export function repairIntrinsics(
 export const makeLockdown = (
   makeCompartmentConstructor,
   compartmentPrototype,
+  getAnonymousIntrinsics,
 ) => {
   const lockdown = (options = {}) => {
     const maybeHardenIntrinsics = repairIntrinsics(
       makeCompartmentConstructor,
       compartmentPrototype,
+      getAnonymousIntrinsics,
       options,
     );
     return maybeHardenIntrinsics();

--- a/packages/ses/test/compartment-prototype.test.js
+++ b/packages/ses/test/compartment-prototype.test.js
@@ -1,6 +1,8 @@
 import tap from 'tap';
 import '../lockdown.js';
 
+lockdown({ errorTaming: 'unsafe' });
+
 const { test } = tap;
 
 test('Compartment prototype', t => {

--- a/packages/ses/test/lockdown-options.test.js
+++ b/packages/ses/test/lockdown-options.test.js
@@ -1,7 +1,16 @@
 import test from 'tape';
 import { makeLockdown } from '../src/lockdown-shim.js';
+import { getAnonymousIntrinsics } from '../src/get-anonymous-intrinsics.js';
+import {
+  makeCompartmentConstructor,
+  CompartmentPrototype,
+} from '../src/compartment-shim.js';
 
-const lockdown = makeLockdown();
+const lockdown = makeLockdown(
+  makeCompartmentConstructor,
+  CompartmentPrototype,
+  getAnonymousIntrinsics,
+);
 
 test('lockdown throws with non-recognized options', t => {
   t.plan(2);

--- a/packages/ses/test/whitelist-intrinsics.test.js
+++ b/packages/ses/test/whitelist-intrinsics.test.js
@@ -1,6 +1,7 @@
 import tap from 'tap';
 import '../ses.js';
 import { repairIntrinsics } from '../src/lockdown-shim.js';
+import { getModularAnonymousIntrinsics } from '../src/get-anonymous-intrinsics.js';
 import {
   makeCompartmentConstructor,
   CompartmentPrototype,
@@ -28,6 +29,7 @@ test('whitelistPrototypes - on', t => {
   const hardenIntrinsics = repairIntrinsics(
     makeCompartmentConstructor,
     CompartmentPrototype,
+    getModularAnonymousIntrinsics,
   );
   console.timeEnd('Benchmark repairIntrinsics()');
 


### PR DESCRIPTION
This change divides the anonymous intrinsics into the lockdown+compartment and compartment+module layers.

Fixes #467 
