### PR TITLE
fix: eslint rule to suppress bogus dependency warning

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,7 +50,13 @@
     "max-statements-per-line": ["error", { "max": 1 }],
     "import/no-unresolved": "off",
     "import/extensions": "off",
-    "eslint-comments/no-unused-disable": "error"
+    "eslint-comments/no-unused-disable": "error",
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": true
+      }
+    ]
   },
   "ignorePatterns": [
     "**/dist/**",

--- a/packages/ses/test262/compartment-shim.js
+++ b/packages/ses/test262/compartment-shim.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import test262Runner from '@agoric/test262-runner';
 import '../ses.js';
 

--- a/packages/ses/test262/repair-legacy-accessors.js
+++ b/packages/ses/test262/repair-legacy-accessors.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import test262Runner from '@agoric/test262-runner';
 import repairLegacyAccessors from '../src/repair-legacy-accessors.js';
 

--- a/packages/ses/test262/tame-global-date-object.js
+++ b/packages/ses/test262/tame-global-date-object.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import test262Runner from '@agoric/test262-runner';
 import tameDateConstructor from '../src/tame-date-constructor.js';
 

--- a/packages/ses/test262/tame-global-error-object.js
+++ b/packages/ses/test262/tame-global-error-object.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import test262Runner from '@agoric/test262-runner';
 import tameErrorConstructor from '../src/tame-error-constructor.js';
 

--- a/packages/ses/test262/tame-global-math-object.js
+++ b/packages/ses/test262/tame-global-math-object.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import test262Runner from '@agoric/test262-runner';
 import tameMathObject from '../src/tame-math-object.js';
 

--- a/packages/ses/test262/tame-global-regexp-object.js
+++ b/packages/ses/test262/tame-global-regexp-object.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import test262Runner from '@agoric/test262-runner';
 import tameRegExpConstructor from '../src/tame-regexp-constructor.js';
 


### PR DESCRIPTION
In keybase @katelynsills said:

Btw, the way to turn off the annoying red squigglies in tests when they tell you something you import should be a real dependency is this ESLint setting:
```js
"import/no-extraneous-dependencies": [
        "error",
        {
          "devDependencies": true
        }
      ]
```

This PR does that.