### PR TITLE
fix(compartment-mapper): Different tack to evade SES import censor

### DIFF
--- a/packages/compartment-mapper/NEWS.md
+++ b/packages/compartment-mapper/NEWS.md
@@ -1,5 +1,12 @@
 User-visible changes to the compartment mapper:
 
+## Next release
+
+* Embellishes all calls to methods named `import` to work around SES-shim
+  `Compartment` censoring for dynamic import, using properties instead
+  of parentheses, since the syntax transformation tools at hand do not
+  currently simplify these.
+
 ## 0.2.2 (2020-11-05)
 
 * Embellishes all calls to methods named `import` to work around SES-shim

--- a/packages/compartment-mapper/src/import-archive.js
+++ b/packages/compartment-mapper/src/import-archive.js
@@ -75,9 +75,9 @@ export const parseArchive = async (archiveBytes, archiveLocation) => {
       __shimTransforms__,
       Compartment
     });
-    // Wrap import calls to bypass SES censoring for dynamic import.
-    // eslint-disable-next-line prettier/prettier
-    return (compartment.import)(moduleSpecifier);
+    // Call import by property to bypass SES censoring for dynamic import.
+    // eslint-disable-next-line dot-notation
+    return compartment["import"](moduleSpecifier);
   };
 
   return { import: execute };
@@ -90,7 +90,7 @@ export const loadArchive = async (read, archiveLocation) => {
 
 export const importArchive = async (read, archiveLocation, options) => {
   const archive = await loadArchive(read, archiveLocation);
-  // Wrap import calls to bypass SES censoring for dynamic import.
-  // eslint-disable-next-line prettier/prettier
-  return (archive.import)(options);
+  // Call import by property to bypass SES censoring for dynamic import.
+  // eslint-disable-next-line dot-notation
+  return archive["import"](options);
 };

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -44,9 +44,9 @@ export const loadLocation = async (read, moduleLocation) => {
       __shimTransforms__,
       Compartment
     });
-    // Wrap import calls to bypass SES censoring for dynamic import.
-    // eslint-disable-next-line prettier/prettier
-    return (compartment.import)(moduleSpecifier);
+    // Call import by property to bypass SES censoring for dynamic import.
+    // eslint-disable-next-line dot-notation
+    return compartment["import"](moduleSpecifier);
   };
 
   return { import: execute };
@@ -54,7 +54,7 @@ export const loadLocation = async (read, moduleLocation) => {
 
 export const importLocation = async (read, moduleLocation, options = {}) => {
   const application = await loadLocation(read, moduleLocation);
-  // Wrap import calls to bypass SES censoring for dynamic import.
-  // eslint-disable-next-line prettier/prettier
-  return (application.import)(options);
+  // Call import by property to bypass SES censoring for dynamic import.
+  // eslint-disable-next-line dot-notation
+  return application["import"](options);
 };


### PR DESCRIPTION
The prior tack was simplified away when round-tripped through certain Babel transforms. I don’t believe we’ve arrived at a principled stance to how to press this code through the Agoric SDK consistently, but this one gets us farther for now.