### PR TITLE
feat(ses): Add __shimTransforms__ Compartment option

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -3,10 +3,14 @@ User-visible changes in SES:
 ## Next release
 
 * `lockdown()` adds new global `assert` and tames the global `console`. The
-   error taming hides error stacks, accumulating them in side tables. The
-   `assert` system generated other diagnostic information hidden in side
-   tables. The tamed console uses these side tables to output more informative
-   diagnostics. [Logging Errors](./src/error/README.md) explains the design.
+  error taming hides error stacks, accumulating them in side tables. The
+  `assert` system generated other diagnostic information hidden in side
+  tables. The tamed console uses these side tables to output more informative
+  diagnostics. [Logging Errors](./src/error/README.md) explains the design.
+* Adds a non-standardizable `__shimTransforms__` option to the
+  Compartment constructor that allows a single transform to work
+  for both programs passed to `evaluate` and modules that the SES shim
+  compiles to programs.
 
 ## Release 0.10.4 (28-September-2020)
 

--- a/packages/ses/README.md
+++ b/packages/ses/README.md
@@ -277,8 +277,10 @@ top-level await.
 The `Compartment` constructor accepts a `transforms` option.
 This is an array of JavaScript source to source translation functions,
 in the order they should be applied.
-The input and output must both be valid JavaScript "Program" grammar
-constructions, code that is valid in a `<script>`, not a module.
+Passing the source to the first function's input, then from each function's
+output to the next's input, the final function's output must be a valid
+JavaScript "Program" grammar construction, code that is valid in a `<script>`,
+not a module.
 
 ```js
 const transforms = [addCodeCoverageInstrumentation];

--- a/packages/ses/README.md
+++ b/packages/ses/README.md
@@ -301,13 +301,13 @@ These transforms do not apply to modules.
 To transform the source of an ECMAScript module, the `importHook` must
 intercept the source and transform it before passing it to the
 `StaticModuleRecord` constructor.
-These are distinct because a programs and modules have distinct grammar
+These are distinct because programs and modules have distinct grammar
 productions.
 
 An **internal implementation detail** of the SES-shim is that it
 converts modules to programs and evaluates them as programs.
 So, only for this implementation of `Compartment`, it is possible for a program
-transform to be equally applicable for both modules, but that transform will
+transform to be equally applicable for modules, but that transform will
 have a window into the internal translation, will be sensitive to changes to
 that translation between any pair of releases, even those that do not disclose
 any breaking changes, and will only work on SES-shim, not any other
@@ -328,6 +328,10 @@ const c = new Compartment({ console }, null, {
 });
 c.evaluate('console.log("Hello");');
 ```
+
+The `__shimTransforms__` feature is designed to uphold the security properties
+of compartments, since an attacker may use all available features, whether they
+are standard or not.
 
 ### Logging Errors
 

--- a/packages/ses/src/module-instance.js
+++ b/packages/ses/src/module-instance.js
@@ -29,6 +29,8 @@ export const makeModuleInstance = (
 
   const compartmentFields = privateFields.get(compartment);
 
+  const { __shimTransforms__ } = compartmentFields;
+
   const { exportsProxy, proxiedExports, activate } = getDeferredExports(
     compartment,
     compartmentFields,
@@ -318,6 +320,7 @@ export const makeModuleInstance = (
 
   let optFunctor = compartment.evaluate(functorSource, {
     globalObject,
+    transforms: __shimTransforms__,
     __moduleShimLexicals__: localLexicals,
   });
   let didThrow = false;

--- a/packages/ses/src/module-shim.js
+++ b/packages/ses/src/module-shim.js
@@ -198,7 +198,12 @@ export const makeModularCompartmentConstructor = (
       new.target,
     );
 
-    const { resolveHook, importHook, moduleMapHook } = options;
+    const {
+      resolveHook,
+      importHook,
+      moduleMapHook,
+      __shimTransforms__,
+    } = options;
 
     // Map<FullSpecifier, ModuleCompartmentRecord>
     const moduleRecords = new Map();
@@ -237,6 +242,7 @@ export const makeModularCompartmentConstructor = (
       moduleMap,
       moduleMapHook,
       moduleRecords,
+      __shimTransforms__,
       deferredExports,
       instances,
     });

--- a/packages/ses/test/compartment-transforms.test.js
+++ b/packages/ses/test/compartment-transforms.test.js
@@ -1,0 +1,93 @@
+import tap from 'tap';
+import '../ses.js';
+
+const { test } = tap;
+
+lockdown();
+
+test('transforms apply to evaluated expressions', t => {
+  t.plan(1);
+
+  const transform = source => source.replace(/Farewell/g, 'Hello');
+  const transforms = [transform];
+  const c = new Compartment({}, {}, { transforms });
+  const greeting = c.evaluate('"Farewell, World!"');
+
+  t.equal(greeting, 'Hello, World!');
+});
+
+test('transforms apply to dynamic eval in compartments', t => {
+  t.plan(1);
+
+  const transform = source => source.replace(/Farewell/g, 'Hello');
+  const transforms = [transform];
+  const c = new Compartment(
+    {
+      greeting: '"Farewell, World!"',
+    },
+    {},
+    { transforms },
+  );
+  const greeting = c.evaluate('(0, eval)(greeting)');
+
+  t.equal(greeting, 'Hello, World!');
+});
+
+test('transforms do not apply to dynamic eval in compartments within compartments', t => {
+  t.plan(1);
+
+  const transform = source => source.replace(/Farewell/g, 'Hello');
+  const transforms = [transform];
+  const c = new Compartment({}, {}, { transforms });
+  const d = c.evaluate('new Compartment()');
+  const greeting = d.evaluate('"Farewell, World!"');
+
+  t.equal(greeting, 'Farewell, World!');
+});
+
+test('transforms do not apply to imported modules', async t => {
+  t.plan(1);
+
+  const transform = source => source.replace(/Farewell/g, 'Hello');
+  const transforms = [transform];
+  const resolveHook = () => '';
+  const importHook = () =>
+    new StaticModuleRecord('export default "Farewell, World!";');
+  const c = new Compartment({}, {}, { transforms, resolveHook, importHook });
+
+  const { namespace } = await c.import('any-string-here');
+  const { default: greeting } = namespace;
+
+  t.equal(greeting, 'Farewell, World!');
+});
+
+test('__shimTransforms__ apply to evaluated expressions', t => {
+  t.plan(1);
+
+  const transform = source => source.replace(/Farewell/g, 'Hello');
+  const transforms = [transform];
+  const c = new Compartment({}, {}, { transforms });
+  const greeting = c.evaluate('"Farewell, World!"');
+
+  t.equal(greeting, 'Hello, World!');
+});
+
+test('__shimTransforms__ do apply to imported modules', async t => {
+  t.plan(1);
+
+  const transform = source => source.replace(/Farewell/g, 'Hello');
+  const transforms = [transform];
+  const resolveHook = () => '';
+  const importHook = () =>
+    new StaticModuleRecord('export default "Farewell, World!";');
+  const c = new Compartment(
+    {},
+    {},
+    { __shimTransforms__: transforms, resolveHook, importHook },
+  );
+
+  const { namespace } = await c.import('any-string-here');
+  const { default: greeting } = namespace;
+
+  t.equal(greeting, 'Hello, World!');
+});


### PR DESCRIPTION
This is a non-standardizable short-cut that allows a compartment to be constructed with a single chain of Program construction to Program construction transforms that apply both to evaluated expressions within the compartment and imported modules **after** they have been converted from Module to Program constructions. This reveals an implementation detail of SES-shim but does not compromise security, since the evaluator provides the foundation for our security guarantees.