### PR TITLE
chore: Add dependency consistency checker

### DIFF
--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -1,0 +1,25 @@
+name: Test project mutual dependency versions
+
+# run CI on pushes to master, and on all PRs (even the ones that target other
+# branches)
+
+on:
+ push:
+   branches: [master]
+ pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['12.14.1', '12.x', '14.x']
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: 'true'
+    - uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: check dependencies
+      run: yarn depcheck

--- a/.github/workflows/depcheck.yml
+++ b/.github/workflows/depcheck.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['12.14.1', '12.x', '14.x']
+        node-version: ['14.x']
     steps:
     - uses: actions/checkout@v1
       with:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "clean": "lerna clean",
-    "depcheck": "lerna run --no-bail depcheck",
+    "depcheck": "node scripts/check-mismatched-dependencies.js",
     "update": "lernaupdate --dedupe",
     "prettier": "lerna run prettier",
     "lint": "yarn clean --yes && lerna run lint",

--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -14,7 +14,6 @@
   "scripts": {
     "build": "rollup --config rollup.config.js",
     "clean": "rm -rf dist",
-    "depcheck": "depcheck",
     "lint": "eslint '**/*.js'",
     "lint-fix": "eslint --fix '**/*.js'",
     "prepublish": "yarn clean && yarn build",

--- a/packages/endo/package.json
+++ b/packages/endo/package.json
@@ -6,7 +6,6 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "depcheck": "depcheck",
     "lint": "eslint '**/*.js'",
     "lint-fix": "eslint --fix '**/*.js'",
     "postinstall": "node src/postinstall.js",

--- a/packages/make-hardener/package.json
+++ b/packages/make-hardener/package.json
@@ -42,7 +42,6 @@
   "scripts": {
     "prepublish": "yarn clean && yarn build",
     "clean": "rm -rf dist",
-    "depcheck": "depcheck",
     "lint": "eslint '**/*.js'",
     "lint-fix": "eslint --fix '**/*.js'",
     "test": "tap --no-esm --no-coverage --reporter spec 'test/**/*.test.js'",

--- a/packages/make-importer/package.json
+++ b/packages/make-importer/package.json
@@ -24,7 +24,6 @@
     "prepublish": "yarn clean && yarn build",
     "build": "rollup --config rollup.config.js",
     "clean": "rm -rf dist",
-    "depcheck": "depcheck",
     "lint": "eslint '**/*.js'",
     "lint-fix": "eslint --fix '**/*.js'",
     "OFF-test": "tap --no-esm --no-coverage --reporter spec 'test/**/*.test.js'",

--- a/packages/make-simple-evaluate/package.json
+++ b/packages/make-simple-evaluate/package.json
@@ -9,7 +9,6 @@
   "type": "module",
   "main": "./src/main.js",
   "scripts": {
-    "depcheck": "depcheck",
     "lint": "eslint '**/*.js'",
     "lint-fix": "eslint --fix '**/*.js'",
     "OFF-test": "tap --no-esm --no-coverage --reporter spec 'test/**/*.test.js'"

--- a/packages/ses-integration-test/package.json
+++ b/packages/ses-integration-test/package.json
@@ -8,7 +8,6 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "depcheck": "depcheck",
     "lint": "eslint '**/*.js'",
     "lint-fix": "eslint --fix '**/*.js'",
     "test:pre-release": "node -r esm puppeteer-test/pre-release.test.js",

--- a/packages/ses-integration-test/package.json
+++ b/packages/ses-integration-test/package.json
@@ -26,7 +26,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ses": "file:../ses"
+    "ses": "^0.11.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^13.0.0",

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -25,7 +25,6 @@
   },
   "scripts": {
     "prepublish": "yarn clean && yarn build",
-    "depcheck": "depcheck",
     "clean": "rm -rf dist",
     "lint": "eslint '**/*.js'",
     "lint-fix": "eslint --fix '**/*.js'",

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -8,7 +8,6 @@
   "type": "module",
   "main": "./src/main.js",
   "scripts": {
-    "depcheck": "depcheck",
     "lint-fix": "eslint --fix '**/*.js'",
     "lint": "eslint '**/*.js'"
   },

--- a/packages/transform-module/package.json
+++ b/packages/transform-module/package.json
@@ -22,7 +22,6 @@
     "clean": "rm -rf dist",
     "build": "rollup --config rollup.config.js",
     "prepublish": "yarn clean && yarn build",
-    "depcheck": "depcheck",
     "lint": "eslint '**/*.js'",
     "lint-fix": "eslint --fix '**/*.js'",
     "OFF-test": "tap --no-esm --no-coverage --reporter spec 'test/**/*.test.js'"

--- a/scripts/check-mismatched-dependencies.js
+++ b/scripts/check-mismatched-dependencies.js
@@ -1,0 +1,33 @@
+#! /usr/bin/env node
+
+const { spawnSync } = require('child_process');
+console.log(`running 'yarn workspaces info' to check for mismatched dependencies`);
+const s = spawnSync('yarn', ['--silent', 'workspaces', 'info'], {
+  stdio: ['ignore', 'pipe', 'inherit']
+});
+if (s.status !== 0) {
+  console.log(`error running 'yarn workspaces info':`);
+  console.log(s.status);
+  console.log(s.signal);
+  console.log(s.error);
+  console.log(s.stdout);
+  console.log(s.stderr);
+  process.exit(1);
+}
+
+let good = true;
+const d = JSON.parse(s.stdout);
+for (const pkgname of Object.getOwnPropertyNames(d)) {
+  const md = d[pkgname].mismatchedWorkspaceDependencies;
+  if (md.length) {
+    console.log(`package '${pkgname}' has mismatched dependencies on: ${md}`);
+    good = false;
+  }
+}
+if (good) {
+  console.log('looks good');
+  process.exit(0);
+} else {
+  process.exit(1);
+}
+

--- a/scripts/check-mismatched-dependencies.js
+++ b/scripts/check-mismatched-dependencies.js
@@ -1,6 +1,7 @@
-#! /usr/bin/env node
+#!/usr/bin/env node
 
 const { spawnSync } = require('child_process');
+
 console.log(`running 'yarn workspaces info' to check for mismatched dependencies`);
 const s = spawnSync('yarn', ['--silent', 'workspaces', 'info'], {
   stdio: ['ignore', 'pipe', 'inherit']
@@ -15,19 +16,11 @@ if (s.status !== 0) {
   process.exit(1);
 }
 
-let good = true;
 const d = JSON.parse(s.stdout);
 for (const pkgname of Object.getOwnPropertyNames(d)) {
   const md = d[pkgname].mismatchedWorkspaceDependencies;
   if (md.length) {
     console.log(`package '${pkgname}' has mismatched dependencies on: ${md}`);
-    good = false;
+    process.exitCode = 1;
   }
 }
-if (good) {
-  console.log('looks good');
-  process.exit(0);
-} else {
-  process.exit(1);
-}
-

--- a/scripts/check-packages.sh
+++ b/scripts/check-packages.sh
@@ -33,7 +33,6 @@ for JSON in $(find packages -depth 2 -name 'package.json'); do
     assert .scripts.prepublish "yarn clean && yarn build"
     assert .scripts.clean "rm -rf dist"
     assert .scripts.build "rollup --config rollup.config.js"
-    assert .scripts.depcheck depcheck
     assert .scripts.lint "eslint '**/*.js'"
     assert '.scripts["lint-fix"]' "eslint --fix '**/*.js'"
     assert '.devDependencies["@rollup/plugin-node-resolve"]' '^6.1.0'

--- a/scripts/repackage.sh
+++ b/scripts/repackage.sh
@@ -56,7 +56,6 @@ NEWPKGJSONHASH=$(
       prepublish: "yarn clean && yarn build",
       clean: "rm -rf dist",
       build: "rollup --config rollup.config.js",
-      depcheck: "depcheck",
       test: "yarn build && tap --no-esm --no-coverage --reporter spec 'test/**/*.test.js'",
       lint: "eslint '"'**/*.js'"'",
       "lint-fix": "eslint --fix '"'**/*.js'"'",


### PR DESCRIPTION
This ports the dependency checker from agoric-sdk to ensure we don’t break the invariant again that dependencies in the project depend on version predicates satisfied by the versions checked into the repository.