### PR TITLE
Suppress override mistake with `originalValue` on getter

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -2,6 +2,12 @@ User-visible changes in SES:
 
 ## Next release
 
+* When converting each of [these data properties](src/enablements.js) to
+  accessor properties, to suppress the
+  [override mistake](https://github.com/tc39/ecma262/pull/1320), we now
+  add to that accessor's getter an `originalValue` property to mark it
+  as alleging that it is emulating a data property whose original value
+  was that value.
 * Fixes an exception thrown when calling `lockdown` after just importing
   `ses/lockdown` in all environments.
 
@@ -38,7 +44,7 @@ User-visible changes in SES:
   https://github.com/tc39/proposal-eventual-send.
 * Corrects our fix for the override mistake, so that it correctly emulates
   how assignment would work in the absence of the override mistake.
-  A property created by assignment will now be a writable, enumerable, 
+  A property created by assignment will now be a writable, enumerable,
   configurable data property, as it is for normal assignment.
 
 ## Release 0.10.0 (8-August-2020)

--- a/packages/ses/README.md
+++ b/packages/ses/README.md
@@ -272,6 +272,21 @@ The compartment will call `execute` with:
 method of third-party static module records to return promises, to support
 top-level await.
 
+### Imperfect emulation
+
+JavaScript suffers from the so-called
+[override mistake](https://web.archive.org/web/20141230041441/http://wiki.ecmascript.org/doku.php?id=strawman:fixing_override_mistake),
+which prevents lockdown from *simply* hardening all the primordials. Rather,
+for each of
+[these data properties](src/enablements.js), we convert it to an accessor
+property whose getter and setter emulate [a data property without the override
+mistake](https://github.com/tc39/ecma262/pull/1320). For non-reflective code
+the illusion is perfect. But reflective code sees that it is an accessor
+rather than a data property. We add a `originalValue` property to the getter
+of that accessor, letting reflective code know that a getter alleges that it
+results from this transform, and what the original data value was. This enables
+a form of cooperative emulation, where that code can decide whether to uphold
+the illusion by pretending it sees the data property that would have been there.
 
 ## Bug Disclosure
 

--- a/packages/ses/test/frozen-primordials.test.js
+++ b/packages/ses/test/frozen-primordials.test.js
@@ -6,11 +6,11 @@ test('check if override-protected primordials are frozen', t => {
   lockdown();
 
   // After removing the detachedProperties mechanism and without
-  // the originalDataPropertyValue mechanism, this test failed.
+  // the originalValue mechanism, this test failed.
   t.ok(Object.isFrozen(Object.prototype.toString));
 
   const desc = getOwnPropertyDescriptor(Object.prototype, 'toString');
-  t.equals(desc.get.originalDataPropertyValue, Object.prototype.toString);
+  t.equals(desc.get.originalValue, Object.prototype.toString);
 
   t.end();
 });


### PR DESCRIPTION
Rename `originalDataPropertyValue` to `originalValue`.

Explain in README and NEWS.