### PR TITLE
fix: flatten tameFunctionToString

### DIFF
--- a/packages/ses/lockdown.js
+++ b/packages/ses/lockdown.js
@@ -24,8 +24,6 @@ import {
   CompartmentPrototype,
 } from './src/compartment-shim.js';
 
-// TODO wasteful to do it twice, once before lockdown and again during
-// lockdown. The second is doubly indirect. We should at least flatten that.
 const nativeBrander = tameFunctionToString();
 
 const Compartment = makeCompartmentConstructor(

--- a/packages/ses/ses.js
+++ b/packages/ses/ses.js
@@ -26,8 +26,6 @@ import {
 
 assign(whitelist, modulesWhitelist);
 
-// TODO wasteful to do it twice, once before lockdown and again during
-// lockdown. The second is doubly indirect. We should at least flatten that.
 const nativeBrander = tameFunctionToString();
 
 const ModularCompartment = makeModularCompartmentConstructor(

--- a/packages/ses/src/tame-function-tostring.js
+++ b/packages/ses/src/tame-function-tostring.js
@@ -1,25 +1,38 @@
-import { defineProperty, apply } from './commons.js';
+import { defineProperty, apply, freeze } from './commons.js';
 
 const nativeSuffix = ') { [native code] }';
 
+// Note: Top level mutable state. Does not make anything worse, since the
+// patching of `Function.prototype.toString` is also globally stateful. We
+// use this top level state so that multiple calls to `tameFunctionToString` are
+// idempotent, rather than creating redundant indirections.
+let nativeBrander;
+
+/**
+ * Replace `Function.prototype.toString` with one that recognizes
+ * shimmed functions as honorary native functions.
+ */
 export function tameFunctionToString() {
-  const nativeBrand = new WeakSet();
+  if (nativeBrander === undefined) {
+    const nativeBrand = new WeakSet();
 
-  const originalFunctionToString = Function.prototype.toString;
+    const originalFunctionToString = Function.prototype.toString;
 
-  const tamingMethods = {
-    toString() {
-      const str = apply(originalFunctionToString, this, []);
-      if (str.endsWith(nativeSuffix) || !nativeBrand.has(this)) {
-        return str;
-      }
-      return `function ${this.name}() { [native code] }`;
-    },
-  };
+    const tamingMethods = {
+      toString() {
+        const str = apply(originalFunctionToString, this, []);
+        if (str.endsWith(nativeSuffix) || !nativeBrand.has(this)) {
+          return str;
+        }
+        return `function ${this.name}() { [native code] }`;
+      },
+    };
 
-  defineProperty(Function.prototype, 'toString', {
-    value: tamingMethods.toString,
-  });
+    defineProperty(Function.prototype, 'toString', {
+      value: tamingMethods.toString,
+    });
 
-  return func => nativeBrand.add(func);
+    nativeBrander = freeze(func => nativeBrand.add(func));
+  }
+  return nativeBrander;
 }


### PR DESCRIPTION
Previously, the multiple calls to `tameFunctionToString` were adding redundant layers of indirection. This was correctness preserving but unnecessary. Add a bit of logic so secondary calls reuse the results of the first call.