### PR TITLE
compartment-mapper: Thread transforms through import options bag

### DIFF
--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -2,6 +2,9 @@ User-visible changes to the compartment mapper:
 
 ## Next release
 
+* *BREAKING*: All `import` methods now take an options bag that may contain
+  `globals` and `modules` options if present, instead of these as positional
+  arguments.
 * Threads transforms through to underlying compartments.
 
 ## Release 0.1.0 (2020-09-21)

--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -2,7 +2,7 @@ User-visible changes to the compartment mapper:
 
 ## Next release
 
-* No changes yet.
+* Threads transforms through to underlying compartments.
 
 ## Release 0.1.0 (2020-09-21)
 

--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -7,6 +7,8 @@ User-visible changes to the compartment mapper:
   arguments.
 * The `import` options bag now also accepts `globalLexicals` and `transforms`,
   passing these without alteration to each `Compartment`.
+* The `import` options bag now also accepts a `Compartment` constructor, to use
+  instead of the one assumed to be present globally.
 
 ## Release 0.1.0 (2020-09-21)
 

--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -5,7 +5,8 @@ User-visible changes to the compartment mapper:
 * *BREAKING*: All `import` methods now take an options bag that may contain
   `globals` and `modules` options if present, instead of these as positional
   arguments.
-* Threads transforms through to underlying compartments.
+* The `import` options bag now also accepts `globalLexicals` and `transforms`,
+  passing these without alteration to each `Compartment`.
 
 ## Release 0.1.0 (2020-09-21)
 

--- a/packages/compartment-mapper/README.md
+++ b/packages/compartment-mapper/README.md
@@ -33,8 +33,10 @@ const read = async location =>
 const { namespace } = await importLocation(
   read,
   moduleLocation,
-  endowments,
-  modules
+  {
+    endowments,
+    modules
+  }
 );
 ```
 
@@ -57,7 +59,7 @@ The `importLocation` function uses `loadLocation`.
 Using `loadLocation` directly allows for deferred execution or multiple runs
 with different endowments or modules in the same process.
 Calling `loadLocation` returns an `Application` object with an
-`import(endowments?, modules?)` method.
+`import({ endowments?, modules? })` method.
 
 Use `writeArchive` to capture an application in an archival format.
 Archives are `zip` files with a `compartment-map.json` manifest file.
@@ -100,8 +102,10 @@ const read = async location =>
 const { namespace } = await importArchive(
   read,
   archiveLocation,
-  endowments,
-  modules
+  {
+    endowments,
+    modules
+  }
 );
 ```
 
@@ -110,7 +114,7 @@ Use `loadArchive` to defer execution or run multiple times with varying
 endowments.
 Use `parseArchive` to construct a runner from the bytes of an archive.
 The `loadArchive` and `parseArchive` functions return an `Application`
-object with an `import(endowments?, modules?)` method.
+object with an `import({ endowments?, modules? })` method.
 
 # Package Descriptors
 

--- a/packages/compartment-mapper/README.md
+++ b/packages/compartment-mapper/README.md
@@ -13,7 +13,7 @@ many libraries and applications work in Compartments without modification.
 
 The `importLocation` function runs a compartmentalized application off the file
 system.
-The `endowments` are properties to add to the `globalThis` in the global scope
+The `globals` are properties to add to the `globalThis` in the global scope
 of the application's main package compartment.
 The `modules` are built-in modules to grant the application's main package
 compartment.
@@ -25,7 +25,7 @@ import { importLocation } from "@agoric/compartment-mapper";
 // ...
 
 const modules = { fs };
-const endowments = { console };
+const globals = { console };
 
 const read = async location =>
   fs.promises.readFile(new URL(location).pathname);
@@ -34,7 +34,7 @@ const { namespace } = await importLocation(
   read,
   moduleLocation,
   {
-    endowments,
+    globals,
     modules
   }
 );
