### PR TITLE
Obsolete: Add lightweight evasive transforms to evade rejection false positives.

### DIFF
--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -13,6 +13,11 @@ import { performEval } from './evaluate.js';
 import { isValidIdentifierName } from './scope-constants.js';
 import { sharedGlobalPropertyNames } from './whitelist.js';
 import { InertCompartment } from './inert.js';
+import {
+  evadeHtmlCommentTest,
+  evadeImportExpressionTest,
+  evadeDirectEvalTest,
+} from './transforms.js';
 
 // privateFields captures the private state for each compartment.
 const privateFields = new WeakMap();
@@ -48,8 +53,20 @@ export const CompartmentPrototype = {
       transforms = [],
       sloppyGlobalsMode = false,
       __moduleShimLexicals__ = undefined,
+      __evadeHtmlCommentTest__ = false,
+      __evadeImportExpressionTest__ = false,
+      __evadeDirectEvalTest__ = false,
     } = options;
     const localTransforms = [...transforms];
+    if (__evadeHtmlCommentTest__ === true) {
+      localTransforms.push(evadeHtmlCommentTest);
+    }
+    if (__evadeImportExpressionTest__ === true) {
+      localTransforms.push(evadeImportExpressionTest);
+    }
+    if (__evadeDirectEvalTest__ === true) {
+      localTransforms.push(evadeDirectEvalTest);
+    }
 
     const compartmentFields = privateFields.get(this);
     let { globalTransforms } = compartmentFields;

