### PR TITLE
fix(compartment-mapper)!: Freeze globalThis in each compartment

### DIFF
--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -10,6 +10,9 @@ User-visible changes to the compartment mapper:
   Compartment Mapper unusable with a combination of `-r esm` and Rollup.
   CommonJS support should be restored with an alternate implementation in
   a future version.
+* *BREAKING*: Every compartment's globals will be frozen unconditionally.
+  A future release may allow a relaxation of this constraint through an
+  annotation in `package.json`.
 * The `import` options bag now also accepts `globalLexicals` and `transforms`,
   passing these without alteration to each `Compartment`.
 * The `import` options bag now also accepts a `Compartment` constructor, to use

--- a/packages/compartment-mapper/src/assemble.js
+++ b/packages/compartment-mapper/src/assemble.js
@@ -175,6 +175,9 @@ export const assemble = (
       name: location
     });
 
+    // TODO freeze global conditionally
+    Object.freeze(compartment.globalThis);
+
     compartments[compartmentName] = compartment;
   }
 


### PR DESCRIPTION
This is the last necessary change to capture in the next release for the bundler in Agoric SDK to work with Compartment Mapper.