@@ -52,14 +52,14 @@ have.
 > TODO
 >
 > A future version will allow application authors to distribute their choices
-> of global endowments and granted built-in modules to third-party packages
-> within the application, as with [LavaMoat].
+> of globals and built-in modules to third-party packages within the
+> application, as with [LavaMoat].
 
 The `importLocation` function uses `loadLocation`.
 Using `loadLocation` directly allows for deferred execution or multiple runs
-with different endowments or modules in the same process.
+with different globals or modules in the same process.
 Calling `loadLocation` returns an `Application` object with an
-`import({ endowments?, modules? })` method.
+`import({ globals?, modules? })` method.
 
 Use `writeArchive` to capture an application in an archival format.
 Archives are `zip` files with a `compartment-map.json` manifest file.
@@ -94,7 +94,7 @@ import { importArchive } from "@agoric/compartment-mapper";
 // ...
 
 const modules = { fs };
-const endowments = { console };
+const globals = { console };
 
 const read = async location =>
   fs.promises.readFile(new URL(location).pathname);
@@ -103,7 +103,7 @@ const { namespace } = await importArchive(
   read,
   archiveLocation,
   {
-    endowments,
+    globals,
     modules
   }
 );
@@ -111,10 +111,10 @@ const { namespace } = await importArchive(
 
 The `importArchive` function composes `loadArchive` and `parseArchive`.
 Use `loadArchive` to defer execution or run multiple times with varying
-endowments.
+globals.
 Use `parseArchive` to construct a runner from the bytes of an archive.
 The `loadArchive` and `parseArchive` functions return an `Application`
-object with an `import({ endowments?, modules? })` method.
+object with an `import({ globals?, modules? })` method.
 
 # Package Descriptors
 
@@ -331,7 +331,7 @@ one workflow to the beginning of another, either as bytes or a location.
      map compartments ->  * *  * *   .'.| | |' : :
          read archive ->  | |  | |  '   * * *  : :
        unpack archive ->  | |  | |  :   * * *  : :
-assemble compartments ->  * *  * *  :   + + *  : : <- endowments
+assemble compartments ->  * *  * *  :   + + *  : : <- powers
     load compartments ->  * *  * *  :   + + *  : :
        import modules ->  *    | |  :   + + *  : :
          pack archive ->       * *  '          : :

--- a/packages/compartment-mapper/src/assemble.js
+++ b/packages/compartment-mapper/src/assemble.js
@@ -130,6 +130,7 @@ export const assemble = (
   {
     makeImportHook,
     endowments = {},
+    transforms = [],
     modules: exitModules = {},
     Compartment = defaultCompartment
   }
@@ -168,6 +169,7 @@ export const assemble = (
       resolveHook,
       importHook,
       moduleMapHook,
+      transforms,
       name: location
     });
 

--- a/packages/compartment-mapper/src/assemble.js
+++ b/packages/compartment-mapper/src/assemble.js
@@ -130,6 +130,7 @@ export const assemble = (
   {
     makeImportHook,
     globals = {},
+    globalLexicals = {},
     transforms = [],
     modules: exitModules = {},
     Compartment = defaultCompartment
@@ -170,6 +171,7 @@ export const assemble = (
       importHook,
       moduleMapHook,
       transforms,
+      globalLexicals,
       name: location
     });
 

--- a/packages/compartment-mapper/src/assemble.js
+++ b/packages/compartment-mapper/src/assemble.js
@@ -123,13 +123,13 @@ const makeModuleMapHook = (
 // Does not load or execute any modules.
 // Uses makeImportHook with the given "location" string of each compartment in
 // the DAG.
-// Passes the given endowments and external modules into the root compartment
+// Passes the given globals and external modules into the root compartment
 // only.
 export const assemble = (
   { entry, compartments: compartmentDescriptors },
   {
     makeImportHook,
-    endowments = {},
+    globals = {},
     transforms = [],
     modules: exitModules = {},
     Compartment = defaultCompartment
@@ -164,8 +164,8 @@ export const assemble = (
     );
     const resolveHook = resolve;
 
-    // TODO also thread endowments selectively.
-    const compartment = new Compartment(endowments, exitModules, {
+    // TODO also thread powers selectively.
+    const compartment = new Compartment(globals, exitModules, {
       resolveHook,
       importHook,
       moduleMapHook,

--- a/packages/compartment-mapper/src/import-archive.js
+++ b/packages/compartment-mapper/src/import-archive.js
@@ -38,7 +38,8 @@ export const parseArchive = async (archiveBytes, archiveLocation) => {
   const compartmentMapText = decoder.decode(compartmentMapBytes);
   const compartmentMap = json.parse(compartmentMapText, "compartment-map.json");
 
-  const execute = (endowments, modules) => {
+  const execute = options => {
+    const { endowments, modules, transforms } = options;
     const {
       compartments,
       entry: { module: moduleSpecifier }
@@ -47,7 +48,8 @@ export const parseArchive = async (archiveBytes, archiveLocation) => {
     const compartment = assemble(compartmentMap, {
       makeImportHook,
       endowments,
-      modules
+      modules,
+      transforms
     });
     return compartment.import(moduleSpecifier);
   };
@@ -60,12 +62,7 @@ export const loadArchive = async (read, archiveLocation) => {
   return parseArchive(archiveBytes, archiveLocation);
 };
 
-export const importArchive = async (
-  read,
-  archiveLocation,
-  endowments,
-  modules
-) => {
+export const importArchive = async (read, archiveLocation, options) => {
   const archive = await loadArchive(read, archiveLocation);
-  return archive.import(endowments, modules);
+  return archive.import(options);
 };

--- a/packages/compartment-mapper/src/import-archive.js
+++ b/packages/compartment-mapper/src/import-archive.js
@@ -39,7 +39,7 @@ export const parseArchive = async (archiveBytes, archiveLocation) => {
   const compartmentMap = json.parse(compartmentMapText, "compartment-map.json");
 
   const execute = options => {
-    const { endowments, modules, transforms } = options;
+    const { globals, modules, transforms } = options;
     const {
       compartments,
       entry: { module: moduleSpecifier }
@@ -47,7 +47,7 @@ export const parseArchive = async (archiveBytes, archiveLocation) => {
     const makeImportHook = makeArchiveImportHookMaker(archive, compartments);
     const compartment = assemble(compartmentMap, {
       makeImportHook,
-      endowments,
+      globals,
       modules,
       transforms
     });

--- a/packages/compartment-mapper/src/import-archive.js
+++ b/packages/compartment-mapper/src/import-archive.js
@@ -39,7 +39,7 @@ export const parseArchive = async (archiveBytes, archiveLocation) => {
   const compartmentMap = json.parse(compartmentMapText, "compartment-map.json");
 
   const execute = options => {
-    const { globals, modules, transforms } = options;
+    const { globals, globalLexicals, modules, transforms } = options;
     const {
       compartments,
       entry: { module: moduleSpecifier }
@@ -48,6 +48,7 @@ export const parseArchive = async (archiveBytes, archiveLocation) => {
     const compartment = assemble(compartmentMap, {
       makeImportHook,
       globals,
+      globalLexicals,
       modules,
       transforms
     });

--- a/packages/compartment-mapper/src/import-archive.js
+++ b/packages/compartment-mapper/src/import-archive.js
@@ -39,7 +39,13 @@ export const parseArchive = async (archiveBytes, archiveLocation) => {
   const compartmentMap = json.parse(compartmentMapText, "compartment-map.json");
 
   const execute = options => {
-    const { globals, globalLexicals, modules, transforms } = options;
+    const {
+      globals,
+      globalLexicals,
+      modules,
+      transforms,
+      Compartment
+    } = options;
     const {
       compartments,
       entry: { module: moduleSpecifier }
@@ -50,7 +56,8 @@ export const parseArchive = async (archiveBytes, archiveLocation) => {
       globals,
       globalLexicals,
       modules,
-      transforms
+      transforms,
+      Compartment
     });
     return compartment.import(moduleSpecifier);
   };

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -26,11 +26,11 @@ export const loadLocation = async (read, moduleLocation) => {
   );
 
   const execute = async (options = {}) => {
-    const { endowments, modules, transforms } = options;
+    const { globals, modules, transforms } = options;
     const makeImportHook = makeImportHookMaker(read, packageLocation);
     const compartment = assemble(compartmentMap, {
       makeImportHook,
-      endowments,
+      globals,
       modules,
       transforms
     });

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -25,12 +25,14 @@ export const loadLocation = async (read, moduleLocation) => {
     packageDescriptor
   );
 
-  const execute = async (endowments = {}, modules = {}) => {
+  const execute = async (options = {}) => {
+    const { endowments, modules, transforms } = options;
     const makeImportHook = makeImportHookMaker(read, packageLocation);
     const compartment = assemble(compartmentMap, {
       makeImportHook,
       endowments,
-      modules
+      modules,
+      transforms
     });
     return compartment.import(moduleSpecifier);
   };
@@ -38,12 +40,7 @@ export const loadLocation = async (read, moduleLocation) => {
   return { import: execute };
 };
 
-export const importLocation = async (
-  read,
-  moduleLocation,
-  endowments,
-  modules
-) => {
+export const importLocation = async (read, moduleLocation, options = {}) => {
   const application = await loadLocation(read, moduleLocation);
-  return application.import(endowments, modules);
+  return application.import(options);
 };

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -26,14 +26,21 @@ export const loadLocation = async (read, moduleLocation) => {
   );
 
   const execute = async (options = {}) => {
-    const { globals, globalLexicals, modules, transforms } = options;
+    const {
+      globals,
+      globalLexicals,
+      modules,
+      transforms,
+      Compartment
+    } = options;
     const makeImportHook = makeImportHookMaker(read, packageLocation);
     const compartment = assemble(compartmentMap, {
       makeImportHook,
       globals,
       globalLexicals,
       modules,
-      transforms
+      transforms,
+      Compartment
     });
     return compartment.import(moduleSpecifier);
   };

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -26,11 +26,12 @@ export const loadLocation = async (read, moduleLocation) => {
   );
 
   const execute = async (options = {}) => {
-    const { globals, modules, transforms } = options;
+    const { globals, globalLexicals, modules, transforms } = options;
     const makeImportHook = makeImportHookMaker(read, packageLocation);
     const compartment = assemble(compartmentMap, {
       makeImportHook,
       globals,
+      globalLexicals,
       modules,
       transforms
     });

--- a/packages/compartment-mapper/test/main.test.js
+++ b/packages/compartment-mapper/test/main.test.js
@@ -19,7 +19,12 @@ const fixture = new URL("node_modules/app/main.js", import.meta.url).toString();
 const read = async location => fs.promises.readFile(new URL(location).pathname);
 
 const globals = {
-  endowment: 42
+  globalProperty: 42,
+  globalLexical: "global" // should be overshadowed
+};
+
+const globalLexicals = {
+  globalLexical: "globalLexical"
 };
 
 const assertFixture = (t, namespace) => {
@@ -29,7 +34,8 @@ const assertFixture = (t, namespace) => {
     clarke,
     danny,
     builtin,
-    endowed,
+    receivedGlobalProperty,
+    receivedGlobalLexical,
     typecommon,
     typemodule,
     typehybrid,
@@ -43,7 +49,12 @@ const assertFixture = (t, namespace) => {
 
   t.equal(builtin, "builtin", "exports builtin");
 
-  t.equal(endowed, globals.endowment, "exports endowment");
+  t.equal(receivedGlobalProperty, globals.globalProperty, "exports global");
+  t.equal(
+    receivedGlobalLexical,
+    globalLexicals.globalLexical,
+    "exports global lexical"
+  );
   t.deepEqual(
     typecommon,
     [42, 42, 42, 42],
@@ -62,7 +73,7 @@ const assertFixture = (t, namespace) => {
   t.equal(typehybrid, 42, "type=module and module= package carries exports");
 };
 
-const fixtureAssertionCount = 10;
+const fixtureAssertionCount = 11;
 
 // The "create builtin" test prepares a builtin module namespace object that
 // gets threaded into all subsequent tests to satisfy the "builtin" module
@@ -89,7 +100,11 @@ test("loadLocation", async t => {
   t.plan(fixtureAssertionCount);
 
   const application = await loadLocation(read, fixture);
-  const { namespace } = await application.import({ globals, modules });
+  const { namespace } = await application.import({
+    globals,
+    globalLexicals,
+    modules
+  });
   assertFixture(t, namespace);
 });
 
@@ -98,6 +113,7 @@ test("importLocation", async t => {
 
   const { namespace } = await importLocation(read, fixture, {
     globals,
+    globalLexicals,
     modules
   });
   assertFixture(t, namespace);
@@ -108,7 +124,11 @@ test("makeArchive / parseArchive", async t => {
 
   const archive = await makeArchive(read, fixture);
   const application = await parseArchive(archive);
-  const { namespace } = await application.import({ globals, modules });
+  const { namespace } = await application.import({
+    globals,
+    globalLexicals,
+    modules
+  });
   assertFixture(t, namespace);
 });
 
@@ -128,7 +148,11 @@ test("writeArchive / loadArchive", async t => {
 
   await writeArchive(fakeWrite, read, "app.agar", fixture);
   const application = await loadArchive(fakeRead, "app.agar");
-  const { namespace } = await application.import({ globals, modules });
+  const { namespace } = await application.import({
+    globals,
+    globalLexicals,
+    modules
+  });
   assertFixture(t, namespace);
 });
 
@@ -149,6 +173,7 @@ test("writeArchive / importArchive", async t => {
   await writeArchive(fakeWrite, read, "app.agar", fixture);
   const { namespace } = await importArchive(fakeRead, "app.agar", {
     globals,
+    globalLexicals,
     modules
   });
   assertFixture(t, namespace);

--- a/packages/compartment-mapper/test/main.test.js
+++ b/packages/compartment-mapper/test/main.test.js
@@ -18,7 +18,7 @@ const fixture = new URL("node_modules/app/main.js", import.meta.url).toString();
 
 const read = async location => fs.promises.readFile(new URL(location).pathname);
 
-const endowments = {
+const globals = {
   endowment: 42
 };
 
@@ -43,7 +43,7 @@ const assertFixture = (t, namespace) => {
 
   t.equal(builtin, "builtin", "exports builtin");
 
-  t.equal(endowed, endowments.endowment, "exports endowment");
+  t.equal(endowed, globals.endowment, "exports endowment");
   t.deepEqual(
     typecommon,
     [42, 42, 42, 42],
@@ -77,7 +77,7 @@ let modules;
 
 test("create builtin", async t => {
   const utility = await loadLocation(read, builtinLocation);
-  const { namespace } = await utility.import({ endowments });
+  const { namespace } = await utility.import({ globals });
   // We pass the builtin module into the module map.
   modules = {
     builtin: namespace
@@ -89,7 +89,7 @@ test("loadLocation", async t => {
   t.plan(fixtureAssertionCount);
 
   const application = await loadLocation(read, fixture);
-  const { namespace } = await application.import({ endowments, modules });
+  const { namespace } = await application.import({ globals, modules });
   assertFixture(t, namespace);
 });
 
@@ -97,7 +97,7 @@ test("importLocation", async t => {
   t.plan(fixtureAssertionCount);
 
   const { namespace } = await importLocation(read, fixture, {
-    endowments,
+    globals,
     modules
   });
   assertFixture(t, namespace);
@@ -108,7 +108,7 @@ test("makeArchive / parseArchive", async t => {
 
   const archive = await makeArchive(read, fixture);
   const application = await parseArchive(archive);
-  const { namespace } = await application.import({ endowments, modules });
+  const { namespace } = await application.import({ globals, modules });
   assertFixture(t, namespace);
 });
 
@@ -128,7 +128,7 @@ test("writeArchive / loadArchive", async t => {
 
   await writeArchive(fakeWrite, read, "app.agar", fixture);
   const application = await loadArchive(fakeRead, "app.agar");
-  const { namespace } = await application.import({ endowments, modules });
+  const { namespace } = await application.import({ globals, modules });
   assertFixture(t, namespace);
 });
 
@@ -148,7 +148,7 @@ test("writeArchive / importArchive", async t => {
 
   await writeArchive(fakeWrite, read, "app.agar", fixture);
   const { namespace } = await importArchive(fakeRead, "app.agar", {
-    endowments,
+    globals,
     modules
   });
   assertFixture(t, namespace);

--- a/packages/compartment-mapper/test/main.test.js
+++ b/packages/compartment-mapper/test/main.test.js
@@ -103,7 +103,8 @@ test("loadLocation", async t => {
   const { namespace } = await application.import({
     globals,
     globalLexicals,
-    modules
+    modules,
+    Compartment
   });
   assertFixture(t, namespace);
 });
@@ -114,7 +115,8 @@ test("importLocation", async t => {
   const { namespace } = await importLocation(read, fixture, {
     globals,
     globalLexicals,
-    modules
+    modules,
+    Compartment
   });
   assertFixture(t, namespace);
 });
@@ -127,7 +129,8 @@ test("makeArchive / parseArchive", async t => {
   const { namespace } = await application.import({
     globals,
     globalLexicals,
-    modules
+    modules,
+    Compartment
   });
   assertFixture(t, namespace);
 });
@@ -151,7 +154,8 @@ test("writeArchive / loadArchive", async t => {
   const { namespace } = await application.import({
     globals,
     globalLexicals,
-    modules
+    modules,
+    Compartment
   });
   assertFixture(t, namespace);
 });
@@ -174,7 +178,8 @@ test("writeArchive / importArchive", async t => {
   const { namespace } = await importArchive(fakeRead, "app.agar", {
     globals,
     globalLexicals,
-    modules
+    modules,
+    Compartment
   });
   assertFixture(t, namespace);
 });

--- a/packages/compartment-mapper/test/main.test.js
+++ b/packages/compartment-mapper/test/main.test.js
@@ -77,7 +77,7 @@ let modules;
 
 test("create builtin", async t => {
   const utility = await loadLocation(read, builtinLocation);
-  const { namespace } = await utility.import(endowments);
+  const { namespace } = await utility.import({ endowments });
   // We pass the builtin module into the module map.
   modules = {
     builtin: namespace
@@ -89,19 +89,17 @@ test("loadLocation", async t => {
   t.plan(fixtureAssertionCount);
 
   const application = await loadLocation(read, fixture);
-  const { namespace } = await application.import(endowments, modules);
+  const { namespace } = await application.import({ endowments, modules });
   assertFixture(t, namespace);
 });
 
 test("importLocation", async t => {
   t.plan(fixtureAssertionCount);
 
-  const { namespace } = await importLocation(
-    read,
-    fixture,
+  const { namespace } = await importLocation(read, fixture, {
     endowments,
     modules
-  );
+  });
   assertFixture(t, namespace);
 });
 
@@ -110,7 +108,7 @@ test("makeArchive / parseArchive", async t => {
 
   const archive = await makeArchive(read, fixture);
   const application = await parseArchive(archive);
-  const { namespace } = await application.import(endowments, modules);
+  const { namespace } = await application.import({ endowments, modules });
   assertFixture(t, namespace);
 });
 
@@ -130,7 +128,7 @@ test("writeArchive / loadArchive", async t => {
 
   await writeArchive(fakeWrite, read, "app.agar", fixture);
   const application = await loadArchive(fakeRead, "app.agar");
-  const { namespace } = await application.import(endowments, modules);
+  const { namespace } = await application.import({ endowments, modules });
   assertFixture(t, namespace);
 });
 
@@ -149,11 +147,9 @@ test("writeArchive / importArchive", async t => {
   };
 
   await writeArchive(fakeWrite, read, "app.agar", fixture);
-  const { namespace } = await importArchive(
-    fakeRead,
-    "app.agar",
+  const { namespace } = await importArchive(fakeRead, "app.agar", {
     endowments,
     modules
-  );
+  });
   assertFixture(t, namespace);
 });

--- a/packages/compartment-mapper/test/node_modules/app/main.js
+++ b/packages/compartment-mapper/test/node_modules/app/main.js
@@ -1,4 +1,4 @@
-/* global endowment */
+/* global globalProperty, globalLexical */
 
 import typemodule from 'typemodule';
 import typecommon from 'typecommon';
@@ -13,4 +13,5 @@ export { clarke } from 'clarke';
 export { danny } from 'danny';
 
 export { builtin } from 'builtin';
-export const endowed = endowment;
+export const receivedGlobalProperty = globalProperty;
+export const receivedGlobalLexical = globalLexical;

--- a/packages/compartment-mapper/test/node_modules/evaluator/evaluator.js
+++ b/packages/compartment-mapper/test/node_modules/evaluator/evaluator.js
@@ -1,0 +1,3 @@
+/* global code */
+// eslint-disable-next-line no-eval
+export default (0, eval)(code);

--- a/packages/compartment-mapper/test/node_modules/evaluator/package.json
+++ b/packages/compartment-mapper/test/node_modules/evaluator/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "evaluator",
+  "type": "module"
+}

--- a/packages/compartment-mapper/test/transform.test.js
+++ b/packages/compartment-mapper/test/transform.test.js
@@ -1,0 +1,32 @@
+// import "./ses-lockdown.js";
+import "ses";
+import fs from "fs";
+import tape from "tape";
+import { loadLocation } from "../src/main.js";
+
+const { test } = tape;
+
+test("transforms applied to evaluation", async t => {
+  t.plan(1);
+
+  const fixture = new URL(
+    "node_modules/evaluator/evaluator.js",
+    import.meta.url
+  ).toString();
+  const read = async location =>
+    fs.promises.readFile(new URL(location).pathname);
+
+  const application = await loadLocation(read, fixture);
+  const { namespace } = await application.import({
+    globals: {
+      code: `"hello"`
+    },
+    transforms: [
+      function transform(source) {
+        return source.replace(/ll/g, "y");
+      }
+    ]
+  });
+  const { default: value } = namespace;
+  t.equal(value, "heyo", "code evaluated in compartment is transforemd");
+});


### PR DESCRIPTION
Previously, the `import` methods provided by the compartment mapper accepted `endowments` and `modules` as positional arguments. With this sequence of changes, they ultimately accept an options bag instead, consisting of options named `globals` (instead of `endowments`), `globalLexicals`, `modules`, `transforms`, and a `Compartment` constructor override.

Commits are individually reviewable and may be rebase-merged instead of squash-merged.

*Aside:* This leaves open the design question of threading module transforms and/or module censors. Module transforms potentially alter the import graph, so would need to be applied before archival. These would be running on behalf of the publisher, not the executor, making them an inadequate foundation for censoring. We could also support module censors, which would be unable to alter the import graph but would be run after archival. Loading an application off disk would apply both the module transforms and module censors.