### PR TITLE
fix: no more detached properties

### DIFF
--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -153,12 +153,11 @@ export function repairIntrinsics(
 
   function hardenIntrinsics() {
     // Circumvent the override mistake.
-    const detachedProperties = enablePropertyOverrides(intrinsics);
+    enablePropertyOverrides(intrinsics);
 
     // Finally register and optionally freeze all the intrinsics. This
     // must be the operation that modifies the intrinsics.
     lockdownHarden(intrinsics);
-    lockdownHarden(detachedProperties);
 
     // Having completed lockdown without failing, the user may now
     // call `harden` and expect the object's transitively accessible properties

--- a/packages/ses/test/frozen-primordials.test.js
+++ b/packages/ses/test/frozen-primordials.test.js
@@ -1,0 +1,21 @@
+import test from 'tape';
+import '../lockdown.js';
+import { getOwnPropertyDescriptor } from '../src/commons.js';
+
+const originalValueSymbol = Symbol.for('originalValue');
+
+test('check if override-protected primordials are frozen', t => {
+  lockdown();
+
+  // After removing the detachedProperties mechanism and before adding
+  // the originalValueSymbol mechanism, this test failed.
+  t.ok(Object.isFrozen(Object.prototype.toString));
+
+  // Just checking that reconstruction produces the *same* symbol
+  t.equals(originalValueSymbol, Symbol.for('originalValue'));
+
+  const desc = getOwnPropertyDescriptor(Object.prototype, 'toString');
+  t.equals(desc.get[originalValueSymbol], Object.prototype.toString);
+
+  t.end();
+});


### PR DESCRIPTION
Addresses https://github.com/ljharb/object.assign/issues/79 . Attn @ljharb . Please feel free to leave review comments. Question for you at the bottom of this note.

This reverts the enable-property-override mechanism to stop using the detached-properties mechanism and instead go back to the original strategy --- putting the original value on an own property of the getter function of the new accessor. However, rather than name this extra property `.value` as Caja did, we name it with the registered symbol `Symbol.for('originalValue')`. We export this symbol, but we also make it a registered symbol so it can be used by reconstructing it rather than importing it. By exposing the original value on any own property, `harden` still finds it and its transitive walk proceeds.

We give the property an obscure but reconstructible name so code like
https://github.com/ljharb/es-abstract/blob/0089955ffac420870f95e517d7fa8592afa17094/GetIntrinsic.js#L266

```js
value = isOwn ? desc.get || desc.value : value[part];
```
which is the cause of https://github.com/ljharb/object.assign/issues/79 , could be changed to the following. I write it out the long way with nested ifs just to make it clear. Recovering some of the brevity of the original is left as an exercise...

```js
//either
import { originalValueSymbol } from 'something/enable-property-overrides';
//or
const originalValueSymbol = Symbol.for('originalValue');

if (isOwn) {
  const getter = desc.get;
  if (getter) {
    if (originalValueSymbol in getter) {
      // either
      value = getter[originalValueSymbol];
      // or
      value = value[part];
      // or
      value = getter();
    } else {
      value = getter;
    }
  } else {
    value = desc.value;
  }
} else {
  value = value[part];
}
```

@ljharb, once this PR is merged and deployed, would you be willing to adapt the above pattern in order to solve https://github.com/ljharb/object.assign/issues/79 ?