### PR TITLE
fix: remove "apply" from enablements whitelist

### DIFF
--- a/packages/ses/src/enablements.js
+++ b/packages/ses/src/enablements.js
@@ -64,7 +64,6 @@ export default {
   '%FunctionPrototype%': {
     constructor: true, // set by "regenerator-runtime"
     bind: true, // set by "underscore"
-    apply: true, // set by "tape"
     name: true,
     toString: true,
   },

--- a/packages/ses/test/enable-property-overrides.test.js
+++ b/packages/ses/test/enable-property-overrides.test.js
@@ -83,7 +83,6 @@ test('enablePropertyOverrides - on', t => {
     'constructor',
     // 'name', // TODO
     'bind',
-    'apply',
     'toString',
   ]);
   testOverriding(t, 'Error', new Error(), [


### PR DESCRIPTION
Fixes #474 

Removes `Function.prototype.apply` from the enablements whitelist, of properties that need the override mistake fixed. This particular entry said it was because `tape` broke. But @ljharb , the maintainer of tape, said that it should not have a problem with `apply`. After removing it, our existing tests work just fine. But (question for reviewers) do any of them use tape in a way that would detect a remaining problem if there is one?