### PR TITLE
fix(compartment-mapper): Work around dynamic import censoring

### DIFF
--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -2,7 +2,8 @@ User-visible changes to the compartment mapper:
 
 ## Next release
 
-* No changes yet.
+* Embellishes all calls to methods named `import` to work around SES-shim
+  `Compartment` censoring for dynamic import.
 
 ## 0.2.1 (2020-11-04)
 

--- a/packages/compartment-mapper/src/import-archive.js
+++ b/packages/compartment-mapper/src/import-archive.js
@@ -75,7 +75,7 @@ export const parseArchive = async (archiveBytes, archiveLocation) => {
       __shimTransforms__,
       Compartment
     });
-    return compartment.import(moduleSpecifier);
+    return (compartment.import)(moduleSpecifier);
   };
 
   return { import: execute };
@@ -88,5 +88,5 @@ export const loadArchive = async (read, archiveLocation) => {
 
 export const importArchive = async (read, archiveLocation, options) => {
   const archive = await loadArchive(read, archiveLocation);
-  return archive.import(options);
+  return (archive.import)(options);
 };

--- a/packages/compartment-mapper/src/import-archive.js
+++ b/packages/compartment-mapper/src/import-archive.js
@@ -1,4 +1,4 @@
-/* eslint no-shadow: 0 */
+/* eslint no-shadow: "off", no-extra-parens: "off" */
 
 import { readZip } from "./zip.js";
 import { assemble } from "./assemble.js";

--- a/packages/compartment-mapper/src/import-archive.js
+++ b/packages/compartment-mapper/src/import-archive.js
@@ -1,4 +1,4 @@
-/* eslint no-shadow: "off", no-extra-parens: "off" */
+/* eslint no-shadow: "off" */
 
 import { readZip } from "./zip.js";
 import { assemble } from "./assemble.js";
@@ -75,6 +75,8 @@ export const parseArchive = async (archiveBytes, archiveLocation) => {
       __shimTransforms__,
       Compartment
     });
+    // Wrap import calls to bypass SES censoring for dynamic import.
+    // eslint-disable-next-line prettier/prettier
     return (compartment.import)(moduleSpecifier);
   };
 
@@ -88,5 +90,7 @@ export const loadArchive = async (read, archiveLocation) => {
 
 export const importArchive = async (read, archiveLocation, options) => {
   const archive = await loadArchive(read, archiveLocation);
+  // Wrap import calls to bypass SES censoring for dynamic import.
+  // eslint-disable-next-line prettier/prettier
   return (archive.import)(options);
 };

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -1,4 +1,4 @@
-/* eslint no-shadow: 0 */
+/* eslint no-shadow: "off", no-extra-parens: "off" */
 
 import { compartmentMapForNodeModules } from "./node-modules.js";
 import { search } from "./search.js";

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -1,4 +1,4 @@
-/* eslint no-shadow: "off", no-extra-parens: "off" */
+/* eslint no-shadow: "off" */
 
 import { compartmentMapForNodeModules } from "./node-modules.js";
 import { search } from "./search.js";
@@ -44,6 +44,8 @@ export const loadLocation = async (read, moduleLocation) => {
       __shimTransforms__,
       Compartment
     });
+    // Wrap import calls to bypass SES censoring for dynamic import.
+    // eslint-disable-next-line prettier/prettier
     return (compartment.import)(moduleSpecifier);
   };
 
@@ -52,5 +54,7 @@ export const loadLocation = async (read, moduleLocation) => {
 
 export const importLocation = async (read, moduleLocation, options = {}) => {
   const application = await loadLocation(read, moduleLocation);
+  // Wrap import calls to bypass SES censoring for dynamic import.
+  // eslint-disable-next-line prettier/prettier
   return (application.import)(options);
 };

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -44,7 +44,7 @@ export const loadLocation = async (read, moduleLocation) => {
       __shimTransforms__,
       Compartment
     });
-    return compartment.import(moduleSpecifier);
+    return (compartment.import)(moduleSpecifier);
   };
 
   return { import: execute };
@@ -52,5 +52,5 @@ export const loadLocation = async (read, moduleLocation) => {
 
 export const importLocation = async (read, moduleLocation, options = {}) => {
   const application = await loadLocation(read, moduleLocation);
-  return application.import(options);
+  return (application.import)(options);
 };

--- a/packages/compartment-mapper/src/zip/format-reader.js
+++ b/packages/compartment-mapper/src/zip/format-reader.js
@@ -28,7 +28,17 @@
  *  comment: string, // presumed UTF-8
  * }} CentralDirectoryLocator
  *
- * @typedef {import('./buffer-reader.js').BufferReader} BufferReader
+ * @typedef {{
+ *   readonly length: number,
+ *   offset: number,
+ *   read(size: number): Uint8Array,
+ *   skip(size: number): void,
+ *   seek(index: number): void,
+ *   expect(bytes: Uint8Array): boolean,
+ *   readUint8(): number,
+ *   readUint16LE(): number,
+ *   readUint32LE(): number,
+ * }} BufferReader
  */
 
 import "./types.js";

--- a/packages/compartment-mapper/src/zip/format-writer.js
+++ b/packages/compartment-mapper/src/zip/format-writer.js
@@ -20,7 +20,15 @@
  *   comment: Uint8Array,
  * } & ArchiveHeaders} FileRecord
  *
- * @typedef {import('./buffer-writer.js').BufferWriter} BufferWriter
+ * @typedef {{
+ *   index: number,
+ *   readonly length: number,
+ *   write(bytes: Uint8Array): void,
+ *   writeCopy(start: number, end: number): void,
+ *   writeUint8(number: number): void,
+ *   writeUint16LE(number: number): void,
+ *   writeUint32LE(number: number): void,
+ * }} BufferWriter
  */
 
 import "./types.js";


### PR DESCRIPTION
This change puts a ring of parentheses on calls to `import`, and inlines type definitions for buffered reader and writer to avoid using `import` at all in TypeScript JSDoc type annotations.