--- a/packages/ses/src/transforms.js
+++ b/packages/ses/src/transforms.js
@@ -81,7 +81,7 @@ export function rejectHtmlComments(src) {
  * @param { string } src
  * @returns { string }
  */
-export function evadeHtmlComments(src) {
+export function evadeHtmlCommentTest(src) {
   const replaceFn = match => (match[0] === '<' ? '< ! --' : '-- >');
   return src.replace(htmlCommentPattern, replaceFn);
 }
@@ -150,7 +150,7 @@ export function rejectImportExpressions(src) {
  * @param { string } src
  * @returns { string }
  */
-export function evadeImportExpressions(src) {
+export function evadeImportExpressionTest(src) {
   const replaceFn = (_, p1) => `__import__${p1}`;
   return src.replace(importPattern, replaceFn);
 }
@@ -223,7 +223,7 @@ export function rejectSomeDirectEvalExpressions(src) {
  * @param { string } src
  * @returns { string }
  */
-export function evadeSomeDirectEvalExpressions(src) {
+export function evadeDirectEvalTest(src) {
   const replaceFn = (_, p1) => `(1,eval)${p1}`;
   return src.replace(someDirectEvalPattern, replaceFn);
 }

--- a/packages/ses/src/transforms.js
+++ b/packages/ses/src/transforms.js
@@ -1,8 +1,15 @@
+// @ts-check
+
 import { stringSearch, stringSlice, stringSplit } from './commons.js';
 
-// Find the first occurence of the given pattern and return
-// the location as the approximate line number.
-
+/**
+ * Find the first occurence of the given pattern and return
+ * the location as the approximate line number.
+ *
+ * @param {string} src
+ * @param {RegExp} pattern
+ * @returns {number}
+ */
 function getLineNumber(src, pattern) {
   const index = stringSearch(src, pattern);
   if (index < 0) {
@@ -11,27 +18,37 @@ function getLineNumber(src, pattern) {
   return stringSplit(stringSlice(src, 0, index), '\n').length;
 }
 
-// https://www.ecma-international.org/ecma-262/9.0/index.html#sec-html-like-comments
-// explains that JavaScript parsers may or may not recognize html
-// comment tokens "<" immediately followed by "!--" and "--"
-// immediately followed by ">" in non-module source text, and treat
-// them as a kind of line comment. Since otherwise both of these can
-// appear in normal JavaScript source code as a sequence of operators,
-// we have the terrifying possibility of the same source code parsing
-// one way on one correct JavaScript implementation, and another way
-// on another.
-//
-// This shim takes the conservative strategy of just rejecting source
-// text that contains these strings anywhere. Note that this very
-// source file is written strangely to avoid mentioning these
-// character strings explicitly.
+// /////////////////////////////////////////////////////////////////////////////
 
-// We do not write the regexp in a straightforward way, so that an
-// apparennt html comment does not appear in this file. Thus, we avoid
-// rejection by the overly eager rejectDangerousSources.
+const htmlCommentPattern = new RegExp(`(?:${'<'}!--|--${'>'})`, 'g');
 
-const htmlCommentPattern = new RegExp(`(?:${'<'}!--|--${'>'})`);
-
+/**
+ * Conservatively reject the source text if it may contain text that some
+ * JavaScript parsers may treat as an html-like comment. To reject without
+ * parsing, `rejectHtmlComments` will also reject some other text as well.
+ *
+ * https://www.ecma-international.org/ecma-262/9.0/index.html#sec-html-like-comments
+ * explains that JavaScript parsers may or may not recognize html
+ * comment tokens "<" immediately followed by "!--" and "--"
+ * immediately followed by ">" in non-module source text, and treat
+ * them as a kind of line comment. Since otherwise both of these can
+ * appear in normal JavaScript source code as a sequence of operators,
+ * we have the terrifying possibility of the same source code parsing
+ * one way on one correct JavaScript implementation, and another way
+ * on another.
+ *
+ * This shim takes the conservative strategy of just rejecting source
+ * text that contains these strings anywhere. Note that this very
+ * source file is written strangely to avoid mentioning these
+ * character strings explicitly.
+ *
+ * We do not write the regexp in a straightforward way, so that an
+ * apparennt html comment does not appear in this file. Thus, we avoid
+ * rejection by the overly eager rejectDangerousSources.
+ *
+ * @param {string} src
+ * @returns {string}
+ */
 export function rejectHtmlComments(src) {
   const linenum = getLineNumber(src, htmlCommentPattern);
   if (linenum < 0) {
@@ -42,30 +59,67 @@ export function rejectHtmlComments(src) {
   );
 }
 
-// The proposed dynamic import expression is the only syntax currently
-// proposed, that can appear in non-module JavaScript code, that
-// enables direct access to the outside world that cannot be
-// surpressed or intercepted without parsing and rewriting. Instead,
-// this shim conservatively rejects any source text that seems to
-// contain such an expression. To do this safely without parsing, we
-// must also reject some valid programs, i.e., those containing
-// apparent import expressions in literal strings or comments.
+/**
+ * An optional transform to place ahead of `rejectHtmlComments` to evade *that*
+ * rejection. However, it may change the meaning of the program.
+ *
+ * This evasion replaces each alleged html comment with the space-separated
+ * JavaScript operator sequence that it may mean, assuming that it appears
+ * outside of a comment or literal string, in source code where the JS
+ * parser makes no special case for html comments (like module source code).
+ * In that case, this evasion preserves the meaning of the program, though it
+ * does change the souce column numbers on each effected line.
+ *
+ * If the html comment appeared in a literal (a string literal, regexp literal,
+ * or a template literal), then this evasion will change the meaning of the
+ * program by changing the text of that literal.
+ *
+ * If the html comment appeared in a JavaScript comment, then this evasion does
+ * not change the meaning of the program because it only changes the contents of
+ * those comments.
+ *
+ * @param { string } src
+ * @returns { string }
+ */
+export function evadeHtmlComments(src) {
+  const replaceFn = match => (match[0] === '<' ? '< ! --' : '-- >');
+  return src.replace(htmlCommentPattern, replaceFn);
+}
 
-// The current conservative rule looks for the identifier "import"
-// followed by either an open paren or something that looks like the
-// beginning of a comment. We assume that we do not need to worry
-// about html comment syntax because that was already rejected by
-// rejectHtmlComments.
+// /////////////////////////////////////////////////////////////////////////////
 
-// this \s *must* match all kinds of syntax-defined whitespace. If e.g.
-// U+2028 (LINE SEPARATOR) or U+2029 (PARAGRAPH SEPARATOR) is treated as
-// whitespace by the parser, but not matched by /\s/, then this would admit
-// an attack like: import\u2028('power.js') . We're trying to distinguish
-// something like that from something like importnotreally('power.js') which
-// is perfectly safe.
+const importPattern = new RegExp('\\bimport(\\s*(?:\\(|/[/*]))', 'g');
 
-const importPattern = new RegExp('\\bimport\\s*(?:\\(|/[/*])');
-
+/**
+ * Conservatively reject the source text if it may contain a dynamic
+ * import expression. To reject without parsing, `rejectImportExpressions` will
+ * also reject some other text as well.
+ *
+ * The proposed dynamic import expression is the only syntax currently
+ * proposed, that can appear in non-module JavaScript code, that
+ * enables direct access to the outside world that cannot be
+ * surpressed or intercepted without parsing and rewriting. Instead,
+ * this shim conservatively rejects any source text that seems to
+ * contain such an expression. To do this safely without parsing, we
+ * must also reject some valid programs, i.e., those containing
+ * apparent import expressions in literal strings or comments.
+ *
+ * The current conservative rule looks for the identifier "import"
+ * followed by either an open paren or something that looks like the
+ * beginning of a comment. We assume that we do not need to worry
+ * about html comment syntax because that was already rejected by
+ * rejectHtmlComments.
+ *
+ * this \s *must* match all kinds of syntax-defined whitespace. If e.g.
+ * U+2028 (LINE SEPARATOR) or U+2029 (PARAGRAPH SEPARATOR) is treated as
+ * whitespace by the parser, but not matched by /\s/, then this would admit
+ * an attack like: import\u2028('power.js') . We're trying to distinguish
+ * something like that from something like importnotreally('power.js') which
+ * is perfectly safe.
+ *
+ * @param { string } src
+ * @returns { string }
+ */
 export function rejectImportExpressions(src) {
   const linenum = getLineNumber(src, importPattern);
   if (linenum < 0) {
@@ -76,26 +130,67 @@ export function rejectImportExpressions(src) {
   );
 }
 
-// The shim cannot correctly emulate a direct eval as explained at
-// https://github.com/Agoric/realms-shim/issues/12
-// Without rejecting apparent direct eval syntax, we would
-// accidentally evaluate these with an emulation of indirect eval. To
-// prevent future compatibility problems, in shifting from use of the
-// shim to genuine platform support for the proposal, we should
-// instead statically reject code that seems to contain a direct eval
-// expression.
-//
-// As with the dynamic import expression, to avoid a full parse, we do
-// this approximately with a regexp, that will also reject strings
-// that appear safely in comments or strings. Unlike dynamic import,
-// if we miss some, this only creates future compat problems, not
-// security problems. Thus, we are only trying to catch innocent
-// occurrences, not malicious one. In particular, `(eval)(...)` is
-// direct eval syntax that would not be caught by the following regexp.
+/**
+ * An optional transform to place ahead of `rejectImportExpressions` to evade
+ * *that* rejection. However, it may change the meaning of the program.
+ *
+ * This evasion replaces each suspicious `import` identifier with `__import__`.
+ * If the alleged import expression appears in a JavaScript comment, this
+ * evasion will not change the meaning of the program. If it appears in a
+ * literal (string literal, regexp literal, or a template literal), then this
+ * evasion will change the contents of that literal. If it appears as code
+ * where it would be parsed as an expression, then it might or might not change
+ * the meaning of the program, depending on the binding, if any, of the lexical
+ * variable `__import__`.
+ *
+ * Finally, if the original appears in code where it is not parsed as an
+ * expression, for example `foo.import(path)`, then this evasion would rewrite
+ * to `foo.__import__(path)` which has a surprisingly different meaning.
+ *
+ * @param { string } src
+ * @returns { string }
+ */
+export function evadeImportExpressions(src) {
+  const replaceFn = (_, p1) => `__import__${p1}`;
+  return src.replace(importPattern, replaceFn);
+}
 
-const someDirectEvalPattern = new RegExp('\\beval\\s*(?:\\(|/[/*])');
+// /////////////////////////////////////////////////////////////////////////////
 
-// Exported for unit tests.
+const someDirectEvalPattern = new RegExp('\\beval(\\s*\\()', 'g');
+
+/**
+ * Heuristically reject some text that seems to contain a direct eval
+ * expression, with both false positives and false negavives. To reject without
+ * parsing, `rejectSomeDirectEvalExpressions` may will also reject some other
+ * text as well. It may also accept source text that contains a direct eval
+ * written oddly, such as `(eval)(src)`. This false negative is not a security
+ * vulnerability. Rather it is a compat hazard because it will execute as
+ * an indirect eval under the SES-shim but as a direct eval on platforms that
+ * support SES directly (like XS).
+ *
+ * The shim cannot correctly emulate a direct eval as explained at
+ * https://github.com/Agoric/realms-shim/issues/12
+ * If we did not reject direct eval syntax, we would
+ * accidentally evaluate these with an emulation of indirect eval. To
+ * prevent future compatibility problems, in shifting from use of the
+ * shim to genuine platform support for the proposal, we should
+ * instead statically reject code that seems to contain a direct eval
+ * expression.
+ *
+ * As with the dynamic import expression, to avoid a full parse, we do
+ * this approximately with a regexp, that will also reject strings
+ * that appear safely in comments or strings. Unlike dynamic import,
+ * if we miss some, this only creates future compat problems, not
+ * security problems. Thus, we are only trying to catch innocent
+ * occurrences, not malicious one. In particular, `(eval)(...)` is
+ * direct eval syntax that would not be caught by the following regexp.
+ *
+ * Exported for unit tests.
+ *
+ * @param { string } src
+ * @returns { string }
+ */
 export function rejectSomeDirectEvalExpressions(src) {
   const linenum = getLineNumber(src, someDirectEvalPattern);
   if (linenum < 0) {
@@ -106,6 +201,42 @@ export function rejectSomeDirectEvalExpressions(src) {
   );
 }
 
+/**
+ * An optional transform to place ahead of `rejectSomeDirectEvalExpressions` to
+ * evade *that* rejection. However, it may change the meaning of the program.
+ *
+ * This evasion replaces allegedly offending expressions like `eval(src)` with
+ * `(1,eval)(src)`. If this pattern occurs in a JavaScript
+ * comment, the evasion does not change the program's meaning. If it occurs in
+ * a literal (a string literal, a regexp literal, or a template literal), then
+ * this evasion would change the meaning of the program.
+ *
+ * If this pattern occurs in code, the evasion is reliably an indirect eval,
+ * whether run on the shim (where direct eval is impossible) or on a platform
+ * directly supporting SES (like XS, where the original would be a direct eval).
+ *
+ * Finally, if the original appears in code where it is not parsed as an
+ * expression, for example `foo.eval(src)`, then this evasion would rewrite
+ * to `foo.(1,eval)(path)` which would not even parse as JavaScript.
+
+ *
+ * @param { string } src
+ * @returns { string }
+ */
+export function evadeSomeDirectEvalExpressions(src) {
+  const replaceFn = (_, p1) => `(1,eval)${p1}`;
+  return src.replace(someDirectEvalPattern, replaceFn);
+}
+
+// /////////////////////////////////////////////////////////////////////////////
+
+/**
+ * A transform that bundles together the transforms that must unconditionally
+ * happen last in order to ensure safe evaluation without parsing.
+ *
+ * @param {string} source
+ * @returns {string}
+ */
 export function mandatoryTransforms(source) {
   source = rejectHtmlComments(source);
   source = rejectImportExpressions(source);
@@ -113,6 +244,14 @@ export function mandatoryTransforms(source) {
   return source;
 }
 
+/**
+ * Starting with `source`, apply each transform to the result of the
+ * previous one, returning the result of the last transformation.
+ *
+ * @param {string} source
+ * @param {((str: string) => string)[]} transforms
+ * @returns {string}
+ */
 export function applyTransforms(source, transforms) {
   for (const transform of transforms) {
     source = transform(source);

--- a/packages/ses/test/compartment-constructor.test.js
+++ b/packages/ses/test/compartment-constructor.test.js
@@ -32,7 +32,6 @@ test('Compartment class', t => {
   );
   t.doesNotThrow(
     () => new Compartment(),
-    TypeError,
     'Compartment must support the [[Construct]] method',
   );
 });

--- a/packages/ses/test/evade-direct-eval.test.js
+++ b/packages/ses/test/evade-direct-eval.test.js
@@ -32,18 +32,17 @@ test('evade direct eval expressions in evaluate', t => {
   const newline = `const a = eval\n('evil')`;
   const multiline = `\neval('a')\neval('b')`;
 
-  t.doesNotThrow(() => c.evaluate(wrap(safe)), SyntaxError, 'safe');
-  t.doesNotThrow(() => c.evaluate(wrap(safe2)), SyntaxError, 'safe2');
-  t.doesNotThrow(() => c.evaluate(wrap(safe3)), SyntaxError, 'safe3');
+  t.doesNotThrow(() => c.evaluate(wrap(safe)), 'safe');
+  t.doesNotThrow(() => c.evaluate(wrap(safe2)), 'safe2');
+  t.doesNotThrow(() => c.evaluate(wrap(safe3)), 'safe3');
 
-  t.doesNotThrow(() => c.evaluate(wrap(bogus)), SyntaxError, 'bogus');
+  t.doesNotThrow(() => c.evaluate(wrap(bogus)), 'bogus');
 
   t.throws(() => c.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => c.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
-  t.doesNotThrow(() => c.evaluate(wrap(comment)), SyntaxError, 'comment');
+  t.doesNotThrow(() => c.evaluate(wrap(comment)), 'comment');
   t.doesNotThrow(
     () => c.evaluate(wrap(doubleSlashComment)),
-    SyntaxError,
     'doubleSlashComment',
   );
   t.throws(() => c.evaluate(wrap(newline)), SyntaxError, 'newline');
@@ -75,15 +74,15 @@ test('evade direct eval expressions in Function', t => {
   const newline = `const a = eval\n('evil')`;
   const multiline = `\neval('a')\neval('b')`;
 
-  t.doesNotThrow(() => c.evaluate(wrap(safe)), SyntaxError, 'safe');
-  t.doesNotThrow(() => c.evaluate(wrap(safe2)), SyntaxError, 'safe2');
-  t.doesNotThrow(() => c.evaluate(wrap(safe3)), SyntaxError, 'safe3');
+  t.doesNotThrow(() => c.evaluate(wrap(safe)), 'safe');
+  t.doesNotThrow(() => c.evaluate(wrap(safe2)), 'safe2');
+  t.doesNotThrow(() => c.evaluate(wrap(safe3)), 'safe3');
 
-  t.doesNotThrow(() => c.evaluate(wrap(bogus)), SyntaxError, 'bogus');
+  t.doesNotThrow(() => c.evaluate(wrap(bogus)), 'bogus');
 
   t.throws(() => c.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => c.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
-  t.doesNotThrow(() => c.evaluate(wrap(comment)), SyntaxError, 'comment');
+  t.doesNotThrow(() => c.evaluate(wrap(comment)), 'comment');
   t.throws(
     () => c.evaluate(wrap(doubleSlashComment)),
     SyntaxError,

--- a/packages/ses/test/evade-direct-eval.test.js
+++ b/packages/ses/test/evade-direct-eval.test.js
@@ -5,6 +5,8 @@ const { test } = tap;
 
 lockdown();
 
+const opt = harden({ __evadeDirectEvalTest__: true });
+
 test('evade direct eval expressions in evaluate', t => {
   const c = new Compartment();
 
@@ -16,37 +18,15 @@ test('evade direct eval expressions in evaluate', t => {
       }`;
   }
 
-  const safe = `const a = 1`;
-  const safe2 = `const a = noteval('evil')`;
-  const safe3 = `const a = evalnot('evil')`;
-
-  // "bogus" is actually direct eval syntax which ideally we could
-  // reject. However, it escapes our regexp, which we allow because
-  // accepting it is a future compat issue, not a security issue.
-  const bogus = `const a = (eval)('evil')`;
-
   const obvious = `const a = eval('evil')`;
   const whitespace = `const a = eval ('evil')`;
-  const comment = `const a = eval/*hah*/('evil')`;
-  const doubleSlashComment = `const a = eval // hah\n('evil')`;
   const newline = `const a = eval\n('evil')`;
   const multiline = `\neval('a')\neval('b')`;
 
-  t.doesNotThrow(() => c.evaluate(wrap(safe)), 'safe');
-  t.doesNotThrow(() => c.evaluate(wrap(safe2)), 'safe2');
-  t.doesNotThrow(() => c.evaluate(wrap(safe3)), 'safe3');
-
-  t.doesNotThrow(() => c.evaluate(wrap(bogus)), 'bogus');
-
-  t.throws(() => c.evaluate(wrap(obvious)), SyntaxError, 'obvious');
-  t.throws(() => c.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
-  t.doesNotThrow(() => c.evaluate(wrap(comment)), 'comment');
-  t.doesNotThrow(
-    () => c.evaluate(wrap(doubleSlashComment)),
-    'doubleSlashComment',
-  );
-  t.throws(() => c.evaluate(wrap(newline)), SyntaxError, 'newline');
-  t.throws(() => c.evaluate(wrap(multiline)), SyntaxError, 'newline');
+  t.doesNotThrow(() => c.evaluate(wrap(obvious), opt), 'obvious');
+  t.doesNotThrow(() => c.evaluate(wrap(whitespace), opt), 'whitespace');
+  t.doesNotThrow(() => c.evaluate(wrap(newline), opt), 'newline');
+  t.doesNotThrow(() => c.evaluate(wrap(multiline), opt), 'newline');
 
   t.end();
 });
@@ -58,37 +38,15 @@ test('evade direct eval expressions in Function', t => {
     return `new Function(${'`'}${s}; return a;${'`'})`;
   }
 
-  const safe = `const a = 1`;
-  const safe2 = `const a = noteval('evil')`;
-  const safe3 = `const a = evalnot('evil')`;
-
-  // "bogus" is actually direct eval syntax which ideally we could
-  // reject. However, it escapes our regexp, which we allow because
-  // accepting it is a future compat issue, not a security issue.
-  const bogus = `const a = (eval)('evil')`;
-
   const obvious = `const a = eval('evil')`;
   const whitespace = `const a = eval ('evil')`;
-  const comment = `const a = eval/*hah*/('evil')`;
-  const doubleSlashComment = `const a = eval // hah\n('evil')`;
   const newline = `const a = eval\n('evil')`;
   const multiline = `\neval('a')\neval('b')`;
 
-  t.doesNotThrow(() => c.evaluate(wrap(safe)), 'safe');
-  t.doesNotThrow(() => c.evaluate(wrap(safe2)), 'safe2');
-  t.doesNotThrow(() => c.evaluate(wrap(safe3)), 'safe3');
-
-  t.doesNotThrow(() => c.evaluate(wrap(bogus)), 'bogus');
-
-  t.throws(() => c.evaluate(wrap(obvious)), SyntaxError, 'obvious');
-  t.throws(() => c.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
-  t.doesNotThrow(() => c.evaluate(wrap(comment)), 'comment');
-  t.doesNotThrow(
-    () => c.evaluate(wrap(doubleSlashComment)),
-    'doubleSlashComment',
-  );
-  t.throws(() => c.evaluate(wrap(newline)), SyntaxError, 'newline');
-  t.throws(() => c.evaluate(wrap(multiline)), SyntaxError, 'newline');
+  t.doesNotThrow(() => c.evaluate(wrap(obvious), opt), 'obvious');
+  t.doesNotThrow(() => c.evaluate(wrap(whitespace), opt), 'whitespace');
+  t.doesNotThrow(() => c.evaluate(wrap(newline), opt), 'newline');
+  t.doesNotThrow(() => c.evaluate(wrap(multiline), opt), 'newline');
 
   t.end();
 });

--- a/packages/ses/test/evade-direct-eval.test.js
+++ b/packages/ses/test/evade-direct-eval.test.js
@@ -5,7 +5,7 @@ const { test } = tap;
 
 lockdown();
 
-test('reject direct eval expressions in evaluate', t => {
+test('evade direct eval expressions in evaluate', t => {
   const c = new Compartment();
 
   function wrap(s) {
@@ -52,7 +52,7 @@ test('reject direct eval expressions in evaluate', t => {
   t.end();
 });
 
-test('reject direct eval expressions in Function', t => {
+test('evade direct eval expressions in Function', t => {
   const c = new Compartment();
 
   function wrap(s) {

--- a/packages/ses/test/evade-direct-eval.test.js
+++ b/packages/ses/test/evade-direct-eval.test.js
@@ -55,7 +55,7 @@ test('evade direct eval expressions in Function', t => {
   const c = new Compartment();
 
   function wrap(s) {
-    return `new Function("${s}; return a;")`;
+    return `new Function(${'`'}${s}; return a;${'`'})`;
   }
 
   const safe = `const a = 1`;
@@ -83,9 +83,8 @@ test('evade direct eval expressions in Function', t => {
   t.throws(() => c.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => c.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
   t.doesNotThrow(() => c.evaluate(wrap(comment)), 'comment');
-  t.throws(
+  t.doesNotThrow(
     () => c.evaluate(wrap(doubleSlashComment)),
-    SyntaxError,
     'doubleSlashComment',
   );
   t.throws(() => c.evaluate(wrap(newline)), SyntaxError, 'newline');

--- a/packages/ses/test/evade-html-comment.test.js
+++ b/packages/ses/test/evade-html-comment.test.js
@@ -5,7 +5,7 @@ const { test } = tap;
 
 lockdown();
 
-test('reject html comment expressions in evaluate', t => {
+test('evade html comment expressions in evaluate', t => {
   const c = new Compartment();
 
   function wrap(s) {
@@ -59,7 +59,7 @@ test('reject html comment expressions in evaluate', t => {
   t.end();
 });
 
-test('reject html comment expressions in Function', t => {
+test('evade html comment expressions in Function', t => {
   const c = new Compartment();
 
   function wrap(s) {

--- a/packages/ses/test/evade-html-comment.test.js
+++ b/packages/ses/test/evade-html-comment.test.js
@@ -63,7 +63,7 @@ test('evade html comment expressions in Function', t => {
   const c = new Compartment();
 
   function wrap(s) {
-    return `new Function("${s}; return a;")`;
+    return `new Function(${'`'}${s}; return a;${'`'})`;
   }
 
   const htmlOpenComment1 = `const a = foo <!-- hah\n('evil')`;

--- a/packages/ses/test/evade-html-comment.test.js
+++ b/packages/ses/test/evade-html-comment.test.js
@@ -5,6 +5,8 @@ const { test } = tap;
 
 lockdown();
 
+const opt = harden({ __evadeHtmlCommentTest__: true });
+
 test('evade html comment expressions in evaluate', t => {
   const c = new Compartment();
 
@@ -19,43 +21,20 @@ test('evade html comment expressions in evaluate', t => {
   const htmlOpenComment1 = `const a = foo <!-- hah\n('evil')`;
   const htmlCloseComment1 = `const a = foo --> hah\n('evil')`;
   const htmlOpenComment2 = `const a = eval <!-- hah\n('evil')`;
-  const htmlCloseComment2 = `const a = eval --> hah\n('evil')`;
-  const htmlOpenComment3 = `const a = import <!-- hah\n('evil')`;
-  const htmlCloseComment3 = `const a = import --> hah\n('evil')`;
 
-  t.throws(
-    () => c.evaluate(wrap(htmlOpenComment1)),
-    SyntaxError,
+  t.doesNotThrow(
+    () => c.evaluate(wrap(htmlOpenComment1), opt),
     'htmlOpenComment',
   );
-  t.throws(
-    () => c.evaluate(wrap(htmlCloseComment1)),
-    SyntaxError,
+  t.doesNotThrow(
+    () => c.evaluate(wrap(htmlCloseComment1), opt),
     'htmlCloseComment',
   );
 
-  t.throws(
-    () => c.evaluate(wrap(htmlOpenComment2)),
-    SyntaxError,
+  t.doesNotThrow(
+    () => c.evaluate(wrap(htmlOpenComment2), opt),
     'htmlOpenComment',
   );
-  t.throws(
-    () => c.evaluate(wrap(htmlCloseComment2)),
-    SyntaxError,
-    'htmlCloseComment',
-  );
-
-  t.throws(
-    () => c.evaluate(wrap(htmlOpenComment3)),
-    SyntaxError,
-    'htmlOpenComment',
-  );
-  t.throws(
-    () => c.evaluate(wrap(htmlCloseComment3)),
-    SyntaxError,
-    'htmlCloseComment',
-  );
-
   t.end();
 });
 
@@ -69,41 +48,19 @@ test('evade html comment expressions in Function', t => {
   const htmlOpenComment1 = `const a = foo <!-- hah\n('evil')`;
   const htmlCloseComment1 = `const a = foo --> hah\n('evil')`;
   const htmlOpenComment2 = `const a = eval <!-- hah\n('evil')`;
-  const htmlCloseComment2 = `const a = eval --> hah\n('evil')`;
-  const htmlOpenComment3 = `const a = import <!-- hah\n('evil')`;
-  const htmlCloseComment3 = `const a = import --> hah\n('evil')`;
 
-  t.throws(
-    () => c.evaluate(wrap(htmlOpenComment1)),
-    SyntaxError,
+  t.doesNotThrow(
+    () => c.evaluate(wrap(htmlOpenComment1), opt),
     'htmlOpenComment',
   );
-  t.throws(
-    () => c.evaluate(wrap(htmlCloseComment1)),
-    SyntaxError,
+  t.doesNotThrow(
+    () => c.evaluate(wrap(htmlCloseComment1), opt),
     'htmlCloseComment',
   );
 
-  t.throws(
-    () => c.evaluate(wrap(htmlOpenComment2)),
-    SyntaxError,
+  t.doesNotThrow(
+    () => c.evaluate(wrap(htmlOpenComment2), opt),
     'htmlOpenComment',
-  );
-  t.throws(
-    () => c.evaluate(wrap(htmlCloseComment2)),
-    SyntaxError,
-    'htmlCloseComment',
-  );
-
-  t.throws(
-    () => c.evaluate(wrap(htmlOpenComment3)),
-    SyntaxError,
-    'htmlOpenComment',
-  );
-  t.throws(
-    () => c.evaluate(wrap(htmlCloseComment3)),
-    SyntaxError,
-    'htmlCloseComment',
   );
 
   t.end();

--- a/packages/ses/test/evade-import-expression.test.js
+++ b/packages/ses/test/evade-import-expression.test.js
@@ -5,7 +5,7 @@ const { test } = tap;
 
 lockdown();
 
-test('reject import expressions in evaluate', t => {
+test('evade import expressions in evaluate', t => {
   const c = new Compartment();
 
   function wrap(s) {
@@ -44,7 +44,7 @@ test('reject import expressions in evaluate', t => {
   t.end();
 });
 
-test('reject import expressions in Function', t => {
+test('evade import expressions in Function', t => {
   const c = new Compartment();
 
   function wrap(s) {

--- a/packages/ses/test/evade-import-expression.test.js
+++ b/packages/ses/test/evade-import-expression.test.js
@@ -5,6 +5,8 @@ const { test } = tap;
 
 lockdown();
 
+const opt = harden({ __evadeImportExpressionTest__: true });
+
 test('evade import expressions in evaluate', t => {
   const c = new Compartment();
 
@@ -16,10 +18,6 @@ test('evade import expressions in evaluate', t => {
       }`;
   }
 
-  const safe = `const a = 1`;
-  const safe2 = `const a = notimport('evil')`;
-  const safe3 = `const a = importnot('evil')`;
-
   const obvious = `const a = import('evil')`;
   const whitespace = `const a = import ('evil')`;
   const comment = `const a = import/*hah*/('evil')`;
@@ -27,19 +25,15 @@ test('evade import expressions in evaluate', t => {
   const newline = `const a = import\n('evil')`;
   const multiline = `\nimport('a')\nimport('b')`;
 
-  t.doesNotThrow(() => c.evaluate(wrap(safe)), 'safe');
-  t.doesNotThrow(() => c.evaluate(wrap(safe2)), 'safe2');
-  t.doesNotThrow(() => c.evaluate(wrap(safe3)), 'safe3');
-  t.throws(() => c.evaluate(wrap(obvious)), SyntaxError, 'obvious');
-  t.throws(() => c.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
-  t.throws(() => c.evaluate(wrap(comment)), SyntaxError, 'comment');
-  t.throws(
-    () => c.evaluate(wrap(doubleSlashComment)),
-    SyntaxError,
+  t.doesNotThrow(() => c.evaluate(wrap(obvious), opt), 'obvious');
+  t.doesNotThrow(() => c.evaluate(wrap(whitespace), opt), 'whitespace');
+  t.doesNotThrow(() => c.evaluate(wrap(comment), opt), 'comment');
+  t.doesNotThrow(
+    () => c.evaluate(wrap(doubleSlashComment), opt),
     'doubleSlashComment',
   );
-  t.throws(() => c.evaluate(wrap(newline)), SyntaxError, 'newline');
-  t.throws(() => c.evaluate(wrap(multiline)), SyntaxError, 'multiline');
+  t.doesNotThrow(() => c.evaluate(wrap(newline), opt), 'newline');
+  t.doesNotThrow(() => c.evaluate(wrap(multiline), opt), 'multiline');
 
   t.end();
 });
@@ -48,12 +42,8 @@ test('evade import expressions in Function', t => {
   const c = new Compartment();
 
   function wrap(s) {
-    return `new Function("${s}; return a;")`;
+    return `new Function(${'`'}${s}; return a;${'`'})`;
   }
-
-  const safe = `const a = 1`;
-  const safe2 = `const a = notimport('evil')`;
-  const safe3 = `const a = importnot('evil')`;
 
   const obvious = `const a = import('evil')`;
   const whitespace = `const a = import ('evil')`;
@@ -62,19 +52,15 @@ test('evade import expressions in Function', t => {
   const newline = `const a = import\n('evil')`;
   const multiline = `\nimport('a')\nimport('b')`;
 
-  t.doesNotThrow(() => c.evaluate(wrap(safe)), 'safe');
-  t.doesNotThrow(() => c.evaluate(wrap(safe2)), 'safe2');
-  t.doesNotThrow(() => c.evaluate(wrap(safe3)), 'safe3');
-  t.throws(() => c.evaluate(wrap(obvious)), SyntaxError, 'obvious');
-  t.throws(() => c.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
-  t.throws(() => c.evaluate(wrap(comment)), SyntaxError, 'comment');
-  t.throws(
-    () => c.evaluate(wrap(doubleSlashComment)),
-    SyntaxError,
+  t.doesNotThrow(() => c.evaluate(wrap(obvious), opt), 'obvious');
+  t.doesNotThrow(() => c.evaluate(wrap(whitespace), opt), 'whitespace');
+  t.doesNotThrow(() => c.evaluate(wrap(comment), opt), 'comment');
+  t.doesNotThrow(
+    () => c.evaluate(wrap(doubleSlashComment), opt),
     'doubleSlashComment',
   );
-  t.throws(() => c.evaluate(wrap(newline)), SyntaxError, 'newline');
-  t.throws(() => c.evaluate(wrap(multiline)), SyntaxError, 'multiline');
+  t.doesNotThrow(() => c.evaluate(wrap(newline), opt), 'newline');
+  t.doesNotThrow(() => c.evaluate(wrap(multiline), opt), 'multiline');
 
   t.end();
 });

--- a/packages/ses/test/evade-import-expression.test.js
+++ b/packages/ses/test/evade-import-expression.test.js
@@ -27,9 +27,9 @@ test('evade import expressions in evaluate', t => {
   const newline = `const a = import\n('evil')`;
   const multiline = `\nimport('a')\nimport('b')`;
 
-  t.doesNotThrow(() => c.evaluate(wrap(safe)), SyntaxError, 'safe');
-  t.doesNotThrow(() => c.evaluate(wrap(safe2)), SyntaxError, 'safe2');
-  t.doesNotThrow(() => c.evaluate(wrap(safe3)), SyntaxError, 'safe3');
+  t.doesNotThrow(() => c.evaluate(wrap(safe)), 'safe');
+  t.doesNotThrow(() => c.evaluate(wrap(safe2)), 'safe2');
+  t.doesNotThrow(() => c.evaluate(wrap(safe3)), 'safe3');
   t.throws(() => c.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => c.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
   t.throws(() => c.evaluate(wrap(comment)), SyntaxError, 'comment');
@@ -62,9 +62,9 @@ test('evade import expressions in Function', t => {
   const newline = `const a = import\n('evil')`;
   const multiline = `\nimport('a')\nimport('b')`;
 
-  t.doesNotThrow(() => c.evaluate(wrap(safe)), SyntaxError, 'safe');
-  t.doesNotThrow(() => c.evaluate(wrap(safe2)), SyntaxError, 'safe2');
-  t.doesNotThrow(() => c.evaluate(wrap(safe3)), SyntaxError, 'safe3');
+  t.doesNotThrow(() => c.evaluate(wrap(safe)), 'safe');
+  t.doesNotThrow(() => c.evaluate(wrap(safe2)), 'safe2');
+  t.doesNotThrow(() => c.evaluate(wrap(safe3)), 'safe3');
   t.throws(() => c.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => c.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
   t.throws(() => c.evaluate(wrap(comment)), SyntaxError, 'comment');

--- a/packages/ses/test/reject-direct-eval.test.js
+++ b/packages/ses/test/reject-direct-eval.test.js
@@ -55,7 +55,7 @@ test('reject direct eval expressions in Function', t => {
   const c = new Compartment();
 
   function wrap(s) {
-    return `new Function("${s}; return a;")`;
+    return `new Function(${'`'}${s}; return a;${'`'})`;
   }
 
   const safe = `const a = 1`;
@@ -83,9 +83,8 @@ test('reject direct eval expressions in Function', t => {
   t.throws(() => c.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => c.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
   t.doesNotThrow(() => c.evaluate(wrap(comment)), 'comment');
-  t.throws(
+  t.doesNotThrow(
     () => c.evaluate(wrap(doubleSlashComment)),
-    SyntaxError,
     'doubleSlashComment',
   );
   t.throws(() => c.evaluate(wrap(newline)), SyntaxError, 'newline');

--- a/packages/ses/test/reject-direct-eval.test.js
+++ b/packages/ses/test/reject-direct-eval.test.js
@@ -45,8 +45,8 @@ test('reject direct eval expressions in evaluate', t => {
 
   t.throws(() => c.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => c.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
-  t.throws(() => c.evaluate(wrap(comment)), SyntaxError, 'comment');
-  t.throws(
+  t.doesNotThrow(() => c.evaluate(wrap(comment)), SyntaxError, 'comment');
+  t.doesNotThrow(
     () => c.evaluate(wrap(doubleSlashComment)),
     SyntaxError,
     'doubleSlashComment',
@@ -93,7 +93,7 @@ test('reject direct eval expressions in Function', t => {
 
   t.throws(() => c.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => c.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
-  t.throws(() => c.evaluate(wrap(comment)), SyntaxError, 'comment');
+  t.doesNotThrow(() => c.evaluate(wrap(comment)), SyntaxError, 'comment');
   t.throws(
     () => c.evaluate(wrap(doubleSlashComment)),
     SyntaxError,

--- a/packages/ses/test/reject-direct-eval.test.js
+++ b/packages/ses/test/reject-direct-eval.test.js
@@ -32,18 +32,17 @@ test('reject direct eval expressions in evaluate', t => {
   const newline = `const a = eval\n('evil')`;
   const multiline = `\neval('a')\neval('b')`;
 
-  t.doesNotThrow(() => c.evaluate(wrap(safe)), SyntaxError, 'safe');
-  t.doesNotThrow(() => c.evaluate(wrap(safe2)), SyntaxError, 'safe2');
-  t.doesNotThrow(() => c.evaluate(wrap(safe3)), SyntaxError, 'safe3');
+  t.doesNotThrow(() => c.evaluate(wrap(safe)), 'safe');
+  t.doesNotThrow(() => c.evaluate(wrap(safe2)), 'safe2');
+  t.doesNotThrow(() => c.evaluate(wrap(safe3)), 'safe3');
 
-  t.doesNotThrow(() => c.evaluate(wrap(bogus)), SyntaxError, 'bogus');
+  t.doesNotThrow(() => c.evaluate(wrap(bogus)), 'bogus');
 
   t.throws(() => c.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => c.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
-  t.doesNotThrow(() => c.evaluate(wrap(comment)), SyntaxError, 'comment');
+  t.doesNotThrow(() => c.evaluate(wrap(comment)), 'comment');
   t.doesNotThrow(
     () => c.evaluate(wrap(doubleSlashComment)),
-    SyntaxError,
     'doubleSlashComment',
   );
   t.throws(() => c.evaluate(wrap(newline)), SyntaxError, 'newline');
@@ -75,15 +74,15 @@ test('reject direct eval expressions in Function', t => {
   const newline = `const a = eval\n('evil')`;
   const multiline = `\neval('a')\neval('b')`;
 
-  t.doesNotThrow(() => c.evaluate(wrap(safe)), SyntaxError, 'safe');
-  t.doesNotThrow(() => c.evaluate(wrap(safe2)), SyntaxError, 'safe2');
-  t.doesNotThrow(() => c.evaluate(wrap(safe3)), SyntaxError, 'safe3');
+  t.doesNotThrow(() => c.evaluate(wrap(safe)), 'safe');
+  t.doesNotThrow(() => c.evaluate(wrap(safe2)), 'safe2');
+  t.doesNotThrow(() => c.evaluate(wrap(safe3)), 'safe3');
 
-  t.doesNotThrow(() => c.evaluate(wrap(bogus)), SyntaxError, 'bogus');
+  t.doesNotThrow(() => c.evaluate(wrap(bogus)), 'bogus');
 
   t.throws(() => c.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => c.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
-  t.doesNotThrow(() => c.evaluate(wrap(comment)), SyntaxError, 'comment');
+  t.doesNotThrow(() => c.evaluate(wrap(comment)), 'comment');
   t.throws(
     () => c.evaluate(wrap(doubleSlashComment)),
     SyntaxError,

--- a/packages/ses/test/reject-html-comment.test.js
+++ b/packages/ses/test/reject-html-comment.test.js
@@ -63,7 +63,7 @@ test('reject html comment expressions in Function', t => {
   const c = new Compartment();
 
   function wrap(s) {
-    return `new Function("${s}; return a;")`;
+    return `new Function(${'`'}${s}; return a;${'`'})`;
   }
 
   const htmlOpenComment1 = `const a = foo <!-- hah\n('evil')`;

--- a/packages/ses/test/reject-import-expression.test.js
+++ b/packages/ses/test/reject-import-expression.test.js
@@ -27,9 +27,9 @@ test('reject import expressions in evaluate', t => {
   const newline = `const a = import\n('evil')`;
   const multiline = `\nimport('a')\nimport('b')`;
 
-  t.doesNotThrow(() => c.evaluate(wrap(safe)), SyntaxError, 'safe');
-  t.doesNotThrow(() => c.evaluate(wrap(safe2)), SyntaxError, 'safe2');
-  t.doesNotThrow(() => c.evaluate(wrap(safe3)), SyntaxError, 'safe3');
+  t.doesNotThrow(() => c.evaluate(wrap(safe)), 'safe');
+  t.doesNotThrow(() => c.evaluate(wrap(safe2)), 'safe2');
+  t.doesNotThrow(() => c.evaluate(wrap(safe3)), 'safe3');
   t.throws(() => c.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => c.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
   t.throws(() => c.evaluate(wrap(comment)), SyntaxError, 'comment');
@@ -62,9 +62,9 @@ test('reject import expressions in Function', t => {
   const newline = `const a = import\n('evil')`;
   const multiline = `\nimport('a')\nimport('b')`;
 
-  t.doesNotThrow(() => c.evaluate(wrap(safe)), SyntaxError, 'safe');
-  t.doesNotThrow(() => c.evaluate(wrap(safe2)), SyntaxError, 'safe2');
-  t.doesNotThrow(() => c.evaluate(wrap(safe3)), SyntaxError, 'safe3');
+  t.doesNotThrow(() => c.evaluate(wrap(safe)), 'safe');
+  t.doesNotThrow(() => c.evaluate(wrap(safe2)), 'safe2');
+  t.doesNotThrow(() => c.evaluate(wrap(safe3)), 'safe3');
   t.throws(() => c.evaluate(wrap(obvious)), SyntaxError, 'obvious');
   t.throws(() => c.evaluate(wrap(whitespace)), SyntaxError, 'whitespace');
   t.throws(() => c.evaluate(wrap(comment)), SyntaxError, 'comment');

--- a/packages/ses/test/reject-import-expression.test.js
+++ b/packages/ses/test/reject-import-expression.test.js
@@ -48,7 +48,7 @@ test('reject import expressions in Function', t => {
   const c = new Compartment();
 
   function wrap(s) {
-    return `new Function("${s}; return a;")`;
+    return `new Function(${'`'}${s}; return a;${'`'})`;
   }
 
   const safe = `const a = 1`;

--- a/packages/ses/test/transforms.test.js
+++ b/packages/ses/test/transforms.test.js
@@ -136,12 +136,12 @@ test('no-eval-expression regexp', t => {
     SyntaxError,
     'whitespace',
   );
-  t.throws(
+  t.doesNotThrow(
     () => rejectSomeDirectEvalExpressions(comment),
     SyntaxError,
     'comment',
   );
-  t.throws(
+  t.doesNotThrow(
     () => rejectSomeDirectEvalExpressions(doubleSlashComment),
     SyntaxError,
     'doubleSlashComment',

--- a/packages/ses/test/transforms.test.js
+++ b/packages/ses/test/transforms.test.js
@@ -136,14 +136,9 @@ test('no-eval-expression regexp', t => {
     SyntaxError,
     'whitespace',
   );
-  t.doesNotThrow(
-    () => rejectSomeDirectEvalExpressions(comment),
-    SyntaxError,
-    'comment',
-  );
+  t.doesNotThrow(() => rejectSomeDirectEvalExpressions(comment), 'comment');
   t.doesNotThrow(
     () => rejectSomeDirectEvalExpressions(doubleSlashComment),
-    SyntaxError,
     'doubleSlashComment',
   );
   // t.throws(

--- a/packages/ses/test/typeof.test.js
+++ b/packages/ses/test/typeof.test.js
@@ -23,7 +23,7 @@ test('typeof', t => {
   // TODO: the Compartment currently censors objects from the unsafe global, but
   // they appear defined as 'undefined' and don't throw a ReferenceError.
   // https://github.com/Agoric/SES-shim/issues/309
-  t.doesNotThrow(() => c.evaluate('global'), ReferenceError);
+  t.doesNotThrow(() => c.evaluate('global'));
   t.equal(c.evaluate('global'), undefined);
   t.equal(c.evaluate('typeof global'), 'undefined');
 


### PR DESCRIPTION
Fixes #498 
is the intention. Currently WIP Draft which does not.

Note that these are lightweight because they avoid parsing. As a result, they can change the meaning of some programs. Any system that parses and transforms should instead evade accurately by generating code that avoids the rejections without changing the meaning of programs.