### PR TITLE
style: Converge on single quotes and dangling commas

### DIFF
--- a/packages/compartment-mapper/package.json
+++ b/packages/compartment-mapper/package.json
@@ -7,17 +7,20 @@
   "type": "module",
   "main": "./dist/compartment-mapper.cjs",
   "module": "./src/main.js",
+  "browser": "./dist/compartment-mapper.umd.js",
+  "unpkg": "./dist/compartment-mapper.umd.js",
   "exports": {
     "import": "./src/main.js",
-    "require": "./dist/compartment-mapper.cjs"
+    "require": "./dist/compartment-mapper.cjs",
+    "browser": "./dist/compartment-mapper.umd.js"
   },
   "scripts": {
     "build": "rollup --config rollup.config.js",
     "clean": "rm -rf dist",
     "lint": "yarn lint:types && yarn lint:js",
-    "lint:types": "tsc --build jsconfig.json",
-    "lint:js": "eslint '**/*.js'",
     "lint-fix": "eslint --fix '**/*.js'",
+    "lint:js": "eslint '**/*.js'",
+    "lint:types": "tsc --build jsconfig.json",
     "prepublish": "yarn clean && yarn build",
     "qt": "tap --no-esm --no-coverage --reporter spec 'test/**/*.test.js'",
     "test": "ava"
@@ -26,12 +29,12 @@
     "ses": "^0.11.0"
   },
   "devDependencies": {
-    "@agoric/eslint-config": "^0.1.0+1-dev",
+    "@agoric/eslint-config": "^0.1.0",
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
-    "rollup": "^2.0.0",
-    "ava": "^3.12.1"
+    "ava": "^3.12.1",
+    "rollup": "^2.0.0"
   },
   "ava": {
     "files": [
@@ -43,6 +46,10 @@
     "extends": [
       "@agoric"
     ]
+  },
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
   },
   "files": [
     "LICENSE*",

--- a/packages/compartment-mapper/rollup.config.js
+++ b/packages/compartment-mapper/rollup.config.js
@@ -1,25 +1,25 @@
-import resolve from "@rollup/plugin-node-resolve";
-import commonjs from "@rollup/plugin-commonjs";
-import json from "@rollup/plugin-json";
-import fs from "fs";
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import json from '@rollup/plugin-json';
+import fs from 'fs';
 
-const metaPath = new URL("package.json", import.meta.url).pathname;
-const meta = JSON.parse(fs.readFileSync(metaPath, "utf-8"));
-const name = meta.name.split("/").pop();
+const metaPath = new URL('package.json', import.meta.url).pathname;
+const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+const name = meta.name.split('/').pop();
 
 const resolveWithBuiltins = () => resolve({ preferBuiltins: true });
-const external = ["buffer", "events", "os", "stream", "tty", "util"];
+const external = ['buffer', 'events', 'os', 'stream', 'tty', 'util'];
 
 export default [
   {
-    input: "src/main.js",
+    input: 'src/main.js',
     output: [
       {
         file: `dist/${name}.cjs`,
-        format: "cjs"
-      }
+        format: 'cjs',
+      },
     ],
     external,
-    plugins: [resolveWithBuiltins(), commonjs(), json()]
-  }
+    plugins: [resolveWithBuiltins(), commonjs(), json()],
+  },
 ];

--- a/packages/compartment-mapper/src/archive.js
+++ b/packages/compartment-mapper/src/archive.js
@@ -1,12 +1,12 @@
 /* eslint no-shadow: 0 */
 
-import { writeZip } from "./zip.js";
-import { resolve } from "./node-module-specifier.js";
-import { compartmentMapForNodeModules } from "./node-modules.js";
-import { search } from "./search.js";
-import { assemble } from "./assemble.js";
-import { makeImportHookMaker } from "./import-hook.js";
-import * as json from "./json.js";
+import { writeZip } from './zip.js';
+import { resolve } from './node-module-specifier.js';
+import { compartmentMapForNodeModules } from './node-modules.js';
+import { search } from './search.js';
+import { assemble } from './assemble.js';
+import { makeImportHookMaker } from './import-hook.js';
+import * as json from './json.js';
 
 const encoder = new TextEncoder();
 
@@ -38,7 +38,7 @@ const translateCompartmentMap = (compartments, sources, renames) => {
         : undefined;
       modules[name] = {
         ...module,
-        compartment
+        compartment,
       };
     }
 
@@ -49,14 +49,14 @@ const translateCompartmentMap = (compartments, sources, renames) => {
       modules[name] = {
         location,
         parser,
-        exit
+        exit,
       };
     }
 
     result[renames[name]] = {
       label,
       location: renames[name],
-      modules
+      modules,
       // `scopes`, `types`, and `parsers` are not necessary since every
       // loadable module is captured in `modules`.
     };
@@ -67,13 +67,13 @@ const translateCompartmentMap = (compartments, sources, renames) => {
 
 const renameSources = (sources, renames) => {
   return fromEntries(
-    entries(sources).map(([name, compartment]) => [renames[name], compartment])
+    entries(sources).map(([name, compartment]) => [renames[name], compartment]),
   );
 };
 
 const addSourcesToArchive = async (archive, sources) => {
   for (const [compartment, modules] of entries(sources)) {
-    const compartmentLocation = resolveLocation(`${compartment}/`, "file:///");
+    const compartmentLocation = resolveLocation(`${compartment}/`, 'file:///');
     for (const { location, bytes } of values(modules)) {
       const moduleLocation = resolveLocation(location, compartmentLocation);
       const path = new URL(moduleLocation).pathname.slice(1); // elide initial "/"
@@ -90,24 +90,24 @@ export const makeArchive = async (read, moduleLocation) => {
     packageLocation,
     packageDescriptorText,
     packageDescriptorLocation,
-    moduleSpecifier
+    moduleSpecifier,
   } = await search(read, moduleLocation);
 
   const packageDescriptor = json.parse(
     packageDescriptorText,
-    packageDescriptorLocation
+    packageDescriptorLocation,
   );
   const compartmentMap = await compartmentMapForNodeModules(
     read,
     packageLocation,
     [],
     packageDescriptor,
-    moduleSpecifier
+    moduleSpecifier,
   );
 
   const {
     compartments,
-    entry: { compartment: entryCompartmentName, module: entryModuleSpecifier }
+    entry: { compartment: entryCompartmentName, module: entryModuleSpecifier },
   } = compartmentMap;
   const sources = {};
 
@@ -115,13 +115,13 @@ export const makeArchive = async (read, moduleLocation) => {
     read,
     packageLocation,
     sources,
-    compartments
+    compartments,
   );
 
   // Induce importHook to record all the necessary modules to import the given module specifier.
   const compartment = assemble(compartmentMap, {
     resolve,
-    makeImportHook
+    makeImportHook,
   });
   await compartment.load(entryModuleSpecifier);
 
@@ -129,7 +129,7 @@ export const makeArchive = async (read, moduleLocation) => {
   const archiveCompartments = translateCompartmentMap(
     compartments,
     sources,
-    renames
+    renames,
   );
   const archiveEntryCompartmentName = renames[entryCompartmentName];
   const archiveSources = renameSources(sources, renames);
@@ -137,19 +137,19 @@ export const makeArchive = async (read, moduleLocation) => {
   const archiveCompartmentMap = {
     entry: {
       compartment: archiveEntryCompartmentName,
-      module: moduleSpecifier
+      module: moduleSpecifier,
     },
-    compartments: archiveCompartments
+    compartments: archiveCompartments,
   };
   const archiveCompartmentMapText = JSON.stringify(
     archiveCompartmentMap,
     null,
-    2
+    2,
   );
   const archiveCompartmentMapBytes = encoder.encode(archiveCompartmentMapText);
 
   const archive = writeZip();
-  await archive.write("compartment-map.json", archiveCompartmentMapBytes);
+  await archive.write('compartment-map.json', archiveCompartmentMapBytes);
   await addSourcesToArchive(archive, archiveSources);
 
   return archive.snapshot();
@@ -159,7 +159,7 @@ export const writeArchive = async (
   write,
   read,
   archiveLocation,
-  moduleLocation
+  moduleLocation,
 ) => {
   const archiveBytes = await makeArchive(read, moduleLocation);
   await write(archiveLocation, archiveBytes);

--- a/packages/compartment-mapper/src/assemble.js
+++ b/packages/compartment-mapper/src/assemble.js
@@ -1,5 +1,5 @@
-import { resolve } from "./node-module-specifier.js";
-import { mapParsers } from "./parse.js";
+import { resolve } from './node-module-specifier.js';
+import { mapParsers } from './parse.js';
 
 const { entries } = Object;
 
@@ -14,7 +14,7 @@ const q = JSON.stringify;
 // "./aux".
 const trimModuleSpecifierPrefix = (moduleSpecifier, prefix) => {
   if (moduleSpecifier === prefix) {
-    return ".";
+    return '.';
   }
   if (moduleSpecifier.startsWith(`${prefix}/`)) {
     return `./${moduleSpecifier.slice(prefix.length + 1)}`;
@@ -35,7 +35,7 @@ const makeModuleMapHook = (
   compartmentName,
   moduleDescriptors,
   scopeDescriptors,
-  exitModules
+  exitModules,
 ) => {
   const moduleMapHook = moduleSpecifier => {
     const moduleDescriptor = moduleDescriptors[moduleSpecifier];
@@ -43,7 +43,7 @@ const makeModuleMapHook = (
       const {
         compartment: foreignCompartmentName = compartmentName,
         module: foreignModuleSpecifier,
-        exit
+        exit,
       } = moduleDescriptor;
       if (exit !== undefined) {
         // TODO Currenly, only the entry package can connect to built-in modules.
@@ -61,8 +61,8 @@ const makeModuleMapHook = (
         if (foreignCompartment === undefined) {
           throw new Error(
             `Cannot import from missing compartment ${q(
-              foreignCompartmentName
-            )}`
+              foreignCompartmentName,
+            )}`,
           );
         }
         return foreignCompartment.module(foreignModuleSpecifier);
@@ -77,7 +77,7 @@ const makeModuleMapHook = (
     for (const [scopePrefix, scopeDescriptor] of entries(scopeDescriptors)) {
       const foreignModuleSpecifier = trimModuleSpecifierPrefix(
         moduleSpecifier,
-        scopePrefix
+        scopePrefix,
       );
 
       if (foreignModuleSpecifier !== undefined) {
@@ -86,8 +86,8 @@ const makeModuleMapHook = (
         if (foreignCompartment === undefined) {
           throw new Error(
             `Cannot import from missing compartment ${q(
-              foreignCompartmentName
-            )}`
+              foreignCompartmentName,
+            )}`,
           );
         }
 
@@ -101,7 +101,7 @@ const makeModuleMapHook = (
         // archiev.
         moduleDescriptors[moduleSpecifier] = {
           compartment: foreignCompartmentName,
-          module: foreignModuleSpecifier
+          module: foreignModuleSpecifier,
         };
         return foreignCompartment.module(foreignModuleSpecifier);
       }
@@ -134,21 +134,21 @@ export const assemble = (
     transforms = [],
     __shimTransforms__ = [],
     modules: exitModules = {},
-    Compartment = defaultCompartment
-  }
+    Compartment = defaultCompartment,
+  },
 ) => {
   const { compartment: entryCompartmentName } = entry;
 
   const compartments = {};
   for (const [compartmentName, compartmentDescriptor] of entries(
-    compartmentDescriptors
+    compartmentDescriptors,
   )) {
     const {
       location,
       modules = {},
       parsers = {},
       types = {},
-      scopes = {}
+      scopes = {},
     } = compartmentDescriptor;
 
     // Capture the default.
@@ -162,7 +162,7 @@ export const assemble = (
       compartmentName,
       modules,
       scopes,
-      exitModules
+      exitModules,
     );
     const resolveHook = resolve;
 
@@ -174,7 +174,7 @@ export const assemble = (
       transforms,
       __shimTransforms__,
       globalLexicals,
-      name: location
+      name: location,
     });
 
     compartments[compartmentName] = compartment;
@@ -184,8 +184,8 @@ export const assemble = (
   if (compartment === undefined) {
     throw new Error(
       `Cannot assemble compartment graph because the root compartment named ${q(
-        entryCompartmentName
-      )} is missing from the compartment map`
+        entryCompartmentName,
+      )} is missing from the compartment map`,
     );
   }
 

--- a/packages/compartment-mapper/src/extension.js
+++ b/packages/compartment-mapper/src/extension.js
@@ -2,14 +2,14 @@
 // string if the path has no extension.
 // Exported for tests.
 export const parseExtension = location => {
-  const lastSlash = location.lastIndexOf("/");
+  const lastSlash = location.lastIndexOf('/');
   if (lastSlash < 0) {
-    return "";
+    return '';
   }
   const base = location.slice(lastSlash + 1);
-  const lastDot = base.lastIndexOf(".");
+  const lastDot = base.lastIndexOf('.');
   if (lastDot < 0) {
-    return "";
+    return '';
   }
   return base.slice(lastDot + 1);
 };

--- a/packages/compartment-mapper/src/import-archive.js
+++ b/packages/compartment-mapper/src/import-archive.js
@@ -1,9 +1,9 @@
 /* eslint no-shadow: "off" */
 
-import { readZip } from "./zip.js";
-import { assemble } from "./assemble.js";
-import { parserForLanguage } from "./parse.js";
-import * as json from "./json.js";
+import { readZip } from './zip.js';
+import { assemble } from './assemble.js';
+import { parserForLanguage } from './parse.js';
+import * as json from './json.js';
 
 // q as in quote for strings in error messages.
 const q = JSON.stringify;
@@ -22,8 +22,8 @@ const makeArchiveImportHookMaker = (archive, compartments, archiveLocation) => {
       if (parse === undefined) {
         throw new Error(
           `Cannot parse ${q(module.parser)} module ${q(
-            moduleSpecifier
-          )} in package ${q(packageLocation)} in archive ${q(archiveLocation)}`
+            moduleSpecifier,
+          )} in package ${q(packageLocation)} in archive ${q(archiveLocation)}`,
         );
       }
       const moduleLocation = `${packageLocation}/${module.location}`;
@@ -33,7 +33,7 @@ const makeArchiveImportHookMaker = (archive, compartments, archiveLocation) => {
         moduleSource,
         moduleSpecifier,
         `file:///${moduleLocation}`,
-        packageLocation
+        packageLocation,
       ).record;
     };
     return importHook;
@@ -44,9 +44,9 @@ const makeArchiveImportHookMaker = (archive, compartments, archiveLocation) => {
 export const parseArchive = async (archiveBytes, archiveLocation) => {
   const archive = await readZip(archiveBytes, archiveLocation);
 
-  const compartmentMapBytes = await archive.read("compartment-map.json");
+  const compartmentMapBytes = await archive.read('compartment-map.json');
   const compartmentMapText = decoder.decode(compartmentMapBytes);
-  const compartmentMap = json.parse(compartmentMapText, "compartment-map.json");
+  const compartmentMap = json.parse(compartmentMapText, 'compartment-map.json');
 
   const execute = options => {
     const {
@@ -55,16 +55,16 @@ export const parseArchive = async (archiveBytes, archiveLocation) => {
       modules,
       transforms,
       __shimTransforms__,
-      Compartment
+      Compartment,
     } = options;
     const {
       compartments,
-      entry: { module: moduleSpecifier }
+      entry: { module: moduleSpecifier },
     } = compartmentMap;
     const makeImportHook = makeArchiveImportHookMaker(
       archive,
       compartments,
-      archiveLocation
+      archiveLocation,
     );
     const compartment = assemble(compartmentMap, {
       makeImportHook,
@@ -73,11 +73,11 @@ export const parseArchive = async (archiveBytes, archiveLocation) => {
       modules,
       transforms,
       __shimTransforms__,
-      Compartment
+      Compartment,
     });
     // Call import by property to bypass SES censoring for dynamic import.
     // eslint-disable-next-line dot-notation
-    return compartment["import"](moduleSpecifier);
+    return compartment['import'](moduleSpecifier);
   };
 
   return { import: execute };
@@ -92,5 +92,5 @@ export const importArchive = async (read, archiveLocation, options) => {
   const archive = await loadArchive(read, archiveLocation);
   // Call import by property to bypass SES censoring for dynamic import.
   // eslint-disable-next-line dot-notation
-  return archive["import"](options);
+  return archive['import'](options);
 };

--- a/packages/compartment-mapper/src/import-hook.js
+++ b/packages/compartment-mapper/src/import-hook.js
@@ -1,4 +1,4 @@
-import { parseExtension } from "./extension.js";
+import { parseExtension } from './extension.js';
 
 // q, as in quote, for quoting strings in error messages.
 const q = JSON.stringify;
@@ -13,7 +13,7 @@ export const makeImportHookMaker = (
   read,
   baseLocation,
   sources = {},
-  compartments = {}
+  compartments = {},
 ) => {
   // per-assembly:
   const makeImportHook = (packageLocation, parse) => {
@@ -29,9 +29,9 @@ export const makeImportHookMaker = (
       // In Node.js, an absolute specifier always indicates a built-in or
       // third-party dependency.
       // The `moduleMapHook` captures all third-party dependencies.
-      if (moduleSpecifier !== "." && !moduleSpecifier.startsWith("./")) {
+      if (moduleSpecifier !== '.' && !moduleSpecifier.startsWith('./')) {
         packageSources[moduleSpecifier] = {
-          exit: moduleSpecifier
+          exit: moduleSpecifier,
         };
         // Return a place-holder.
         // Archived compartments are not executed.
@@ -41,14 +41,14 @@ export const makeImportHookMaker = (
       // Collate candidate locations for the moduleSpecifier per Node.js
       // conventions.
       const candidates = [];
-      if (moduleSpecifier === ".") {
-        candidates.push("./index.js");
+      if (moduleSpecifier === '.') {
+        candidates.push('./index.js');
       } else {
         candidates.push(moduleSpecifier);
-        if (parseExtension(moduleSpecifier) === "") {
+        if (parseExtension(moduleSpecifier) === '') {
           candidates.push(
             `${moduleSpecifier}.js`,
-            `${moduleSpecifier}/index.js`
+            `${moduleSpecifier}/index.js`,
           );
         }
       }
@@ -60,11 +60,11 @@ export const makeImportHookMaker = (
         // name, they are usable as URL's.
         const moduleLocation = resolveLocation(
           candidateSpecifier,
-          packageLocation
+          packageLocation,
         );
         // eslint-disable-next-line no-await-in-loop
         const moduleBytes = await read(moduleLocation).catch(
-          _error => undefined
+          _error => undefined,
         );
         if (moduleBytes !== undefined) {
           const moduleSource = decoder.decode(moduleBytes);
@@ -73,7 +73,7 @@ export const makeImportHookMaker = (
             moduleSource,
             candidateSpecifier,
             moduleLocation,
-            packageLocation
+            packageLocation,
           );
           const { parser } = envelope;
           let { record } = envelope;
@@ -83,18 +83,18 @@ export const makeImportHookMaker = (
           if (candidateSpecifier !== moduleSpecifier) {
             modules[moduleSpecifier] = {
               module: candidateSpecifier,
-              compartment: packageLocation
+              compartment: packageLocation,
             };
             record = { record, specifier: candidateSpecifier };
           }
 
           const packageRelativeLocation = moduleLocation.slice(
-            packageLocation.length
+            packageLocation.length,
           );
           packageSources[candidateSpecifier] = {
             location: packageRelativeLocation,
             parser,
-            bytes: moduleBytes
+            bytes: moduleBytes,
           };
           return record;
         }
@@ -103,10 +103,10 @@ export const makeImportHookMaker = (
       // TODO offer breadcrumbs in the error message, or how to construct breadcrumbs with another tool.
       throw new Error(
         `Cannot find file for internal module ${q(
-          moduleSpecifier
+          moduleSpecifier,
         )} (with candidates ${candidates
           .map(q)
-          .join(", ")}) in package ${packageLocation}`
+          .join(', ')}) in package ${packageLocation}`,
       );
     };
     return importHook;

--- a/packages/compartment-mapper/src/import.js
+++ b/packages/compartment-mapper/src/import.js
@@ -1,28 +1,28 @@
 /* eslint no-shadow: "off" */
 
-import { compartmentMapForNodeModules } from "./node-modules.js";
-import { search } from "./search.js";
-import { assemble } from "./assemble.js";
-import { makeImportHookMaker } from "./import-hook.js";
-import * as json from "./json.js";
+import { compartmentMapForNodeModules } from './node-modules.js';
+import { search } from './search.js';
+import { assemble } from './assemble.js';
+import { makeImportHookMaker } from './import-hook.js';
+import * as json from './json.js';
 
 export const loadLocation = async (read, moduleLocation) => {
   const {
     packageLocation,
     packageDescriptorText,
     packageDescriptorLocation,
-    moduleSpecifier
+    moduleSpecifier,
   } = await search(read, moduleLocation);
 
   const packageDescriptor = json.parse(
     packageDescriptorText,
-    packageDescriptorLocation
+    packageDescriptorLocation,
   );
   const compartmentMap = await compartmentMapForNodeModules(
     read,
     packageLocation,
     [],
-    packageDescriptor
+    packageDescriptor,
   );
 
   const execute = async (options = {}) => {
@@ -32,7 +32,7 @@ export const loadLocation = async (read, moduleLocation) => {
       modules,
       transforms,
       __shimTransforms__,
-      Compartment
+      Compartment,
     } = options;
     const makeImportHook = makeImportHookMaker(read, packageLocation);
     const compartment = assemble(compartmentMap, {
@@ -42,11 +42,11 @@ export const loadLocation = async (read, moduleLocation) => {
       modules,
       transforms,
       __shimTransforms__,
-      Compartment
+      Compartment,
     });
     // Call import by property to bypass SES censoring for dynamic import.
     // eslint-disable-next-line dot-notation
-    return compartment["import"](moduleSpecifier);
+    return compartment['import'](moduleSpecifier);
   };
 
   return { import: execute };
@@ -56,5 +56,5 @@ export const importLocation = async (read, moduleLocation, options = {}) => {
   const application = await loadLocation(read, moduleLocation);
   // Call import by property to bypass SES censoring for dynamic import.
   // eslint-disable-next-line dot-notation
-  return application["import"](options);
+  return application['import'](options);
 };

--- a/packages/compartment-mapper/src/infer-exports.js
+++ b/packages/compartment-mapper/src/infer-exports.js
@@ -1,15 +1,15 @@
-import { join, relativize } from "./node-module-specifier.js";
+import { join, relativize } from './node-module-specifier.js';
 
 const { entries, fromEntries } = Object;
 
 function* interpretBrowserExports(name, exports) {
-  if (typeof exports === "string") {
+  if (typeof exports === 'string') {
     yield [name, relativize(exports)];
     return;
   }
   if (Object(exports) !== exports) {
     throw new Error(
-      `Cannot interpret package.json browser property for package ${name}, must be string or object, got ${exports}`
+      `Cannot interpret package.json browser property for package ${name}, must be string or object, got ${exports}`,
     );
   }
   for (const [key, value] of entries(exports)) {
@@ -18,17 +18,17 @@ function* interpretBrowserExports(name, exports) {
 }
 
 function* interpretExports(name, exports, tags) {
-  if (typeof exports === "string") {
+  if (typeof exports === 'string') {
     yield [name, relativize(exports)];
     return;
   }
   if (Object(exports) !== exports) {
     throw new Error(
-      `Cannot interpret package.json exports property for package ${name}, must be string or object, got ${exports}`
+      `Cannot interpret package.json exports property for package ${name}, must be string or object, got ${exports}`,
     );
   }
   for (const [key, value] of entries(exports)) {
-    if (key.startsWith("./") || key === ".") {
+    if (key.startsWith('./') || key === '.') {
       yield* interpretExports(join(name, key), value, tags);
     } else if (tags.has(key)) {
       yield* interpretExports(name, value, tags);
@@ -47,23 +47,23 @@ function* interpretExports(name, exports, tags) {
 export function* inferExportsEntries(
   { name, main, module, browser, exports },
   tags,
-  types
+  types,
 ) {
   // From lowest to highest precedence, such that later entries override former
   // entries.
   if (main !== undefined) {
     yield [name, relativize(main)];
   }
-  if (module !== undefined && tags.has("import")) {
+  if (module !== undefined && tags.has('import')) {
     // In this one case, the key "module" has carried a hint that the
     // referenced module is an ECMASCript module, and that hint is necessary to
     // override whatever type might be inferred from the module specifier
     // extension.
     const spec = relativize(module);
-    types[spec] = "mjs";
+    types[spec] = 'mjs';
     yield [name, spec];
   }
-  if (browser !== undefined && tags.has("browser")) {
+  if (browser !== undefined && tags.has('browser')) {
     yield* interpretBrowserExports(name, browser);
   }
   if (exports !== undefined) {

--- a/packages/compartment-mapper/src/main.js
+++ b/packages/compartment-mapper/src/main.js
@@ -1,5 +1,5 @@
-export { loadLocation, importLocation } from "./import.js";
-export { makeArchive, writeArchive } from "./archive.js";
-export { parseArchive, loadArchive, importArchive } from "./import-archive.js";
-export { search } from "./search.js";
-export { compartmentMapForNodeModules } from "./node-modules.js";
+export { loadLocation, importLocation } from './import.js';
+export { makeArchive, writeArchive } from './archive.js';
+export { parseArchive, loadArchive, importArchive } from './import-archive.js';
+export { search } from './search.js';
+export { compartmentMapForNodeModules } from './node-modules.js';

--- a/packages/compartment-mapper/src/node-module-specifier.js
+++ b/packages/compartment-mapper/src/node-module-specifier.js
@@ -10,9 +10,9 @@ const q = JSON.stringify;
 // `relativize`, which have different invariants.
 const solve = (solution, problem) => {
   for (const part of problem) {
-    if (part === "." || part === "") {
+    if (part === '.' || part === '') {
       // no-op
-    } else if (part === "..") {
+    } else if (part === '..') {
       if (solution.length === 0) {
         return false;
       }
@@ -34,36 +34,36 @@ const solve = (solution, problem) => {
 // paths that begin with / are disallowed as they could be used to defeat
 // compartment containment.
 export const resolve = (spec, referrer) => {
-  spec = String(spec || "");
-  referrer = String(referrer || "");
+  spec = String(spec || '');
+  referrer = String(referrer || '');
 
-  if (spec.startsWith("/")) {
+  if (spec.startsWith('/')) {
     throw new Error(`Module specifier ${q(spec)} must not begin with "/"`);
   }
-  if (!referrer.startsWith("./")) {
+  if (!referrer.startsWith('./')) {
     throw new Error(`Module referrer ${q(referrer)} must begin with "./"`);
   }
 
-  const specParts = spec.split("/");
+  const specParts = spec.split('/');
   const solution = [];
   const problem = [];
-  if (specParts[0] === "." || specParts[0] === "..") {
-    const referrerParts = referrer.split("/");
+  if (specParts[0] === '.' || specParts[0] === '..') {
+    const referrerParts = referrer.split('/');
     problem.push(...referrerParts);
     problem.pop();
-    solution.push(".");
+    solution.push('.');
   }
   problem.push(...specParts);
 
   if (!solve(solution, problem)) {
     throw new Error(
       `Module specifier ${q(spec)} via referrer ${q(
-        referrer
-      )} must not traverse behind an empty path`
+        referrer,
+      )} must not traverse behind an empty path`,
     );
   }
 
-  return solution.join("/");
+  return solution.join('/');
 };
 
 // To construct a module map from a node_modules package, inter-package linkage
@@ -74,19 +74,19 @@ export const resolve = (spec, referrer) => {
 // This type of join may assert that the base is absolute and the referrent is
 // relative.
 export const join = (base, spec) => {
-  spec = String(spec || "");
-  base = String(base || "");
+  spec = String(spec || '');
+  base = String(base || '');
 
-  const specParts = spec.split("/");
-  const baseParts = base.split("/");
+  const specParts = spec.split('/');
+  const baseParts = base.split('/');
 
-  if (specParts.length > 1 && specParts[0] === "") {
+  if (specParts.length > 1 && specParts[0] === '') {
     throw new Error(`Module specifier ${q(spec)} must not start with "/"`);
   }
-  if (baseParts[0] === "." || baseParts[0] === "..") {
+  if (baseParts[0] === '.' || baseParts[0] === '..') {
     throw new Error(`External module specifier ${q(base)} must be absolute`);
   }
-  if (specParts[0] !== ".") {
+  if (specParts[0] !== '.') {
     throw new Error(`Internal module specifier ${q(spec)} must be relative`);
   }
 
@@ -94,12 +94,12 @@ export const join = (base, spec) => {
   if (!solve(solution, specParts)) {
     throw new Error(
       `Module specifier ${q(spec)} via base ${q(
-        base
-      )} must not refer to a module outside of the base`
+        base,
+      )} must not refer to a module outside of the base`,
     );
   }
 
-  return [base, ...solution].join("/");
+  return [base, ...solution].join('/');
 };
 
 // Relativize turns absolute identifiers into relative identifiers.
@@ -107,14 +107,14 @@ export const join = (base, spec) => {
 // absolute, but compartments backed by node_modules always use relative module
 // specifiers for internal linkage.
 export const relativize = spec => {
-  spec = String(spec || "");
+  spec = String(spec || '');
 
   const solution = [];
-  if (!solve(solution, spec.split("/"))) {
+  if (!solve(solution, spec.split('/'))) {
     throw Error(
-      `Module specifier ${q(spec)} must not traverse behind an empty path`
+      `Module specifier ${q(spec)} must not traverse behind an empty path`,
     );
   }
 
-  return [".", ...solution].join("/");
+  return ['.', ...solution].join('/');
 };

--- a/packages/compartment-mapper/src/node-modules.js
+++ b/packages/compartment-mapper/src/node-modules.js
@@ -1,7 +1,7 @@
 /* eslint no-shadow: 0 */
 
-import { inferExports } from "./infer-exports.js";
-import * as json from "./json.js";
+import { inferExports } from './infer-exports.js';
+import * as json from './json.js';
 
 const { create, entries, keys, values } = Object;
 
@@ -14,7 +14,7 @@ const resolveLocation = (rel, abs) => new URL(rel, abs).toString();
 
 const basename = location => {
   const { pathname } = new URL(location);
-  const index = pathname.lastIndexOf("/");
+  const index = pathname.lastIndexOf('/');
   if (index < 0) {
     return pathname;
   }
@@ -22,9 +22,9 @@ const basename = location => {
 };
 
 const readDescriptor = async (read, packageLocation) => {
-  const descriptorLocation = resolveLocation("package.json", packageLocation);
+  const descriptorLocation = resolveLocation('package.json', packageLocation);
   const descriptorBytes = await read(descriptorLocation).catch(
-    _error => undefined
+    _error => undefined,
   );
   if (descriptorBytes === undefined) {
     return undefined;
@@ -59,15 +59,15 @@ const findPackage = async (readDescriptor, directory, name) => {
       return { packageLocation, packageDescriptor };
     }
 
-    const parent = resolveLocation("../", directory);
+    const parent = resolveLocation('../', directory);
     if (parent === directory) {
       return undefined;
     }
     directory = parent;
 
     const base = basename(directory);
-    if (base === "node_modules") {
-      directory = resolveLocation("../", directory);
+    if (base === 'node_modules') {
+      directory = resolveLocation('../', directory);
       if (parent === directory) {
         return undefined;
       }
@@ -76,42 +76,42 @@ const findPackage = async (readDescriptor, directory, name) => {
   }
 };
 
-const languages = ["mjs", "json"];
-const uncontroversialParsers = { mjs: "mjs", json: "json" };
+const languages = ['mjs', 'json'];
+const uncontroversialParsers = { mjs: 'mjs', json: 'json' };
 const commonParsers = uncontroversialParsers;
-const moduleParsers = { js: "mjs", ...uncontroversialParsers };
+const moduleParsers = { js: 'mjs', ...uncontroversialParsers };
 
 const inferParsers = (descriptor, location) => {
   const { type, parsers } = descriptor;
   if (parsers !== undefined) {
-    if (typeof parsers !== "object") {
+    if (typeof parsers !== 'object') {
       throw new Error(
         `Cannot interpret parser map ${JSON.stringify(
-          parsers
-        )} of package at ${location}, must be an object mapping file extensions to corresponding languages (mjs for ECMAScript modules or json for JSON modules`
+          parsers,
+        )} of package at ${location}, must be an object mapping file extensions to corresponding languages (mjs for ECMAScript modules or json for JSON modules`,
       );
     }
     const invalidLanguages = values(parsers).filter(
-      language => !languages.includes(language)
+      language => !languages.includes(language),
     );
     if (invalidLanguages.length > 0) {
       throw new Error(
         `Cannot interpret parser map language values ${JSON.stringify(
-          invalidLanguages
-        )} of package at ${location}, must be an object mapping file extensions to corresponding languages (mjs for ECMAScript modules or json for JSON modules`
+          invalidLanguages,
+        )} of package at ${location}, must be an object mapping file extensions to corresponding languages (mjs for ECMAScript modules or json for JSON modules`,
       );
     }
     return { ...uncontroversialParsers, ...parsers };
   }
-  if (type === "module") {
+  if (type === 'module') {
     return moduleParsers;
   }
-  if (type === "commonjs") {
+  if (type === 'commonjs') {
     return commonParsers;
   }
   if (type !== undefined) {
     throw new Error(
-      `Cannot infer parser map for package of type ${type} at ${location}`
+      `Cannot infer parser map for package of type ${type} at ${location}`,
     );
   }
   return commonParsers;
@@ -125,11 +125,11 @@ const inferParsers = (descriptor, location) => {
 // that the package exports.
 
 const graphPackage = async (
-  name = "",
+  name = '',
   readDescriptor,
   graph,
   { packageLocation, packageDescriptor },
-  tags
+  tags,
 ) => {
   if (graph[packageLocation] !== undefined) {
     // Returning the promise here would create a causal cycle and stall recursion.
@@ -138,7 +138,7 @@ const graphPackage = async (
 
   if (packageDescriptor.name !== name) {
     console.warn(
-      `Package named ${q(name)} does not match location ${packageLocation}`
+      `Package named ${q(name)} does not match location ${packageLocation}`,
     );
   }
 
@@ -157,21 +157,21 @@ const graphPackage = async (
         dependencies,
         packageLocation,
         name,
-        tags
-      )
+        tags,
+      ),
     );
   }
 
-  const { version = "", exports } = packageDescriptor;
+  const { version = '', exports } = packageDescriptor;
   const types = {};
 
   Object.assign(result, {
-    label: `${name}${version ? `-v${version}` : ""}`,
+    label: `${name}${version ? `-v${version}` : ''}`,
     explicit: exports !== undefined,
     exports: inferExports(packageDescriptor, tags, types),
     dependencies,
     types,
-    parsers: inferParsers(packageDescriptor, packageLocation)
+    parsers: inferParsers(packageDescriptor, packageLocation),
   });
 
   return Promise.all(children);
@@ -183,7 +183,7 @@ const gatherDependency = async (
   dependencies,
   packageLocation,
   name,
-  tags
+  tags,
 ) => {
   const dependency = await findPackage(readDescriptor, packageLocation, name);
   if (dependency === undefined) {
@@ -204,7 +204,7 @@ const graphPackages = async (
   read,
   packageLocation,
   tags,
-  mainPackageDescriptor
+  mainPackageDescriptor,
 ) => {
   const memo = create(null);
   const readDescriptor = packageLocation =>
@@ -217,11 +217,11 @@ const graphPackages = async (
   const packageDescriptor = await readDescriptor(packageLocation);
 
   tags = new Set(tags || []);
-  tags.add("import");
+  tags.add('import');
 
   if (packageDescriptor === undefined) {
     throw new Error(
-      `Cannot find package.json for application at ${packageLocation}`
+      `Cannot find package.json for application at ${packageLocation}`,
     );
   }
   const graph = create(null);
@@ -231,9 +231,9 @@ const graphPackages = async (
     graph,
     {
       packageLocation,
-      packageDescriptor
+      packageDescriptor,
     },
-    tags
+    tags,
   );
   return graph;
 };
@@ -254,7 +254,7 @@ const translateGraph = (entryPackageLocation, entryModuleSpecifier, graph) => {
   // corresponding compartment can import.
   for (const [
     packageLocation,
-    { label, dependencies, parsers, types }
+    { label, dependencies, parsers, types },
   ] of entries(graph)) {
     const modules = {};
     const scopes = {};
@@ -263,12 +263,12 @@ const translateGraph = (entryPackageLocation, entryModuleSpecifier, graph) => {
       for (const [exportName, module] of entries(exports)) {
         modules[exportName] = {
           compartment: packageLocation,
-          module
+          module,
         };
       }
       if (!explicit) {
         scopes[dependencyName] = {
-          compartment: packageLocation
+          compartment: packageLocation,
         };
       }
     }
@@ -278,16 +278,16 @@ const translateGraph = (entryPackageLocation, entryModuleSpecifier, graph) => {
       modules,
       scopes,
       parsers,
-      types
+      types,
     };
   }
 
   return {
     entry: {
       compartment: entryPackageLocation,
-      module: entryModuleSpecifier
+      module: entryModuleSpecifier,
     },
-    compartments
+    compartments,
   };
 };
 
@@ -296,13 +296,13 @@ export const compartmentMapForNodeModules = async (
   packageLocation,
   tags,
   packageDescriptor,
-  moduleSpecifier
+  moduleSpecifier,
 ) => {
   const graph = await graphPackages(
     read,
     packageLocation,
     tags,
-    packageDescriptor
+    packageDescriptor,
   );
   return translateGraph(packageLocation, moduleSpecifier, graph);
 };

--- a/packages/compartment-mapper/src/parse.js
+++ b/packages/compartment-mapper/src/parse.js
@@ -1,5 +1,5 @@
-import { parseExtension } from "./extension.js";
-import * as json from "./json.js";
+import { parseExtension } from './extension.js';
+import * as json from './json.js';
 
 const { entries, freeze, fromEntries } = Object;
 
@@ -11,8 +11,8 @@ const q = JSON.stringify;
 
 export const parseMjs = (source, _specifier, location, _packageLocation) => {
   return {
-    parser: "mjs",
-    record: new StaticModuleRecord(source, location)
+    parser: 'mjs',
+    record: new StaticModuleRecord(source, location),
   };
 };
 
@@ -22,8 +22,8 @@ export const parseJson = (source, _specifier, location, _packageLocation) => {
     exports.default = json.parse(source, location);
   };
   return {
-    parser: "json",
-    record: freeze({ imports, execute })
+    parser: 'json',
+    record: freeze({ imports, execute }),
   };
 };
 
@@ -37,7 +37,7 @@ export const makeExtensionParser = (extensions, types) => {
     }
     if (!hasOwnProperty.call(extensions, extension)) {
       throw new Error(
-        `Cannot parse module ${specifier} at ${location}, no parser configured for that extension`
+        `Cannot parse module ${specifier} at ${location}, no parser configured for that extension`,
       );
     }
     const parse = extensions[extension];
@@ -47,7 +47,7 @@ export const makeExtensionParser = (extensions, types) => {
 
 export const parserForLanguage = {
   mjs: parseMjs,
-  json: parseJson
+  json: parseJson,
 };
 
 export const mapParsers = (parsers, types) => {
@@ -62,7 +62,7 @@ export const mapParsers = (parsers, types) => {
     }
   }
   if (errors.length > 0) {
-    throw new Error(`No parser available for language: ${errors.join(", ")}`);
+    throw new Error(`No parser available for language: ${errors.join(', ')}`);
   }
   return makeExtensionParser(fromEntries(parserForExtension), types);
 };

--- a/packages/compartment-mapper/src/search.js
+++ b/packages/compartment-mapper/src/search.js
@@ -1,5 +1,5 @@
-import { relativize } from "./node-module-specifier.js";
-import { relative } from "./url.js";
+import { relativize } from './node-module-specifier.js';
+import { relative } from './url.js';
 
 // q, as in quote, for enquoting strings in error messages.
 const q = JSON.stringify;
@@ -14,15 +14,15 @@ const resolveLocation = (rel, abs) => new URL(rel, abs).toString();
 // To avoid duplicate work later, returns the text of the package.json for
 // inevitable later use.
 export const search = async (read, moduleLocation) => {
-  let directory = resolveLocation("./", moduleLocation);
+  let directory = resolveLocation('./', moduleLocation);
   for (;;) {
     const packageDescriptorLocation = resolveLocation(
-      "package.json",
-      directory
+      'package.json',
+      directory,
     );
     // eslint-disable-next-line no-await-in-loop
     const packageDescriptorBytes = await read(packageDescriptorLocation).catch(
-      () => undefined
+      () => undefined,
     );
     if (packageDescriptorBytes !== undefined) {
       const packageDescriptorText = decoder.decode(packageDescriptorBytes);
@@ -30,13 +30,13 @@ export const search = async (read, moduleLocation) => {
         packageLocation: directory,
         packageDescriptorText,
         packageDescriptorLocation,
-        moduleSpecifier: relativize(relative(directory, moduleLocation))
+        moduleSpecifier: relativize(relative(directory, moduleLocation)),
       };
     }
-    const parentDirectory = resolveLocation("../", directory);
+    const parentDirectory = resolveLocation('../', directory);
     if (parentDirectory === directory) {
       throw new Error(
-        `Cannot find package.json along path to module ${q(moduleLocation)}`
+        `Cannot find package.json along path to module ${q(moduleLocation)}`,
       );
     }
     directory = parentDirectory;

--- a/packages/compartment-mapper/src/url.js
+++ b/packages/compartment-mapper/src/url.js
@@ -17,11 +17,11 @@
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 export const relative = (referrer, location) => {
-  referrer = String(referrer || "");
-  location = String(location || "");
+  referrer = String(referrer || '');
+  location = String(location || '');
 
   if (referrer === location) {
-    return "";
+    return '';
   }
 
   const referrerURL = new URL(referrer);
@@ -40,12 +40,12 @@ export const relative = (referrer, location) => {
   }
 
   // left location right, look for closest common path segment
-  const referrerParts = referrerURL.pathname.substr(1).split("/");
-  const locationParts = locationURL.pathname.substr(1).split("/");
+  const referrerParts = referrerURL.pathname.substr(1).split('/');
+  const locationParts = locationURL.pathname.substr(1).split('/');
 
   if (referrerURL.pathname === locationURL.pathname) {
-    if (locationURL.pathname[locationURL.pathname.length - 1] === "/") {
-      return ".";
+    if (locationURL.pathname[locationURL.pathname.length - 1] === '/') {
+      return '.';
     }
     return locationParts[locationParts.length - 1];
   }
@@ -57,22 +57,22 @@ export const relative = (referrer, location) => {
 
   let length = referrerParts.length - locationParts.length;
   if (length > 0) {
-    if (referrer.endsWith("/")) {
-      locationParts.unshift("..");
+    if (referrer.endsWith('/')) {
+      locationParts.unshift('..');
     }
     while (length > 0) {
       length -= 1;
-      locationParts.unshift("..");
+      locationParts.unshift('..');
     }
-    return locationParts.join("/");
+    return locationParts.join('/');
   }
   if (length < 0) {
-    return locationParts.join("/");
+    return locationParts.join('/');
   }
   length = locationParts.length - 1;
   while (length > 0) {
     length -= 1;
-    locationParts.unshift("..");
+    locationParts.unshift('..');
   }
-  return locationParts.join("/");
+  return locationParts.join('/');
 };

--- a/packages/compartment-mapper/src/zip.js
+++ b/packages/compartment-mapper/src/zip.js
@@ -1,7 +1,7 @@
 // Decouples Zip usage from JSZip's particular presentation.
 
-import { ZipReader } from "./zip/reader.js";
-import { ZipWriter } from "./zip/writer.js";
+import { ZipReader } from './zip/reader.js';
+import { ZipWriter } from './zip/writer.js';
 
 export const readZip = async (data, location) => {
   const reader = new ZipReader(data, { name: location });

--- a/packages/compartment-mapper/src/zip/buffer-reader.js
+++ b/packages/compartment-mapper/src/zip/buffer-reader.js
@@ -15,7 +15,7 @@ export class BufferReader {
       data,
       length: data.length,
       index: 0,
-      offset: 0
+      offset: 0,
     });
   }
 
@@ -46,10 +46,10 @@ export class BufferReader {
   set offset(offset) {
     const fields = privateFields.get(this);
     if (offset > fields.data.length) {
-      throw new Error(`Cannot set offset beyond length of underlying data`);
+      throw new Error('Cannot set offset beyond length of underlying data');
     }
     if (offset < 0) {
-      throw new Error(`Cannot set negative offset`);
+      throw new Error('Cannot set negative offset');
     }
     fields.offset = offset;
     fields.length = fields.data.length - fields.offset;
@@ -73,7 +73,7 @@ export class BufferReader {
     const fields = privateFields.get(this);
     if (!this.canSeek(index)) {
       throw new Error(
-        `End of data reached (data length = ${fields.length}, asked index ${index}`
+        `End of data reached (data length = ${fields.length}, asked index ${index}`,
       );
     }
   }
@@ -104,7 +104,7 @@ export class BufferReader {
     }
     const result = fields.data.subarray(
       fields.offset + fields.index,
-      fields.offset + fields.index + size
+      fields.offset + fields.index + size,
     );
     return result;
   }
@@ -239,8 +239,8 @@ export class BufferReader {
     if (!this.expect(expected)) {
       throw new Error(
         `Expected ${q(expected)} at ${fields.index}, got ${this.peek(
-          expected.length
-        )}`
+          expected.length,
+        )}`,
       );
     }
   }

--- a/packages/compartment-mapper/src/zip/buffer-writer.js
+++ b/packages/compartment-mapper/src/zip/buffer-writer.js
@@ -34,7 +34,7 @@ export class BufferWriter {
       data,
       index: 0,
       length: 0,
-      capacity
+      capacity,
     });
   }
 

--- a/packages/compartment-mapper/src/zip/compression.js
+++ b/packages/compartment-mapper/src/zip/compression.js
@@ -1,2 +1,2 @@
 // STORE is the magic number for "not compressed".
-export const STORE = "\x00\x00";
+export const STORE = '\x00\x00';

--- a/packages/compartment-mapper/src/zip/format-reader.js
+++ b/packages/compartment-mapper/src/zip/format-reader.js
@@ -41,10 +41,10 @@
  * }} BufferReader
  */
 
-import "./types.js";
-import { crc32 } from "./crc32.js";
-import * as signature from "./signature.js";
-import * as compression from "./compression.js";
+import './types.js';
+import { crc32 } from './crc32.js';
+import * as signature from './signature.js';
+import * as compression from './compression.js';
 
 // q, as in quote, for quoting strings in errors
 const q = JSON.stringify;
@@ -77,8 +77,8 @@ function readDosDateTime(reader) {
       (dosTime >> 16) & 0x1f, // day
       (dosTime >> 11) & 0x1f, // hour
       (dosTime >> 5) & 0x3f, // minute
-      (dosTime & 0x1f) << 1 // second
-    )
+      (dosTime & 0x1f) << 1, // second
+    ),
   );
 }
 
@@ -94,7 +94,7 @@ function readHeaders(reader) {
     date: readDosDateTime(reader),
     crc32: reader.readUint32LE(),
     compressedLength: reader.readUint32LE(),
-    uncompressedLength: reader.readUint32LE()
+    uncompressedLength: reader.readUint32LE(),
   };
 }
 
@@ -119,16 +119,16 @@ function readCentralFileHeader(reader) {
   reader.skip(extraFieldsLength);
 
   if (headers.uncompressedLength === MAX_VALUE_32BITS) {
-    throw new Error("Cannot read Zip64");
+    throw new Error('Cannot read Zip64');
   }
   if (headers.compressedLength === MAX_VALUE_32BITS) {
-    throw new Error("Cannot read Zip64");
+    throw new Error('Cannot read Zip64');
   }
   if (fileStart === MAX_VALUE_32BITS) {
-    throw new Error("Cannot read Zip64");
+    throw new Error('Cannot read Zip64');
   }
   if (diskNumberStart === MAX_VALUE_32BITS) {
-    throw new Error("Cannot read Zip64");
+    throw new Error('Cannot read Zip64');
   }
 
   const comment = reader.read(commentLength);
@@ -142,7 +142,7 @@ function readCentralFileHeader(reader) {
     internalFileAttributes,
     externalFileAttributes,
     fileStart,
-    comment
+    comment,
   };
 }
 
@@ -165,7 +165,7 @@ function readCentralDirectory(reader, locator) {
     // We expected some records but couldn't find ANY.
     // This is really suspicious, as if something went wrong.
     throw new Error(
-      `Corrupted zip or bug: expected ${centralDirectoryRecords} records in central dir, got ${entries.length}`
+      `Corrupted zip or bug: expected ${centralDirectoryRecords} records in central dir, got ${entries.length}`,
     );
   }
 
@@ -209,7 +209,7 @@ function readLocalFiles(reader, records) {
 function readBlockEndOfCentral(reader) {
   if (!reader.expect(signature.CENTRAL_DIRECTORY_END)) {
     throw new Error(
-      "Corrupt zip file, or zip file containing an unsupported variable-width end-of-archive comment, or an unsupported zip file with 64 bit sizes"
+      'Corrupt zip file, or zip file containing an unsupported variable-width end-of-archive comment, or an unsupported zip file with 64 bit sizes',
     );
   }
   const diskNumber = reader.readUint16LE();
@@ -231,7 +231,7 @@ function readBlockEndOfCentral(reader) {
     centralDirectoryRecords,
     centralDirectorySize,
     centralDirectoryOffset,
-    comment
+    comment,
   };
 }
 
@@ -253,7 +253,7 @@ function readEndOfCentralDirectoryRecord(reader) {
   // from the end.
   const centralDirectoryEnd = reader.length - 22;
   if (centralDirectoryEnd < 0) {
-    throw new Error("Corrupted zip: not enough content");
+    throw new Error('Corrupted zip: not enough content');
   }
   reader.seek(centralDirectoryEnd);
   const locator = readBlockEndOfCentral(reader);
@@ -276,12 +276,12 @@ function readEndOfCentralDirectoryRecord(reader) {
     locator.centralDirectoryOffset === MAX_VALUE_32BITS;
 
   if (zip64) {
-    throw new Error("Cannot read Zip64");
+    throw new Error('Cannot read Zip64');
   }
 
   const {
     centralDirectoryOffset,
-    centralDirectorySize
+    centralDirectorySize,
     // zip64EndOfCentralSize
   } = locator;
 
@@ -318,13 +318,13 @@ function checkRecords(centralRecord, localRecord, archiveName) {
   //
   // We strike a compromise: the central directory name may vary from the local
   // name exactly and only by different slashes.
-  if (centralName.replace(/\\/g, "/") !== localName) {
+  if (centralName.replace(/\\/g, '/') !== localName) {
     throw new Error(
       `Zip integrity error: central record file name ${q(
-        centralName
+        centralName,
       )} must match local file name ${q(localName)} in archive ${q(
-        archiveName
-      )}`
+        archiveName,
+      )}`,
     );
   }
 
@@ -336,8 +336,8 @@ function checkRecords(centralRecord, localRecord, archiveName) {
     if (!value) {
       throw new Error(
         `Zip integrity error: ${message} for file ${q(
-          localName
-        )} in archive ${q(archiveName)}`
+          localName,
+        )} in archive ${q(archiveName)}`,
       );
     }
   }
@@ -345,34 +345,34 @@ function checkRecords(centralRecord, localRecord, archiveName) {
   check(
     centralRecord.bitFlag === localRecord.bitFlag,
     `Central record bit flag ${centralRecord.bitFlag.toString(
-      16
-    )} must match local record bit flag ${localRecord.bitFlag.toString(16)}`
+      16,
+    )} must match local record bit flag ${localRecord.bitFlag.toString(16)}`,
   );
   check(
     centralRecord.compressionMethod === localRecord.compressionMethod,
     `Central record compression method ${q(
-      centralRecord.compressionMethod
-    )} must match local compression method ${q(localRecord.compressionMethod)}`
+      centralRecord.compressionMethod,
+    )} must match local compression method ${q(localRecord.compressionMethod)}`,
   );
   // TODO Date integrity check would be easier on the original bytes.
   // Perhaps defer decoding the underlying bytes.
   check(
     centralRecord.crc32 === localRecord.crc32,
-    `Central record CRC-32 checksum ${centralRecord.crc32} must match local checksum ${localRecord.crc32}`
+    `Central record CRC-32 checksum ${centralRecord.crc32} must match local checksum ${localRecord.crc32}`,
   );
   check(
     centralRecord.compressedLength === localRecord.compressedLength,
-    `Central record compressed size ${centralRecord.compressedLength} must match local ${localRecord.compressedLength}`
+    `Central record compressed size ${centralRecord.compressedLength} must match local ${localRecord.compressedLength}`,
   );
   check(
     centralRecord.uncompressedLength === localRecord.uncompressedLength,
-    `Central record uncompressed size ${centralRecord.uncompressedLength} must match local ${localRecord.uncompressedLength}`
+    `Central record uncompressed size ${centralRecord.uncompressedLength} must match local ${localRecord.uncompressedLength}`,
   );
 
   const checksum = crc32(localRecord.content);
   check(
     checksum === localRecord.crc32,
-    `CRC-32 checksum mismatch, wanted ${localRecord.crc32} but actual content is ${checksum}`
+    `CRC-32 checksum mismatch, wanted ${localRecord.crc32} but actual content is ${checksum}`,
   );
 }
 
@@ -399,7 +399,7 @@ function recordToFile(centralRecord, localRecord) {
     compressedLength: centralRecord.compressedLength,
     uncompressedLength: centralRecord.uncompressedLength,
     content: localRecord.content,
-    comment: centralRecord.comment
+    comment: centralRecord.comment,
   };
 }
 
@@ -411,8 +411,8 @@ function decompressFile(file) {
   if (file.compressionMethod !== compression.STORE) {
     throw new Error(
       `Cannot find decompressor for compression method ${q(
-        file.compressionMethod
-      )} for file ${file.name}`
+        file.compressionMethod,
+      )} for file ${file.name}`,
     );
   }
   return {
@@ -420,7 +420,7 @@ function decompressFile(file) {
     mode: file.mode,
     date: file.date,
     content: file.content,
-    comment: file.comment
+    comment: file.comment,
   };
 }
 
@@ -433,11 +433,11 @@ function decodeFile(file) {
   const comment = textDecoder.decode(file.comment);
   return {
     name,
-    type: "file",
+    type: 'file',
     mode: file.mode & 0o777,
     date: file.date,
     content: file.content,
-    comment
+    comment,
   };
 }
 
@@ -445,7 +445,7 @@ function decodeFile(file) {
  * @param {BufferReader} reader
  * @param {string} name
  */
-export function readZip(reader, name = "<unknown>") {
+export function readZip(reader, name = '<unknown>') {
   const locator = readEndOfCentralDirectoryRecord(reader);
   const centralRecords = readCentralDirectory(reader, locator);
   const localRecords = readLocalFiles(reader, centralRecords);
@@ -458,7 +458,7 @@ export function readZip(reader, name = "<unknown>") {
     checkRecords(centralRecord, localRecord, name);
 
     if (isEncrypted(centralRecord.bitFlag)) {
-      throw new Error("Encrypted zip are not supported");
+      throw new Error('Encrypted zip are not supported');
     }
 
     const isDir = (centralRecord.externalFileAttributes & 0x0010) !== 0;

--- a/packages/compartment-mapper/src/zip/format-writer.js
+++ b/packages/compartment-mapper/src/zip/format-writer.js
@@ -31,10 +31,10 @@
  * }} BufferWriter
  */
 
-import "./types.js";
-import { crc32 } from "./crc32.js";
-import * as signature from "./signature.js";
-import * as compression from "./compression.js";
+import './types.js';
+import { crc32 } from './crc32.js';
+import * as signature from './signature.js';
+import * as compression from './compression.js';
 
 const UNIX = 3;
 const UNIX_VERSION = 30;
@@ -90,7 +90,7 @@ function writeFile(writer, file) {
   return {
     fileStart,
     headerStart,
-    headerEnd
+    headerEnd,
   };
 }
 
@@ -128,7 +128,7 @@ function writeEndOfCentralDirectoryRecord(
   entriesCount,
   centralDirectoryStart,
   centralDirectoryLength,
-  commentBytes
+  commentBytes,
 ) {
   writer.write(signature.CENTRAL_DIRECTORY_END);
   writer.writeUint16LE(0);
@@ -146,7 +146,7 @@ function writeEndOfCentralDirectoryRecord(
  * @param {Array<FileRecord>} records
  * @param {string} comment
  */
-export function writeZipRecords(writer, records, comment = "") {
+export function writeZipRecords(writer, records, comment = '') {
   // Write records with local headers.
   const locators = [];
   for (let i = 0; i < records.length; i += 1) {
@@ -168,7 +168,7 @@ export function writeZipRecords(writer, records, comment = "") {
     records.length,
     centralDirectoryStart,
     centralDirectoryLength,
-    commentBytes
+    commentBytes,
   );
 }
 
@@ -177,14 +177,14 @@ export function writeZipRecords(writer, records, comment = "") {
  * @returns {UncompressedFile}
  */
 function encodeFile(file) {
-  const name = textEncoder.encode(file.name.replace(/\\/g, "/"));
+  const name = textEncoder.encode(file.name.replace(/\\/g, '/'));
   const comment = textEncoder.encode(file.comment);
   return {
     name,
     mode: file.mode,
     date: file.date,
     content: file.content,
-    comment
+    comment,
   };
 }
 
@@ -202,7 +202,7 @@ function compressFileWithStore(file) {
     compressedLength: file.content.length,
     uncompressedLength: file.content.length,
     content: file.content,
-    comment: file.comment
+    comment: file.comment,
   };
 }
 
@@ -247,7 +247,7 @@ function makeFileRecord(file) {
     internalFileAttributes: 0,
     externalFileAttributes: externalFileAttributes(file.mode),
     comment: file.comment,
-    content: file.content
+    content: file.content,
   };
 }
 
@@ -256,7 +256,7 @@ function makeFileRecord(file) {
  * @param {Array<ArchivedFile>} files
  * @param {string} comment
  */
-export function writeZip(writer, files, comment = "") {
+export function writeZip(writer, files, comment = '') {
   const encodedFiles = files.map(encodeFile);
   const compressedFiles = encodedFiles.map(compressFileWithStore);
   // TODO collate directoryRecords from file bases.

--- a/packages/compartment-mapper/src/zip/reader.js
+++ b/packages/compartment-mapper/src/zip/reader.js
@@ -1,7 +1,7 @@
 // @ts-check
 
-import { BufferReader } from "./buffer-reader.js";
-import { readZip } from "./format-reader.js";
+import { BufferReader } from './buffer-reader.js';
+import { readZip } from './format-reader.js';
 
 export class ZipReader {
   /**
@@ -10,7 +10,7 @@ export class ZipReader {
    * @param {string} [options.name]
    */
   constructor(data, options = {}) {
-    const { name = "<unknown>" } = options;
+    const { name = '<unknown>' } = options;
     const reader = new BufferReader(data);
     this.files = readZip(reader);
     this.name = name;
@@ -41,7 +41,7 @@ export class ZipReader {
       type: file.type,
       mode: file.mode,
       date: file.date,
-      comment: file.comment
+      comment: file.comment,
     };
   }
 }

--- a/packages/compartment-mapper/src/zip/signature.js
+++ b/packages/compartment-mapper/src/zip/signature.js
@@ -12,9 +12,9 @@ function u(string) {
   return array;
 }
 
-export const LOCAL_FILE_HEADER = u("PK\x03\x04");
-export const CENTRAL_FILE_HEADER = u("PK\x01\x02");
-export const CENTRAL_DIRECTORY_END = u("PK\x05\x06");
-export const ZIP64_CENTRAL_DIRECTORY_LOCATOR = u("PK\x06\x07");
-export const ZIP64_CENTRAL_DIRECTORY_END = u("PK\x06\x06");
-export const DATA_DESCRIPTOR = u("PK\x07\x08");
+export const LOCAL_FILE_HEADER = u('PK\x03\x04');
+export const CENTRAL_FILE_HEADER = u('PK\x01\x02');
+export const CENTRAL_DIRECTORY_END = u('PK\x05\x06');
+export const ZIP64_CENTRAL_DIRECTORY_LOCATOR = u('PK\x06\x07');
+export const ZIP64_CENTRAL_DIRECTORY_END = u('PK\x06\x06');
+export const DATA_DESCRIPTOR = u('PK\x07\x08');

--- a/packages/compartment-mapper/src/zip/writer.js
+++ b/packages/compartment-mapper/src/zip/writer.js
@@ -1,7 +1,7 @@
 // @ts-check
-import "./types.js";
-import { BufferWriter } from "./buffer-writer.js";
-import { writeZip } from "./format-writer.js";
+import './types.js';
+import { BufferWriter } from './buffer-writer.js';
+import { writeZip } from './format-writer.js';
 
 export class ZipWriter {
   /**
@@ -26,7 +26,7 @@ export class ZipWriter {
    * }} [options]
    */
   write(name, content, options = {}) {
-    const { mode = 0o644, date = undefined, comment = "" } = options;
+    const { mode = 0o644, date = undefined, comment = '' } = options;
     if (!content) {
       throw new Error(`ZipWriter write requires content for ${name}`);
     }
@@ -35,7 +35,7 @@ export class ZipWriter {
       mode,
       date,
       content,
-      comment
+      comment,
     });
   }
 

--- a/packages/compartment-mapper/test/app.agar-make.js
+++ b/packages/compartment-mapper/test/app.agar-make.js
@@ -1,9 +1,9 @@
-import "ses";
-import fs from "fs";
-import { writeArchive } from "../src/main.js";
+import 'ses';
+import fs from 'fs';
+import { writeArchive } from '../src/main.js';
 
-const fixture = new URL("node_modules/app/main.js", import.meta.url).toString();
-const archiveFixture = new URL("app.agar", import.meta.url).toString();
+const fixture = new URL('node_modules/app/main.js', import.meta.url).toString();
+const archiveFixture = new URL('app.agar', import.meta.url).toString();
 
 const read = async location => fs.promises.readFile(new URL(location).pathname);
 const write = async (location, data) =>

--- a/packages/compartment-mapper/test/extension.test.js
+++ b/packages/compartment-mapper/test/extension.test.js
@@ -1,29 +1,29 @@
-import test from "ava";
-import { parseExtension } from "../src/extension.js";
+import test from 'ava';
+import { parseExtension } from '../src/extension.js';
 
 const q = JSON.stringify;
 
 [
   {
-    location: "https://example.com/",
-    extension: ""
+    location: 'https://example.com/',
+    extension: '',
   },
   {
-    location: "https://example.com/.",
-    extension: ""
+    location: 'https://example.com/.',
+    extension: '',
   },
   {
-    location: "https://example.com/.bashrc",
-    extension: "bashrc"
+    location: 'https://example.com/.bashrc',
+    extension: 'bashrc',
   },
   {
-    location: "https://example.com/foo.js",
-    extension: "js"
+    location: 'https://example.com/foo.js',
+    extension: 'js',
   },
   {
-    location: "https://example.com/foo.tar.gz",
-    extension: "gz"
-  }
+    location: 'https://example.com/foo.tar.gz',
+    extension: 'gz',
+  },
 ].forEach(c => {
   test(`parseExtension(${q(c.location)}) -> ${q(c.extension)}`, t => {
     t.plan(1);
@@ -31,7 +31,7 @@ const q = JSON.stringify;
     t.is(
       extension,
       c.extension,
-      `parseExtension(${q(c.location)}) === ${q(c.extension)}`
+      `parseExtension(${q(c.location)}) === ${q(c.extension)}`,
     );
   });
 });

--- a/packages/compartment-mapper/test/join.test.js
+++ b/packages/compartment-mapper/test/join.test.js
@@ -1,18 +1,18 @@
-import test from "ava";
-import { join } from "../src/node-module-specifier.js";
+import test from 'ava';
+import { join } from '../src/node-module-specifier.js';
 
 const q = JSON.stringify;
 
 [
   // { via: "", rel: "./", res: "" },
-  { via: "external", rel: "./main.js", res: "external/main.js" },
+  { via: 'external', rel: './main.js', res: 'external/main.js' },
   {
-    via: "external",
-    rel: "./internal/main.js",
-    res: "external/internal/main.js"
+    via: 'external',
+    rel: './internal/main.js',
+    res: 'external/internal/main.js',
   },
-  { via: "@org/lib", rel: "./lib/app.js", res: "@org/lib/lib/app.js" },
-  { via: "external", rel: "./internal/../main.js", res: "external/main.js" }
+  { via: '@org/lib', rel: './lib/app.js', res: '@org/lib/lib/app.js' },
+  { via: 'external', rel: './internal/../main.js', res: 'external/main.js' },
 ].forEach(c => {
   test(`join(${q(c.via)}, ${q(c.rel)}) -> ${q(c.res)}`, t => {
     t.plan(1);
@@ -21,42 +21,42 @@ const q = JSON.stringify;
   });
 });
 
-test("throws if the specifier is a fully qualified path", t => {
+test('throws if the specifier is a fully qualified path', t => {
   t.throws(
     () => {
-      join("", "/");
+      join('', '/');
     },
     undefined,
-    "throws if the specifier is a fully qualified path"
+    'throws if the specifier is a fully qualified path',
   );
 });
 
-test("throws if the specifier is absolute", t => {
+test('throws if the specifier is absolute', t => {
   t.throws(
     () => {
-      join("from", "to");
+      join('from', 'to');
     },
     undefined,
-    "throws if the specifier is absolute"
+    'throws if the specifier is absolute',
   );
 });
 
-test("throws if the referrer is relative", t => {
+test('throws if the referrer is relative', t => {
   t.throws(
     () => {
-      join("./", "foo");
+      join('./', 'foo');
     },
     undefined,
-    "throws if the referrer is relative"
+    'throws if the referrer is relative',
   );
 });
 
-test("throws if specifier reaches outside of base", t => {
+test('throws if specifier reaches outside of base', t => {
   t.throws(
     () => {
-      join("path/to/base", "./deeper/../..");
+      join('path/to/base', './deeper/../..');
     },
     undefined,
-    "throw if specifier reaches outside of base"
+    'throw if specifier reaches outside of base',
   );
 });

--- a/packages/compartment-mapper/test/main.test.js
+++ b/packages/compartment-mapper/test/main.test.js
@@ -1,6 +1,6 @@
-import "ses";
-import fs from "fs";
-import test from "ava";
+import 'ses';
+import fs from 'fs';
+import test from 'ava';
 import {
   loadLocation,
   importLocation,
@@ -8,21 +8,21 @@ import {
   writeArchive,
   parseArchive,
   loadArchive,
-  importArchive
-} from "../src/main.js";
+  importArchive,
+} from '../src/main.js';
 
-const fixture = new URL("node_modules/app/main.js", import.meta.url).toString();
-const archiveFixture = new URL("app.agar", import.meta.url).toString();
+const fixture = new URL('node_modules/app/main.js', import.meta.url).toString();
+const archiveFixture = new URL('app.agar', import.meta.url).toString();
 
 const read = async location => fs.promises.readFile(new URL(location).pathname);
 
 const globals = {
   globalProperty: 42,
-  globalLexical: "global" // should be overshadowed
+  globalLexical: 'global', // should be overshadowed
 };
 
 const globalLexicals = {
-  globalLexical: "globalLexical"
+  globalLexical: 'globalLexical',
 };
 
 const assertFixture = (t, namespace) => {
@@ -32,20 +32,20 @@ const assertFixture = (t, namespace) => {
     clarke,
     builtin,
     receivedGlobalProperty,
-    receivedGlobalLexical
+    receivedGlobalLexical,
   } = namespace;
 
-  t.is(avery, "Avery", "exports avery");
-  t.is(brooke, "Brooke", "exports brooke");
-  t.is(clarke, "Clarke", "exports clarke");
+  t.is(avery, 'Avery', 'exports avery');
+  t.is(brooke, 'Brooke', 'exports brooke');
+  t.is(clarke, 'Clarke', 'exports clarke');
 
-  t.is(builtin, "builtin", "exports builtin");
+  t.is(builtin, 'builtin', 'exports builtin');
 
-  t.is(receivedGlobalProperty, globals.globalProperty, "exports global");
+  t.is(receivedGlobalProperty, globals.globalProperty, 'exports global');
   t.is(
     receivedGlobalLexical,
     globalLexicals.globalLexical,
-    "exports global lexical"
+    'exports global lexical',
   );
 };
 
@@ -56,8 +56,8 @@ const fixtureAssertionCount = 6;
 // dependency of the application package.
 
 const builtinLocation = new URL(
-  "node_modules/builtin/builtin.js",
-  import.meta.url
+  'node_modules/builtin/builtin.js',
+  import.meta.url,
 ).toString();
 
 let modules;
@@ -70,11 +70,11 @@ async function setup() {
   const { namespace } = await utility.import({ globals });
   // We pass the builtin module into the module map.
   modules = {
-    builtin: namespace
+    builtin: namespace,
   };
 }
 
-test("loadLocation", async t => {
+test('loadLocation', async t => {
   t.plan(fixtureAssertionCount);
   await setup();
 
@@ -83,12 +83,12 @@ test("loadLocation", async t => {
     globals,
     globalLexicals,
     modules,
-    Compartment
+    Compartment,
   });
   assertFixture(t, namespace);
 });
 
-test("importLocation", async t => {
+test('importLocation', async t => {
   t.plan(fixtureAssertionCount);
   await setup();
 
@@ -96,12 +96,12 @@ test("importLocation", async t => {
     globals,
     globalLexicals,
     modules,
-    Compartment
+    Compartment,
   });
   assertFixture(t, namespace);
 });
 
-test("makeArchive / parseArchive", async t => {
+test('makeArchive / parseArchive', async t => {
   t.plan(fixtureAssertionCount);
   await setup();
 
@@ -111,12 +111,12 @@ test("makeArchive / parseArchive", async t => {
     globals,
     globalLexicals,
     modules,
-    Compartment
+    Compartment,
   });
   assertFixture(t, namespace);
 });
 
-test("makeArchive / parseArchive with a prefix", async t => {
+test('makeArchive / parseArchive with a prefix', async t => {
   t.plan(fixtureAssertionCount);
   await setup();
 
@@ -130,63 +130,63 @@ test("makeArchive / parseArchive with a prefix", async t => {
     globals,
     globalLexicals,
     modules,
-    Compartment
+    Compartment,
   });
   assertFixture(t, namespace);
 });
 
-test("writeArchive / loadArchive", async t => {
+test('writeArchive / loadArchive', async t => {
   t.plan(fixtureAssertionCount + 2);
   await setup();
 
   // Single file slot.
   let archive;
   const fakeRead = async path => {
-    t.is(path, "app.agar");
+    t.is(path, 'app.agar');
     return archive;
   };
   const fakeWrite = async (path, content) => {
-    t.is(path, "app.agar");
+    t.is(path, 'app.agar');
     archive = content;
   };
 
-  await writeArchive(fakeWrite, read, "app.agar", fixture);
-  const application = await loadArchive(fakeRead, "app.agar");
+  await writeArchive(fakeWrite, read, 'app.agar', fixture);
+  const application = await loadArchive(fakeRead, 'app.agar');
   const { namespace } = await application.import({
     globals,
     globalLexicals,
     modules,
-    Compartment
+    Compartment,
   });
   assertFixture(t, namespace);
 });
 
-test("writeArchive / importArchive", async t => {
+test('writeArchive / importArchive', async t => {
   t.plan(fixtureAssertionCount + 2);
   await setup();
 
   // Single file slot.
   let archive;
   const fakeRead = async path => {
-    t.is(path, "app.agar");
+    t.is(path, 'app.agar');
     return archive;
   };
   const fakeWrite = async (path, content) => {
-    t.is(path, "app.agar");
+    t.is(path, 'app.agar');
     archive = content;
   };
 
-  await writeArchive(fakeWrite, read, "app.agar", fixture);
-  const { namespace } = await importArchive(fakeRead, "app.agar", {
+  await writeArchive(fakeWrite, read, 'app.agar', fixture);
+  const { namespace } = await importArchive(fakeRead, 'app.agar', {
     globals,
     globalLexicals,
     modules,
-    Compartment
+    Compartment,
   });
   assertFixture(t, namespace);
 });
 
-test("importArchive", async t => {
+test('importArchive', async t => {
   t.plan(fixtureAssertionCount);
   await setup();
 
@@ -194,7 +194,7 @@ test("importArchive", async t => {
     globals,
     globalLexicals,
     modules,
-    Compartment
+    Compartment,
   });
   assertFixture(t, namespace);
 });

--- a/packages/compartment-mapper/test/node_modules/danny/src/danny.js
+++ b/packages/compartment-mapper/test/node_modules/danny/src/danny.js
@@ -1,1 +1,1 @@
-export const danny = "Danny";
+export const danny = 'Danny';

--- a/packages/compartment-mapper/test/node_modules/danny/src/index.js
+++ b/packages/compartment-mapper/test/node_modules/danny/src/index.js
@@ -1,1 +1,1 @@
-export * from "./danny.js";
+export * from './danny.js';

--- a/packages/compartment-mapper/test/node_modules/typecommon/main.js
+++ b/packages/compartment-mapper/test/node_modules/typecommon/main.js
@@ -1,6 +1,6 @@
-const js = require("./js.js");
-const mjs = require("./mjs.mjs");
-const cjs = require("./cjs.cjs");
-const json = require("./json.json");
+const js = require('./js.js');
+const mjs = require('./mjs.mjs');
+const cjs = require('./cjs.cjs');
+const json = require('./json.json');
 
 module.exports = [js, mjs, cjs, json];

--- a/packages/compartment-mapper/test/node_modules/typehybrid/main.js
+++ b/packages/compartment-mapper/test/node_modules/typehybrid/main.js
@@ -1,1 +1,1 @@
-export { meaning as default } from "./meaning.js";
+export { meaning as default } from './meaning.js';

--- a/packages/compartment-mapper/test/relative.test.js
+++ b/packages/compartment-mapper/test/relative.test.js
@@ -16,100 +16,100 @@
 // OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 // CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-import test from "ava";
-import { relative } from "../src/url.js";
+import test from 'ava';
+import { relative } from '../src/url.js';
 
-test("different protocol", t => {
+test('different protocol', t => {
   t.plan(2);
   t.is(
-    relative("http://a.com:12/a", "https://a.com:12/a"),
-    "https://a.com:12/a"
+    relative('http://a.com:12/a', 'https://a.com:12/a'),
+    'https://a.com:12/a',
   );
   t.is(
-    relative("http://a.com:12/a/", "https://a.com:12/a/"),
-    "https://a.com:12/a/"
+    relative('http://a.com:12/a/', 'https://a.com:12/a/'),
+    'https://a.com:12/a/',
   );
 });
 
-test("file protocol", t => {
+test('file protocol', t => {
   t.plan(1);
-  t.is(relative("file:///a", "file:///b"), "b");
+  t.is(relative('file:///a', 'file:///b'), 'b');
 });
 
-test("different domain", t => {
+test('different domain', t => {
   t.plan(2);
-  t.is(relative("http://a.com:12/a", "http://b.com/a"), "http://b.com/a");
-  t.is(relative("http://a.com:12/a/", "http://b.com/a/"), "http://b.com/a/");
+  t.is(relative('http://a.com:12/a', 'http://b.com/a'), 'http://b.com/a');
+  t.is(relative('http://a.com:12/a/', 'http://b.com/a/'), 'http://b.com/a/');
 });
 
-test("same domain", t => {
+test('same domain', t => {
   t.plan(2);
-  t.is(relative("http://a.com/a", "http://a.com/b"), "b");
-  t.is(relative("http://a.com/a/", "http://a.com/b/"), "../b/");
+  t.is(relative('http://a.com/a', 'http://a.com/b'), 'b');
+  t.is(relative('http://a.com/a/', 'http://a.com/b/'), '../b/');
 });
 
-test("divergent paths, longer from", t => {
+test('divergent paths, longer from', t => {
   t.plan(4);
   t.is(
-    relative("http://example.com/a/b/c/d", "http://example.com/a/b/d"),
-    "../d"
+    relative('http://example.com/a/b/c/d', 'http://example.com/a/b/d'),
+    '../d',
   );
   t.is(
-    relative("http://example.com/a/b/c/d/e", "http://example.com/a/d/e"),
-    "../../d/e"
+    relative('http://example.com/a/b/c/d/e', 'http://example.com/a/d/e'),
+    '../../d/e',
   );
   t.is(
-    relative("http://example.com/a/b/c/d/", "http://example.com/a/b/d/"),
-    "../../d/"
+    relative('http://example.com/a/b/c/d/', 'http://example.com/a/b/d/'),
+    '../../d/',
   );
   t.is(
-    relative("http://example.com/a/b/c/d/e/", "http://example.com/a/d/e/"),
-    "../../../d/e/"
+    relative('http://example.com/a/b/c/d/e/', 'http://example.com/a/d/e/'),
+    '../../../d/e/',
   );
 });
 
-test("divergent paths, longer to", t => {
+test('divergent paths, longer to', t => {
   t.plan(6);
   t.is(
-    relative("http://example.com/a/b/c/d", "http://example.com/a/b/c/d/e"),
-    "e"
+    relative('http://example.com/a/b/c/d', 'http://example.com/a/b/c/d/e'),
+    'e',
   );
   t.is(
-    relative("http://example.com/a/b/c/d", "http://example.com/a/b/c/d/e/f"),
-    "e/f"
+    relative('http://example.com/a/b/c/d', 'http://example.com/a/b/c/d/e/f'),
+    'e/f',
   );
-  t.is(relative("http://example.com/", "http://example.com/a/b"), "a/b");
+  t.is(relative('http://example.com/', 'http://example.com/a/b'), 'a/b');
   t.is(
-    relative("http://example.com/a/b/c/d/", "http://example.com/a/b/c/d/e/"),
-    "e/"
+    relative('http://example.com/a/b/c/d/', 'http://example.com/a/b/c/d/e/'),
+    'e/',
   );
   t.is(
-    relative("http://example.com/a/b/c/d/", "http://example.com/a/b/c/d/e/f/"),
-    "e/f/"
+    relative('http://example.com/a/b/c/d/', 'http://example.com/a/b/c/d/e/f/'),
+    'e/f/',
   );
-  t.is(relative("http://example.com/", "http://example.com/a/b/"), "a/b/");
+  t.is(relative('http://example.com/', 'http://example.com/a/b/'), 'a/b/');
 });
 
-test("divergent paths, equal length", t => {
+test('divergent paths, equal length', t => {
   t.plan(2);
   t.is(
     relative(
-      "http://example.com/a/b/c/d/e/f",
-      "http://example.com/a/b/c/g/h/j"
+      'http://example.com/a/b/c/d/e/f',
+      'http://example.com/a/b/c/g/h/j',
     ),
-    "../../g/h/j"
+    '../../g/h/j',
   );
   t.is(
     relative(
-      "http://example.com/a/b/c/d/e/f/",
-      "http://example.com/a/b/c/g/h/j/"
+      'http://example.com/a/b/c/d/e/f/',
+      'http://example.com/a/b/c/g/h/j/',
     ),
-    "../../../g/h/j/"
+    '../../../g/h/j/',
   );
 });
 
-test("identical", t => {
+test('identical', t => {
   t.plan(2);
-  t.is(relative("https://a.com/a", "https://a.com/a"), "");
-  t.is(relative("https://a.com/a/", "https://a.com/a/"), "");
+  t.is(relative('https://a.com/a', 'https://a.com/a'), '');
+  t.is(relative('https://a.com/a/', 'https://a.com/a/'), '');
 });

--- a/packages/compartment-mapper/test/relativize.test.js
+++ b/packages/compartment-mapper/test/relativize.test.js
@@ -1,11 +1,11 @@
-import test from "ava";
-import { relativize } from "../src/node-module-specifier.js";
+import test from 'ava';
+import { relativize } from '../src/node-module-specifier.js';
 
 const q = JSON.stringify;
 
 [
-  { spec: "index.js", rel: "./index.js" },
-  { spec: "./index.js", rel: "./index.js" }
+  { spec: 'index.js', rel: './index.js' },
+  { spec: './index.js', rel: './index.js' },
 ].forEach(c => {
   test(`relativize(${q(c.spec)}) -> ${q(c.rel)}`, t => {
     t.plan(1);

--- a/packages/compartment-mapper/test/resolve.test.js
+++ b/packages/compartment-mapper/test/resolve.test.js
@@ -1,36 +1,36 @@
-import test from "ava";
-import { resolve } from "../src/node-module-specifier.js";
+import test from 'ava';
+import { resolve } from '../src/node-module-specifier.js';
 
 const q = JSON.stringify;
 
 [
   // Cover degenerate cases
-  { res: "", rel: "", via: "./main.js" },
-  { res: ".", rel: ".", via: "./main.js" },
+  { res: '', rel: '', via: './main.js' },
+  { res: '.', rel: '.', via: './main.js' },
 
   // Non-relative (external) specifiers disregard the referrer.
-  { res: "external", rel: "external", via: "./main.js" },
-  { res: "out/side", rel: "out/side", via: "./main.js" },
-  { res: "external", rel: "external", via: "./anywhere/main.js" },
-  { res: "out/side", rel: "out/side", via: "./anywhere/main.js" },
-  { res: "external", rel: "external", via: "./some/where/main.js" },
-  { res: "out/side", rel: "out/side", via: "./some/where/main.js" },
+  { res: 'external', rel: 'external', via: './main.js' },
+  { res: 'out/side', rel: 'out/side', via: './main.js' },
+  { res: 'external', rel: 'external', via: './anywhere/main.js' },
+  { res: 'out/side', rel: 'out/side', via: './anywhere/main.js' },
+  { res: 'external', rel: 'external', via: './some/where/main.js' },
+  { res: 'out/side', rel: 'out/side', via: './some/where/main.js' },
   // And path arithmetic works.
-  { res: "side", rel: "out/../side", via: "./some/where/main.js" },
-  { res: "out/side", rel: "out/./side", via: "./some/where/main.js" },
-  { res: "out/side", rel: "out//side", via: "./some/where/main.js" },
+  { res: 'side', rel: 'out/../side', via: './some/where/main.js' },
+  { res: 'out/side', rel: 'out/./side', via: './some/where/main.js' },
+  { res: 'out/side', rel: 'out//side', via: './some/where/main.js' },
 
   // Relative (internal) references build upon the referrer.
-  { res: "./internal", rel: "./internal", via: "./main.js" },
-  { res: "./from/to", rel: "./to", via: "./from/main.js" },
+  { res: './internal', rel: './internal', via: './main.js' },
+  { res: './from/to', rel: './to', via: './from/main.js' },
   // And path arithmetic works.
-  { res: ".", rel: "./into/..", via: "./main.js" },
-  { res: ".", rel: "./into/./..", via: "./main.js" },
-  { res: ".", rel: "./into//..", via: "./main.js" },
-  { res: "./from", rel: "./to/..", via: "./from/main.js" },
-  { res: "./to", rel: "../to", via: "./from/main.js" },
-  { res: "./from", rel: ".", via: "./from/main.js" },
-  { res: ".", rel: "..", via: "./from/main.js" }
+  { res: '.', rel: './into/..', via: './main.js' },
+  { res: '.', rel: './into/./..', via: './main.js' },
+  { res: '.', rel: './into//..', via: './main.js' },
+  { res: './from', rel: './to/..', via: './from/main.js' },
+  { res: './to', rel: '../to', via: './from/main.js' },
+  { res: './from', rel: '.', via: './from/main.js' },
+  { res: '.', rel: '..', via: './from/main.js' },
 ].forEach(c => {
   test(`resolve(${q(c.rel)}, ${q(c.via)}) -> ${q(c.res)}`, t => {
     t.plan(1);
@@ -39,42 +39,42 @@ const q = JSON.stringify;
   });
 });
 
-test("throws if the specifier is non-relative", t => {
+test('throws if the specifier is non-relative', t => {
   t.throws(
     () => {
-      resolve("/", "");
+      resolve('/', '');
     },
     undefined,
-    "throw if the specifier is non-relative"
+    'throw if the specifier is non-relative',
   );
 });
 
-test("throws if the referrer is non-relative", t => {
+test('throws if the referrer is non-relative', t => {
   t.throws(
     () => {
-      resolve("", "/");
+      resolve('', '/');
     },
     undefined,
-    "throws if the referrer is non-relative"
+    'throws if the referrer is non-relative',
   );
 });
 
-test("throws if the referrer is external", t => {
+test('throws if the referrer is external', t => {
   t.throws(
     () => {
-      resolve("", "external");
+      resolve('', 'external');
     },
     undefined,
-    "throws if the referrer is external"
+    'throws if the referrer is external',
   );
 });
 
-test("throws if the referrer is external (degenerate case)", t => {
+test('throws if the referrer is external (degenerate case)', t => {
   t.throws(
     () => {
-      resolve("", "");
+      resolve('', '');
     },
     undefined,
-    "throws if the referrer is a null string"
+    'throws if the referrer is a null string',
   );
 });

--- a/packages/compartment-mapper/test/ses-lockdown.js
+++ b/packages/compartment-mapper/test/ses-lockdown.js
@@ -1,5 +1,5 @@
-import "ses";
+import 'ses';
 
 lockdown({
-  errorTaming: "unsafe"
+  errorTaming: 'unsafe',
 });

--- a/packages/compartment-mapper/test/transform.test.js
+++ b/packages/compartment-mapper/test/transform.test.js
@@ -1,15 +1,15 @@
 // import "./ses-lockdown.js";
-import "ses";
-import fs from "fs";
-import test from "ava";
-import { loadLocation } from "../src/main.js";
+import 'ses';
+import fs from 'fs';
+import test from 'ava';
+import { loadLocation } from '../src/main.js';
 
-test("transforms applied to evaluation", async t => {
+test('transforms applied to evaluation', async t => {
   t.plan(1);
 
   const fixture = new URL(
-    "node_modules/evaluator/evaluator.js",
-    import.meta.url
+    'node_modules/evaluator/evaluator.js',
+    import.meta.url,
   ).toString();
   const read = async location =>
     fs.promises.readFile(new URL(location).pathname);
@@ -17,14 +17,14 @@ test("transforms applied to evaluation", async t => {
   const application = await loadLocation(read, fixture);
   const { namespace } = await application.import({
     globals: {
-      code: `"hello"`
+      code: '"hello"',
     },
     transforms: [
       function transform(source) {
-        return source.replace(/ll/g, "y");
-      }
-    ]
+        return source.replace(/ll/g, 'y');
+      },
+    ],
   });
   const { default: value } = namespace;
-  t.is(value, "heyo", "code evaluated in compartment is transforemd");
+  t.is(value, 'heyo', 'code evaluated in compartment is transforemd');
 });

--- a/packages/compartment-mapper/test/zip.test.js
+++ b/packages/compartment-mapper/test/zip.test.js
@@ -1,31 +1,31 @@
-import test from "ava";
-import "../src/zip/types.js";
-import { ZipWriter } from "../src/zip/writer.js";
-import { ZipReader } from "../src/zip/reader.js";
+import test from 'ava';
+import '../src/zip/types.js';
+import { ZipWriter } from '../src/zip/writer.js';
+import { ZipReader } from '../src/zip/reader.js';
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
-test("zip round trip", async t => {
+test('zip round trip', async t => {
   t.plan(3);
 
   const expectedDate = new Date(1970, 1);
 
   const writer = new ZipWriter();
-  writer.write("hello/hello.txt", textEncoder.encode("Hello, World!\n"), {
+  writer.write('hello/hello.txt', textEncoder.encode('Hello, World!\n'), {
     mode: 0o600,
-    date: expectedDate
+    date: expectedDate,
   });
 
   const reader = new ZipReader(writer.snapshot());
-  const text = textDecoder.decode(reader.read("hello/hello.txt"));
-  const { mode, date } = reader.stat("hello/hello.txt");
+  const text = textDecoder.decode(reader.read('hello/hello.txt'));
+  const { mode, date } = reader.stat('hello/hello.txt');
 
-  t.is(text, "Hello, World!\n", "text should match");
-  t.is(mode, 0o600, "mode should match");
+  t.is(text, 'Hello, World!\n', 'text should match');
+  t.is(mode, 0o600, 'mode should match');
   t.is(
     date.getUTCMilliseconds(),
     expectedDate.getUTCMilliseconds(),
-    "date should match"
+    'date should match',
   );
 });

--- a/packages/endo/bin/endo.js
+++ b/packages/endo/bin/endo.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 (async () => {
-  const fs = await import("fs");
-  const { main } = await import("../src/cli.js");
+  const fs = await import('fs');
+  const { main } = await import('../src/cli.js');
   main(process, { fs: fs.promises });
 })();

--- a/packages/endo/package.json
+++ b/packages/endo/package.json
@@ -5,11 +5,12 @@
   "author": "Agoric",
   "license": "Apache-2.0",
   "type": "module",
+  "exports": {},
   "scripts": {
     "lint": "yarn lint:types && yarn lint:js",
-    "lint:types": "tsc --build jsconfig.json",
-    "lint:js": "eslint '**/*.js'",
     "lint-fix": "eslint --fix '**/*.js'",
+    "lint:js": "eslint '**/*.js'",
+    "lint:types": "tsc --build jsconfig.json",
     "postinstall": "node src/postinstall.js",
     "test": "ava"
   },
@@ -31,6 +32,10 @@
     "extends": [
       "@agoric"
     ]
+  },
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
   },
   "files": [
     "LICENSE*",

--- a/packages/endo/src/cli.js
+++ b/packages/endo/src/cli.js
@@ -1,13 +1,13 @@
 /* eslint no-shadow: [0] */
-import "./lockdown.js";
-import subprocess from "child_process";
+import './lockdown.js';
+import subprocess from 'child_process';
 import {
   search,
   writeArchive,
-  compartmentMapForNodeModules
-} from "@agoric/compartment-mapper";
+  compartmentMapForNodeModules,
+} from '@agoric/compartment-mapper';
 
-const mitmPath = new URL("../mitm", import.meta.url).pathname;
+const mitmPath = new URL('../mitm', import.meta.url).pathname;
 
 function usage(message) {
   console.error(message);
@@ -15,17 +15,17 @@ function usage(message) {
 }
 
 async function noEntryUsage() {
-  return usage(`expected path to program`);
+  return usage('expected path to program');
 }
 
 async function noArchiveUsage() {
-  return usage(`expected path for archive`);
+  return usage('expected path for archive');
 }
 
 async function subcommand([arg, ...rest], handlers) {
   const keys = Object.keys(handlers);
   if (arg === undefined || !keys.includes(arg)) {
-    return usage(`expected one of ${keys.join(", ")}`);
+    return usage(`expected one of ${keys.join(', ')}`);
   }
   return handlers[arg](rest);
 }
@@ -33,9 +33,9 @@ async function subcommand([arg, ...rest], handlers) {
 async function parameter(args, handle, usage) {
   const [arg, ...rest] = args;
   if (arg === undefined) {
-    return usage(`expected an argument`);
+    return usage('expected an argument');
   }
-  if (arg.startsWith("-")) {
+  if (arg.startsWith('-')) {
     return usage(`unexpected flag: ${arg}`);
   }
   return handle(arg, rest);
@@ -47,12 +47,12 @@ async function run(args, { cwd, read, write, stdout, env }) {
       if (args.length) {
         return usage(`unexpected arguments: ${JSON.stringify(args)}`);
       }
-      const currentLocation = new URL(`${cwd()}/`, "file:///");
+      const currentLocation = new URL(`${cwd()}/`, 'file:///');
       const applicationLocation = new URL(applicationPath, currentLocation);
       const { packageLocation } = await search(read, applicationLocation);
       const compartmentMap = await compartmentMapForNodeModules(
         read,
-        packageLocation
+        packageLocation,
       );
       stdout.write(`${JSON.stringify(compartmentMap, null, 2)}\n`);
       return 0;
@@ -66,7 +66,7 @@ async function run(args, { cwd, read, write, stdout, env }) {
         if (args.length) {
           return usage(`unexpected arguments: ${JSON.stringify(args)}`);
         }
-        const currentLocation = new URL(`${cwd()}/`, "file:///");
+        const currentLocation = new URL(`${cwd()}/`, 'file:///');
         const archiveLocation = new URL(archivePath, currentLocation);
         const applicationLocation = new URL(applicationPath, currentLocation);
         await writeArchive(write, read, archiveLocation, applicationLocation);
@@ -80,9 +80,9 @@ async function run(args, { cwd, read, write, stdout, env }) {
   async function exec([arg, ...args]) {
     const child = subprocess.spawn(arg, args, {
       env: { ...env, PATH: `${mitmPath}:${env.PATH}` },
-      stdio: "inherit"
+      stdio: 'inherit',
     });
-    return new Promise(resolve => child.on("exit", resolve));
+    return new Promise(resolve => child.on('exit', resolve));
   }
 
   return subcommand(args, { map, archive, exec });
@@ -116,7 +116,7 @@ export async function main(process, modules) {
       write,
       cwd,
       stdout,
-      env
+      env,
     });
   } catch (error) {
     process.exitCode = usage(error.stack || error.message);

--- a/packages/endo/src/lockdown.js
+++ b/packages/endo/src/lockdown.js
@@ -1,9 +1,9 @@
-import "ses";
+import 'ses';
 
 // This is used by Endo to lockdown its own start compartment.
 
 lockdown({
-  errorTaming: "unsafe"
+  errorTaming: 'unsafe',
 });
 
 // Even on non-v8, we tame the start compartment's Error constructor so

--- a/packages/endo/src/postinstall.js
+++ b/packages/endo/src/postinstall.js
@@ -3,15 +3,15 @@
 // that the mitm directory is appears before Node.js's bin directory on the
 // environment PATH.
 
-import fs from "fs";
+import fs from 'fs';
 
 const node = process.argv[0];
-const lockdown = new URL("./lockdown.cjs", import.meta.url).pathname;
-const mitm = new URL("../mitm/node", import.meta.url).pathname;
+const lockdown = new URL('./lockdown.cjs', import.meta.url).pathname;
+const mitm = new URL('../mitm/node', import.meta.url).pathname;
 
 const script = `#!/bin/bash
 set -ueo pipefail
 ${node} -r ${lockdown} "$@"`;
 
-fs.writeFileSync(mitm, script, "utf-8");
+fs.writeFileSync(mitm, script, 'utf-8');
 fs.chmodSync(mitm, 0o755);

--- a/packages/endo/test/main.test.js
+++ b/packages/endo/test/main.test.js
@@ -1,4 +1,4 @@
 // no tests at this time
-import test from "ava";
+import test from 'ava';
 
-test.todo("No tests at this time");
+test.todo('No tests at this time');

--- a/packages/eslint-config/eslint-config.json
+++ b/packages/eslint-config/eslint-config.json
@@ -18,6 +18,15 @@
     "StaticModuleRecord": "readonly"
   },
   "rules": {
+    "quotes": [
+      "error",
+      "single",
+      {
+        "avoidEscape": true,
+        "allowTemplateLiterals": true
+      }
+    ],
+    "comma-dangle": ["error", "always-multiline"],
     "implicit-arrow-linebreak": "off",
     "function-paren-newline": "off",
     "arrow-parens": "off",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -42,5 +42,4 @@
     "eslint-plugin-react-hooks": "^4",
     "prettier": "^1.13.0"
   }
-
 }

--- a/packages/harden/package.json
+++ b/packages/harden/package.json
@@ -1,21 +1,21 @@
 {
   "name": "@agoric/harden",
-  "version": "0.2.0",
+  "version": "0.0.0+1-dev",
   "description": "Please use the package named 'ses' directly to shim 'harden'",
-  "author": "Agoric",
-  "license": "Apache-2.0",
   "keywords": [
     "deepFreeze",
     "harden",
     "Object.freeze",
     "freeze"
   ],
-  "homepage": "https://github.com/Agoric/SES-shim/blob/master/packages/ses/README.md#harden",
-  "bugs": {
-    "url": "https://github.com/Agoric/SES-shim/issues"
-  },
+  "author": "Agoric",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/Agoric/SES-shim/tree/master/packages/harden#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Agoric/SES-shim.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Agoric/SES-shim/issues"
   }
 }

--- a/packages/make-hardener/package.json
+++ b/packages/make-hardener/package.json
@@ -2,29 +2,21 @@
   "name": "@agoric/make-hardener",
   "version": "0.1.1+1-dev",
   "description": "Create a 'hardener' which freezes the API surface of a set of objects",
-  "author": "Agoric",
-  "license": "Apache-2.0",
   "keywords": [
     "deepFreeze",
     "harden",
     "Object.freeze",
     "freeze"
   ],
-  "homepage": "https://github.com/Agoric/packages/make-hardener#readme",
-  "bugs": {
-    "url": "https://github.com/Agoric/make-hardener/issues"
-  },
+  "author": "Agoric",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/Agoric/SES-shim/tree/master/packages/make-hardener#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Agoric/ses-shim.git"
+    "url": "git+https://github.com/Agoric/SES-shim.git"
   },
-  "files": [
-    "dist",
-    "src",
-    "LICENSE*"
-  ],
-  "directories": {
-    "test": "test"
+  "bugs": {
+    "url": "https://github.com/Agoric/SES-shim/issues"
   },
   "type": "module",
   "main": "./dist/make-hardener.cjs",
@@ -49,6 +41,7 @@
     "test": "ava",
     "build": "rollup --config rollup.config.js"
   },
+  "dependencies": {},
   "devDependencies": {
     "@agoric/eslint-config": "^0.1.0",
     "@rollup/plugin-node-resolve": "^6.1.0",
@@ -66,5 +59,17 @@
     "extends": [
       "@agoric"
     ]
+  },
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
+  },
+  "files": [
+    "LICENSE*",
+    "dist",
+    "src"
+  ],
+  "directories": {
+    "test": "test"
   }
 }

--- a/packages/make-importer/package.json
+++ b/packages/make-importer/package.json
@@ -1,11 +1,23 @@
 {
   "name": "@agoric/make-importer",
-  "private": true,
   "version": "0.0.3+1-dev",
+  "private": true,
   "description": "Create an importer to pair with a module transform.",
+  "keywords": [],
+  "author": "Agoric",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/Agoric/SES-shim/tree/master/packages/make-importer#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Agoric/SES-shim.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Agoric/SES-shim/issues"
+  },
+  "type": null,
   "main": "./dist/make-importer.cjs",
-  "browser": "./dist/make-importer.umd.js",
   "module": "./dist/make-importer.esm.js",
+  "browser": "./dist/make-importer.umd.js",
   "unpkg": "./dist/make-importer.umd.js",
   "exports": {
     "./package.json": "./package.json",
@@ -15,11 +27,6 @@
       "browser": "./dist/make-importer.umd.js"
     }
   },
-  "files": [
-    "src",
-    "dist",
-    "LICENSE*"
-  ],
   "scripts": {
     "prepublish": "yarn clean && yarn build",
     "build": "rollup --config rollup.config.js",
@@ -31,6 +38,7 @@
     "lint-fix-jessie": "eslint -c '.eslintrc-jessie.js' --fix '**/*.js'",
     "lint-check-jessie": "eslint -c '.eslintrc-jessie.js' '**/*.js'"
   },
+  "dependencies": {},
   "devDependencies": {
     "@agoric/evaluate": "^2.1.3",
     "@agoric/test262-runner": "0.1.0",
@@ -50,15 +58,24 @@
     "tap": "14.10.5",
     "tape-promise": "^4.0.0"
   },
-  "keywords": [],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Agoric/ses-shim.git"
+  "ava": {
+    "files": [
+      "test/**/*.test.js"
+    ],
+    "require": []
   },
-  "author": "Agoric",
-  "license": "Apache-2.0",
-  "bugs": {
-    "url": "https://github.com/Agoric/make-importer/issues"
+  "eslintConfig": {
+    "extends": [
+      "@agoric"
+    ]
   },
-  "homepage": "https://github.com/Agoric/make-importer#readme"
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
+  },
+  "files": [
+    "LICENSE*",
+    "dist",
+    "src"
+  ]
 }

--- a/packages/make-simple-evaluate/package.json
+++ b/packages/make-simple-evaluate/package.json
@@ -3,9 +3,17 @@
   "version": "0.1.0",
   "private": true,
   "description": "A simple secure evaluator without eval and Function",
+  "keywords": [],
   "author": "Agoric",
   "license": "Apache-2.0",
-  "homepage": "https://github.com/Agoric/ses-shim/packages/make-simple-evaluator#readme",
+  "homepage": "https://github.com/Agoric/SES-shim/tree/master/packages/make-simple-evaluate#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Agoric/SES-shim.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Agoric/SES-shim/issues"
+  },
   "type": "module",
   "main": "./src/main.js",
   "scripts": {
@@ -13,17 +21,29 @@
     "lint-fix": "eslint --fix '**/*.js'",
     "OFF-test": "tap --no-esm --no-coverage --reporter spec 'test/**/*.test.js'"
   },
+  "dependencies": {},
   "devDependencies": {
     "@agoric/eslint-config": "^0.1.0",
     "tap": "14.10.5"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Agoric/ses-shim.git"
+  "ava": {
+    "files": [
+      "test/**/*.test.js"
+    ],
+    "require": []
   },
   "eslintConfig": {
     "extends": [
       "@agoric"
     ]
-  }
+  },
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
+  },
+  "files": [
+    "LICENSE*",
+    "dist",
+    "src"
+  ]
 }

--- a/packages/make-simple-evaluate/src/main.js
+++ b/packages/make-simple-evaluate/src/main.js
@@ -2,73 +2,73 @@ function makeGlobalObject() {
   const globalPropertyNames = [
     // *** 18.2 Function Properties of the Global Object
 
-    "eval",
-    "isFinite",
-    "isNaN",
-    "parseFloat",
-    "parseInt",
+    'eval',
+    'isFinite',
+    'isNaN',
+    'parseFloat',
+    'parseInt',
 
-    "decodeURI",
-    "decodeURIComponent",
-    "encodeURI",
-    "encodeURIComponent",
+    'decodeURI',
+    'decodeURIComponent',
+    'encodeURI',
+    'encodeURIComponent',
 
     // *** 18.3 Constructor Properties of the Global Object
 
-    "Array",
-    "ArrayBuffer",
-    "Boolean",
-    "DataView",
-    "Date",
-    "Error",
-    "EvalError",
-    "Float32Array",
-    "Float64Array",
-    "Function",
-    "Int8Array",
-    "Int16Array",
-    "Int32Array",
-    "Map",
-    "Number",
-    "Object",
-    "Promise",
-    "Proxy",
-    "RangeError",
-    "ReferenceError",
-    "RegExp",
-    "Set",
-    "SharedArrayBuffer",
-    "String",
-    "Symbol",
-    "SyntaxError",
-    "TypeError",
-    "Uint8Array",
-    "Uint8ClampedArray",
-    "Uint16Array",
-    "Uint32Array",
-    "URIError",
-    "WeakMap",
-    "WeakSet",
+    'Array',
+    'ArrayBuffer',
+    'Boolean',
+    'DataView',
+    'Date',
+    'Error',
+    'EvalError',
+    'Float32Array',
+    'Float64Array',
+    'Function',
+    'Int8Array',
+    'Int16Array',
+    'Int32Array',
+    'Map',
+    'Number',
+    'Object',
+    'Promise',
+    'Proxy',
+    'RangeError',
+    'ReferenceError',
+    'RegExp',
+    'Set',
+    'SharedArrayBuffer',
+    'String',
+    'Symbol',
+    'SyntaxError',
+    'TypeError',
+    'Uint8Array',
+    'Uint8ClampedArray',
+    'Uint16Array',
+    'Uint32Array',
+    'URIError',
+    'WeakMap',
+    'WeakSet',
 
     // *** 18.4 Other Properties of the Global Object
 
-    "Atomics",
-    "JSON",
-    "Math",
-    "Reflect",
+    'Atomics',
+    'JSON',
+    'Math',
+    'Reflect',
 
     // *** Annex B
 
-    "escape",
-    "unescape"
+    'escape',
+    'unescape',
   ];
 
   const blacklist = [
-    "eval",
-    "Function",
-    "Atomics",
-    "SharedArrayBuffer",
-    "Constructor"
+    'eval',
+    'Function',
+    'Atomics',
+    'SharedArrayBuffer',
+    'Constructor',
   ];
 
   const globalObject = {};
@@ -76,16 +76,16 @@ function makeGlobalObject() {
   const descs = {
     Infinity: {
       value: Infinity,
-      enumerable: false
+      enumerable: false,
     },
     NaN: {
       value: NaN,
-      enumerable: false
+      enumerable: false,
     },
     undefined: {
       value: undefined,
-      enumerable: false
-    }
+      enumerable: false,
+    },
   };
 
   for (const name of globalPropertyNames) {
@@ -98,7 +98,7 @@ function makeGlobalObject() {
         value: globalThis[name],
         configurable: true,
         writable: true,
-        enumerable: false
+        enumerable: false,
       };
     }
   }
@@ -123,7 +123,7 @@ function makeEvaluateFactory() {
 function applyTransforms(transforms, rewriterState) {
   return transforms.reduce(
     (rs, transform) => (transform.rewrite ? transform.rewrite(rs) : rs),
-    rewriterState
+    rewriterState,
   );
 }
 
@@ -138,24 +138,24 @@ export function makeEvaluate(makerOptions = {}) {
 
     const allEndowments = {
       ...(options.endowments || {}),
-      ...(makerOptions.endowments || {})
+      ...(makerOptions.endowments || {}),
     };
 
     const allTransforms = [
       ...(options.transforms || []),
-      ...(makerOptions.transforms || [])
+      ...(makerOptions.transforms || []),
     ];
 
     const { endowments, src } = applyTransforms(allTransforms, {
       endowments: allEndowments,
-      src: source
+      src: source,
     });
 
     // PROXY
     const shadow = Object.freeze({});
     const scopeProxy = new Proxy(shadow, {
       get(_shadow, prop) {
-        if (typeof prop === "symbol") {
+        if (typeof prop === 'symbol') {
           return undefined;
         }
         if (prop in endowments) {
@@ -166,7 +166,7 @@ export function makeEvaluate(makerOptions = {}) {
       set(_shadow, prop, value) {
         if (prop in endowments) {
           const desc = Object.getOwnPropertyDescriptor(endowments, prop);
-          if ("value" in desc) {
+          if ('value' in desc) {
             // Work around a peculiar behavior in the specs, where
             // value properties are defined on the receiver.
             return Reflect.set(endowments, prop, value);
@@ -177,7 +177,7 @@ export function makeEvaluate(makerOptions = {}) {
       },
       has(_shadow, prop) {
         return prop in endowments || prop in globalObject || prop in globalThis;
-      }
+      },
     });
 
     return Reflect.apply(evaluateFactory, globalObject, [scopeProxy])(src);

--- a/packages/ses-integration-test/package.json
+++ b/packages/ses-integration-test/package.json
@@ -1,12 +1,21 @@
 {
   "name": "ses-integration-test",
   "version": "1.0.0",
-  "description": "",
-  "browserslist": [
-    "last 1 chrome versions"
-  ],
-  "main": "index.js",
   "private": true,
+  "description": "",
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "homepage": "https://github.com/Agoric/SES-shim/tree/master/packages/ses-integration-test#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Agoric/SES-shim.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Agoric/SES-shim/issues"
+  },
+  "main": "index.js",
+  "exports": {},
   "scripts": {
     "lint": "eslint '**/*.js'",
     "lint-fix": "eslint --fix '**/*.js'",
@@ -21,9 +30,6 @@
     "build:rollup": "rollup -c scaffolding/rollup/rollup.config.test.js",
     "build:parcel": "parcel build scaffolding/parcel/index.html --public-url ./ -d bundles/parcel --no-minify"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
   "dependencies": {
     "ses": "^0.11.0"
   },
@@ -43,9 +49,27 @@
     "webpack": "^4.29.6",
     "webpack-cli": "^3.2.3"
   },
+  "ava": {
+    "files": [
+      "*test*/**/*.test.js"
+    ],
+    "require": []
+  },
   "eslintConfig": {
     "extends": [
       "@agoric"
     ]
-  }
+  },
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
+  },
+  "files": [
+    "LICENSE*",
+    "dist",
+    "src"
+  ],
+  "browserslist": [
+    "last 1 chrome versions"
+  ]
 }

--- a/packages/ses-integration-test/package.json
+++ b/packages/ses-integration-test/package.json
@@ -15,7 +15,6 @@
     "url": "https://github.com/Agoric/SES-shim/issues"
   },
   "main": "index.js",
-  "exports": {},
   "scripts": {
     "lint": "eslint '**/*.js'",
     "lint-fix": "eslint --fix '**/*.js'",

--- a/packages/ses-integration-test/puppeteer-test/post-release.test.js
+++ b/packages/ses-integration-test/puppeteer-test/post-release.test.js
@@ -1,3 +1,3 @@
-import testBundler from "./utility/bundler.test";
+import testBundler from './utility/bundler.test';
 
-testBundler("unpkg umd", "../../scaffolding/unpkg-umd/index.html");
+testBundler('unpkg umd', '../../scaffolding/unpkg-umd/index.html');

--- a/packages/ses-integration-test/puppeteer-test/pre-release.test.js
+++ b/packages/ses-integration-test/puppeteer-test/pre-release.test.js
@@ -1,7 +1,7 @@
-import testBundler from "./utility/bundler.test";
+import testBundler from './utility/bundler.test';
 
-testBundler("mock unpkg umd", "../../scaffolding/mock-unpkg-umd/index.html");
-testBundler("webpack", "../../scaffolding/webpack/index.html");
-testBundler("rollup", "../../scaffolding/rollup/index.html");
-testBundler("parcel", "../../bundles/parcel/index.html");
-testBundler("browserify", "../../scaffolding/browserify/index.html");
+testBundler('mock unpkg umd', '../../scaffolding/mock-unpkg-umd/index.html');
+testBundler('webpack', '../../scaffolding/webpack/index.html');
+testBundler('rollup', '../../scaffolding/rollup/index.html');
+testBundler('parcel', '../../bundles/parcel/index.html');
+testBundler('browserify', '../../scaffolding/browserify/index.html');

--- a/packages/ses-integration-test/puppeteer-test/utility/bundler.test.js
+++ b/packages/ses-integration-test/puppeteer-test/utility/bundler.test.js
@@ -1,28 +1,28 @@
-import puppeteer from "puppeteer";
-import test from "tape-promise/tape";
+import puppeteer from 'puppeteer';
+import test from 'tape-promise/tape';
 
-import path from "path";
+import path from 'path';
 
 const runBrowserTests = async indexFile => {
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
-  page.on("pageerror", err => {
+  page.on('pageerror', err => {
     console.log(err);
   });
 
   let numTests;
   let numPass;
-  page.on("console", msg => {
-    if (msg.text().includes("# tests")) {
+  page.on('console', msg => {
+    if (msg.text().includes('# tests')) {
       [numTests] = msg
         .text()
-        .split(" ")
+        .split(' ')
         .slice(-1);
     }
-    if (msg.text().includes("# pass")) {
+    if (msg.text().includes('# pass')) {
       [numPass] = msg
         .text()
-        .split(" ")
+        .split(' ')
         .slice(-1);
     }
   });
@@ -39,7 +39,7 @@ const testBundler = (bundlerName, indexFile) => {
         t.notEqual(numTests, undefined);
         t.equal(numTests, numPass);
       })
-      .catch(e => t.isNot(e, e, "unexpected exception"))
+      .catch(e => t.isNot(e, e, 'unexpected exception'))
       .finally(() => t.end());
   });
 };

--- a/packages/ses-integration-test/scaffolding/rollup/rollup.config.test.js
+++ b/packages/ses-integration-test/scaffolding/rollup/rollup.config.test.js
@@ -1,26 +1,26 @@
-import path from "path";
-import resolve from "@rollup/plugin-node-resolve";
-import commonjs from "@rollup/plugin-commonjs";
+import path from 'path';
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
 
 export default [
   {
-    input: "ses",
+    input: 'ses',
     output: [
       {
-        file: path.resolve(__dirname, "../../bundles/rollup.js"),
-        format: "iife"
-      }
+        file: path.resolve(__dirname, '../../bundles/rollup.js'),
+        format: 'iife',
+      },
     ],
     plugins: [
       resolve({
         only: [
-          "ses",
-          "@agoric/make-hardener",
-          "@agoric/transform-module",
-          "@agoric/babel-standalone"
-        ]
+          'ses',
+          '@agoric/make-hardener',
+          '@agoric/transform-module',
+          '@agoric/babel-standalone',
+        ],
       }),
-      commonjs()
-    ]
-  }
+      commonjs(),
+    ],
+  },
 ];

--- a/packages/ses-integration-test/scaffolding/webpack/webpack.config.js
+++ b/packages/ses-integration-test/scaffolding/webpack/webpack.config.js
@@ -1,15 +1,15 @@
-const path = require("path");
-const webpack = require("webpack");
+const path = require('path');
+const webpack = require('webpack');
 
 module.exports = {
-  mode: "development",
-  entry: "./transform-tests/output/test.esm.js",
+  mode: 'development',
+  entry: './transform-tests/output/test.esm.js',
   output: {
-    path: path.resolve(__dirname, "../../bundles/"),
-    filename: "webpack.js"
+    path: path.resolve(__dirname, '../../bundles/'),
+    filename: 'webpack.js',
   },
   node: {
-    fs: "empty"
+    fs: 'empty',
   },
   plugins: [
     new webpack.IgnorePlugin({
@@ -18,14 +18,14 @@ module.exports = {
       },
       checkResource(resource) {
         if (
-          resource === "foo" ||
-          resource === "unknown" ||
-          resource === "@agoric/harden"
+          resource === 'foo' ||
+          resource === 'unknown' ||
+          resource === '@agoric/harden'
         ) {
           return true;
         }
         return false;
-      }
-    })
-  ]
+      },
+    }),
+  ],
 };

--- a/packages/ses-integration-test/test/sanity.test.js
+++ b/packages/ses-integration-test/test/sanity.test.js
@@ -1,11 +1,11 @@
-import test from "tape";
+import test from 'tape';
 
-import "ses";
+import 'ses';
 
-test("sanity", t => {
-  t.equal(lockdown(), true, "lockdown runs successfully");
+test('sanity', t => {
+  t.equal(lockdown(), true, 'lockdown runs successfully');
   const c = new Compartment({ abc: 456 });
-  t.equal(c.evaluate("123"), 123, "simple evaluate succeeds");
-  t.equal(c.evaluate("abc"), 456, "endowment succeeds");
+  t.equal(c.evaluate('123'), 123, 'simple evaluate succeeds');
+  t.equal(c.evaluate('abc'), 456, 'endowment succeeds');
   t.end();
 });

--- a/packages/ses-integration-test/transform-tests/config/rollup.config.cjs.js
+++ b/packages/ses-integration-test/transform-tests/config/rollup.config.cjs.js
@@ -1,23 +1,23 @@
-import multiEntry from "rollup-plugin-multi-entry";
-import resolve from "@rollup/plugin-node-resolve";
-import commonjs from "@rollup/plugin-commonjs";
+import multiEntry from 'rollup-plugin-multi-entry';
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
 
 export default [
   {
     input: {
-      include: ["test/**/*.js"]
+      include: ['test/**/*.js'],
     },
     output: {
-      file: "transform-tests/output/test.cjs.js",
-      format: "cjs"
+      file: 'transform-tests/output/test.cjs.js',
+      format: 'cjs',
     },
-    external: ["tape", "@agoric/make-hardener"],
+    external: ['tape', '@agoric/make-hardener'],
     plugins: [
       multiEntry(),
       resolve({
-        only: ["@agoric/nat", "ses"]
+        only: ['@agoric/nat', 'ses'],
       }),
-      commonjs()
-    ]
-  }
+      commonjs(),
+    ],
+  },
 ];

--- a/packages/ses-integration-test/transform-tests/config/rollup.config.esm.js
+++ b/packages/ses-integration-test/transform-tests/config/rollup.config.esm.js
@@ -1,26 +1,26 @@
-import multiEntry from "rollup-plugin-multi-entry";
-import resolve from "@rollup/plugin-node-resolve";
-import commonjs from "@rollup/plugin-commonjs";
+import multiEntry from 'rollup-plugin-multi-entry';
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
 
 export default [
   {
     input: {
-      include: ["test/**/*.js"],
-      exclude: ["test/require.test.js"]
+      include: ['test/**/*.js'],
+      exclude: ['test/require.test.js'],
     },
     output: {
-      file: "transform-tests/output/test.esm.js",
-      format: "esm"
+      file: 'transform-tests/output/test.esm.js',
+      format: 'esm',
     },
-    external: ["tape", "@agoric/make-hardener"],
+    external: ['tape', '@agoric/make-hardener'],
     plugins: [
       resolve({
-        only: ["@agoric/nat", "ses"]
+        only: ['@agoric/nat', 'ses'],
       }),
       commonjs(),
-      multiEntry()
-    ]
-  }
+      multiEntry(),
+    ],
+  },
 ];
 
 /* (!) Unresolved dependencies

--- a/packages/ses-integration-test/transform-tests/config/rollup.config.no-lib.js
+++ b/packages/ses-integration-test/transform-tests/config/rollup.config.no-lib.js
@@ -1,28 +1,28 @@
-import replace from "rollup-plugin-replace";
-import multiEntry from "rollup-plugin-multi-entry";
-import resolve from "@rollup/plugin-node-resolve";
-import commonjs from "@rollup/plugin-commonjs";
+import replace from 'rollup-plugin-replace';
+import multiEntry from 'rollup-plugin-multi-entry';
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
 
 export default [
   {
     input: {
-      include: ["test/**/*.js"]
+      include: ['test/**/*.js'],
     },
     output: {
-      file: "transform-tests/output/test.no-lib.cjs.js",
-      format: "cjs"
+      file: 'transform-tests/output/test.no-lib.cjs.js',
+      format: 'cjs',
     },
-    external: ["ses", "tape", "@agoric/make-hardener"],
+    external: ['ses', 'tape', '@agoric/make-hardener'],
     plugins: [
       replace({
-        delimiters: ["", ""],
-        'import "ses";': ""
+        delimiters: ['', ''],
+        'import "ses";': '',
       }),
       resolve({
-        only: ["@agoric/nat"]
+        only: ['@agoric/nat'],
       }),
       commonjs(),
-      multiEntry()
-    ]
-  }
+      multiEntry(),
+    ],
+  },
 ];

--- a/packages/ses-integration-test/transform-tests/config/rollup.config.no-lib.js
+++ b/packages/ses-integration-test/transform-tests/config/rollup.config.no-lib.js
@@ -16,7 +16,8 @@ export default [
     plugins: [
       replace({
         delimiters: ['', ''],
-        'import "ses";': '',
+        "import 'ses';": '', // NEVER
+        'import "ses";': '', // AGAIN
       }),
       resolve({
         only: ['@agoric/nat'],

--- a/packages/ses/package.json
+++ b/packages/ses/package.json
@@ -1,14 +1,29 @@
 {
   "name": "ses",
   "version": "0.11.0+1-dev",
+  "private": false,
   "description": "Secure ECMAScript",
+  "keywords": [
+    "confinement",
+    "isolation",
+    "secure execution",
+    "third-party code"
+  ],
   "author": "Agoric",
   "license": "Apache-2.0",
+  "homepage": "https://github.com/Agoric/SES-shim/tree/master/packages/ses#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Agoric/SES-shim.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Agoric/SES-shim/issues"
+  },
   "type": "module",
+  "types": "./index.d.ts",
   "main": "./dist/ses.cjs",
   "module": "./ses.js",
   "browser": "./dist/ses.umd.js",
-  "types": "./index.d.ts",
   "unpkg": "./dist/ses.umd.js",
   "exports": {
     "./package.json": "./package.json",
@@ -55,8 +70,7 @@
   },
   "ava": {
     "files": [
-      "test/**/*.test.js",
-      "test262/*.js"
+      "*test*/**/*.test.js"
     ],
     "require": []
   },
@@ -65,19 +79,9 @@
       "@agoric"
     ]
   },
-  "keywords": [
-    "confinement",
-    "isolation",
-    "secure execution",
-    "third-party code"
-  ],
-  "homepage": "https://github.com/Agoric/SES-shim",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Agoric/SES-shim.git"
-  },
-  "bugs": {
-    "url": "https://github.com/Agoric/SES-shim/issues"
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
   },
   "files": [
     "LICENSE*",

--- a/packages/ses/rollup.config.js
+++ b/packages/ses/rollup.config.js
@@ -7,11 +7,11 @@ export default [
     input: 'ses.js',
     output: [
       {
-        file: `dist/ses.mjs`,
+        file: 'dist/ses.mjs',
         format: 'esm',
       },
       {
-        file: `dist/ses.cjs`,
+        file: 'dist/ses.cjs',
         format: 'cjs',
       },
     ],
@@ -21,7 +21,7 @@ export default [
     input: 'lockdown.js',
     output: [
       {
-        file: `dist/lockdown.cjs`,
+        file: 'dist/lockdown.cjs',
         format: 'cjs',
       },
     ],
@@ -30,7 +30,7 @@ export default [
   {
     input: 'ses.js',
     output: {
-      file: `dist/ses.umd.js`,
+      file: 'dist/ses.umd.js',
       format: 'umd',
       name: 'SES',
     },
@@ -39,7 +39,7 @@ export default [
   {
     input: 'lockdown.js',
     output: {
-      file: `dist/lockdown.umd.js`,
+      file: 'dist/lockdown.umd.js',
       format: 'umd',
       name: 'SES',
     },
@@ -48,7 +48,7 @@ export default [
   {
     input: 'ses.js',
     output: {
-      file: `dist/ses.umd.min.js`,
+      file: 'dist/ses.umd.min.js',
       format: 'umd',
       name: 'SES',
     },
@@ -57,7 +57,7 @@ export default [
   {
     input: 'lockdown.js',
     output: {
-      file: `dist/lockdown.umd.min.js`,
+      file: 'dist/lockdown.umd.min.js',
       format: 'umd',
       name: 'SES',
     },

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -110,7 +110,7 @@ export const makeCompartmentConstructor = (
   function Compartment(endowments = {}, _moduleMap = {}, options = {}) {
     if (new.target === undefined) {
       throw new TypeError(
-        `Class constructor Compartment cannot be invoked without 'new'`,
+        "Class constructor Compartment cannot be invoked without 'new'",
       );
     }
 

--- a/packages/ses/src/intrinsics.js
+++ b/packages/ses/src/intrinsics.js
@@ -117,7 +117,7 @@ export function makeIntrinsicsCollector() {
     isPseudoNative(obj) {
       if (!pseudoNatives) {
         throw new Error(
-          `isPseudoNative can only be called after finalIntrinsics`,
+          'isPseudoNative can only be called after finalIntrinsics',
         );
       }
       return pseudoNatives.has(obj);

--- a/packages/ses/src/module-link.js
+++ b/packages/ses/src/module-link.js
@@ -64,7 +64,7 @@ const validateStaticModuleRecord = (staticModuleRecord, moduleAnalyses) => {
       // This could either be a partially implemented custom static module
       // record or created by `StaticModuleRecord` in another realm.
       throw new TypeError(
-        `importHook must return a StaticModuleRecord constructed within the same Realm, or a custom record with both imports and an execute method`,
+        'importHook must return a StaticModuleRecord constructed within the same Realm, or a custom record with both imports and an execute method',
       );
     } else {
       // In this case, the static module record has no `imports` or `execute`
@@ -73,7 +73,7 @@ const validateStaticModuleRecord = (staticModuleRecord, moduleAnalyses) => {
       // From this we infer the intent was to produce a valid custom static
       // module record and clue accordingly.
       throw new TypeError(
-        `importHook must return a StaticModuleRecord with both imports and an execute method`,
+        'importHook must return a StaticModuleRecord with both imports and an execute method',
       );
     }
   }

--- a/packages/ses/src/module-proxy.js
+++ b/packages/ses/src/module-proxy.js
@@ -76,7 +76,7 @@ export const deferExports = () => {
       ownKeys(_target) {
         if (!active) {
           throw new TypeError(
-            `Cannot enumerate keys, the module has not yet begun to execute`,
+            'Cannot enumerate keys, the module has not yet begun to execute',
           );
         }
         // return Object.keys(proxiedExports);
@@ -95,7 +95,7 @@ export const deferExports = () => {
       preventExtensions(_target) {
         if (!active) {
           throw new TypeError(
-            `Cannot prevent extensions of module exports namespace, the module has not yet begun to execute`,
+            'Cannot prevent extensions of module exports namespace, the module has not yet begun to execute',
           );
         }
         return Reflect.preventExtensions(proxiedExports);
@@ -103,7 +103,7 @@ export const deferExports = () => {
       isExtensible() {
         if (!active) {
           throw new TypeError(
-            `Cannot check extensibility of module exports namespace, the module has not yet begun to execute`,
+            'Cannot check extensibility of module exports namespace, the module has not yet begun to execute',
           );
         }
         return Reflect.isExtensible(proxiedExports);
@@ -112,7 +112,7 @@ export const deferExports = () => {
         return null;
       },
       setPrototypeOf(_target, _proto) {
-        throw new TypeError(`Cannot set prototype of module exports namespace`);
+        throw new TypeError('Cannot set prototype of module exports namespace');
       },
       defineProperty(_target, name, _descriptor) {
         throw new TypeError(
@@ -121,12 +121,12 @@ export const deferExports = () => {
       },
       apply(_target, _thisArg, _args) {
         throw new TypeError(
-          `Cannot call module exports namespace, it is not a function`,
+          'Cannot call module exports namespace, it is not a function',
         );
       },
       construct(_target, _args) {
         throw new TypeError(
-          `Cannot construct module exports namespace, it is not a constructor`,
+          'Cannot construct module exports namespace, it is not a constructor',
         );
       },
     }),

--- a/packages/ses/src/module-shim.js
+++ b/packages/ses/src/module-shim.js
@@ -93,7 +93,7 @@ const assertModuleHooks = compartment => {
   const { importHook, resolveHook } = privateFields.get(compartment);
   if (typeof importHook !== 'function' || typeof resolveHook !== 'function') {
     throw new TypeError(
-      `Compartment must be constructed with an importHook and a resolveHook for it to be able to load modules`,
+      'Compartment must be constructed with an importHook and a resolveHook for it to be able to load modules',
     );
   }
 };
@@ -188,7 +188,7 @@ export const makeModularCompartmentConstructor = (
   ) {
     if (new.target === undefined) {
       throw new TypeError(
-        `Class constructor Compartment cannot be invoked without 'new'`,
+        "Class constructor Compartment cannot be invoked without 'new'",
       );
     }
 

--- a/packages/ses/src/repair-legacy-accessors.js
+++ b/packages/ses/src/repair-legacy-accessors.js
@@ -40,7 +40,7 @@ export default function repairLegacyAccessors() {
 
   function toObject(obj) {
     if (obj === undefined || obj === null) {
-      throw new TypeError(`can't convert undefined or null to object`);
+      throw new TypeError("can't convert undefined or null to object");
     }
     return Object(obj);
   }

--- a/packages/ses/src/tame-locale-methods.js
+++ b/packages/ses/src/tame-locale-methods.js
@@ -12,7 +12,7 @@ const tamedMethods = {
   localeCompare(that) {
     if (this === null || this === undefined) {
       throw new TypeError(
-        `Cannot localeCompare with null or undefined "this" value`,
+        'Cannot localeCompare with null or undefined "this" value',
       );
     }
     const s = `${this}`;

--- a/packages/ses/test/break-function-eval.test.js
+++ b/packages/ses/test/break-function-eval.test.js
@@ -55,13 +55,13 @@ test('function-injection-2', t => {
   }
 
   // test cases from https://code.google.com/archive/p/google-caja/issues/1616
-  check(`}), target(), (function(){`);
-  check(`})); }); target(); (function(){ ((function(){ `);
+  check('}), target(), (function(){');
+  check('})); }); target(); (function(){ ((function(){ ');
 
   // and from https://bugs.chromium.org/p/v8/issues/detail?id=2470
   check('/*', '*/){');
   check('', '});(function(){');
-  check('', `});print('1+1=' + (1+1));(function(){`);
+  check('', "});print('1+1=' + (1+1));(function(){");
 
   // and from https://bugs.webkit.org/show_bug.cgi?id=106160
   check('){});(function(', '');

--- a/packages/ses/test/compartment.test.js
+++ b/packages/ses/test/compartment.test.js
@@ -19,7 +19,7 @@ test('SES compartment also has compartments', t => {
   const c = new Compartment();
   t.is(1, 1);
   t.is(c.evaluate('1+1'), 2);
-  t.is(c.evaluate(`const c2 = new Compartment(); c2.evaluate('1+2')`), 3);
+  t.is(c.evaluate("const c2 = new Compartment(); c2.evaluate('1+2')"), 3);
 });
 
 // test('SESRealm has SES.confine', t => {
@@ -44,10 +44,10 @@ test('SES compartment also has compartments', t => {
 
 test('SES compartment has harden', t => {
   const c = new Compartment({ a: 123 });
-  const obj = c.evaluate(`harden({a})`);
-  t.is(obj.a, 123, `expected object`);
+  const obj = c.evaluate('harden({a})');
+  t.is(obj.a, 123, 'expected object');
   t.throws(() => (obj.a = 'ignored'));
-  t.is(obj.a, 123, `hardened object retains value`);
+  t.is(obj.a, 123, 'hardened object retains value');
 });
 
 // test('SESRealm.SES wraps exceptions', t => {

--- a/packages/ses/test/get-source-url.test.js
+++ b/packages/ses/test/get-source-url.test.js
@@ -6,7 +6,7 @@ test('getSourceURL', t => {
   t.plan(2 + 1 * 2 * 2 * 2 * 3 * 2);
 
   t.is(getSourceURL(''), '<unknown>');
-  t.is(getSourceURL(`//@sourceURL=path/file.js`), 'path/file.js');
+  t.is(getSourceURL('//@sourceURL=path/file.js'), 'path/file.js');
 
   for (const fileName of ['path/to/file.js']) {
     for (const [startComment, endComment] of [

--- a/packages/ses/test/property-override.test.js
+++ b/packages/ses/test/property-override.test.js
@@ -105,7 +105,7 @@ test('packages in-the-wild', t => {
   }
   t.notThrows(
     () => c.evaluate(`(${testContent4})`)(),
-    `underscore function instance bind`,
+    'underscore function instance bind',
   );
 
   function testContent5() {
@@ -114,6 +114,6 @@ test('packages in-the-wild', t => {
   }
   t.notThrows(
     () => c.evaluate(`(${testContent5})`)(),
-    `core-js promise instance constructor`,
+    'core-js promise instance constructor',
   );
 });

--- a/packages/ses/test/reject-direct-eval.test.js
+++ b/packages/ses/test/reject-direct-eval.test.js
@@ -15,21 +15,21 @@ test('reject direct eval expressions in evaluate', t => {
       }`;
   }
 
-  const safe = `const a = 1`;
-  const safe2 = `const a = noteval('evil')`;
-  const safe3 = `const a = evalnot('evil')`;
+  const safe = 'const a = 1';
+  const safe2 = "const a = noteval('evil')";
+  const safe3 = "const a = evalnot('evil')";
 
   // "bogus" is actually direct eval syntax which ideally we could
   // reject. However, it escapes our regexp, which we allow because
   // accepting it is a future compat issue, not a security issue.
-  const bogus = `const a = (eval)('evil')`;
+  const bogus = "const a = (eval)('evil')";
 
-  const obvious = `const a = eval('evil')`;
-  const whitespace = `const a = eval ('evil')`;
-  const comment = `const a = eval/*hah*/('evil')`;
-  const doubleSlashComment = `const a = eval // hah\n('evil')`;
-  const newline = `const a = eval\n('evil')`;
-  const multiline = `\neval('a')\neval('b')`;
+  const obvious = "const a = eval('evil')";
+  const whitespace = "const a = eval ('evil')";
+  const comment = "const a = eval/*hah*/('evil')";
+  const doubleSlashComment = "const a = eval // hah\n('evil')";
+  const newline = "const a = eval\n('evil')";
+  const multiline = "\neval('a')\neval('b')";
 
   t.notThrows(() => c.evaluate(wrap(safe)), 'safe');
   t.notThrows(() => c.evaluate(wrap(safe2)), 'safe2');
@@ -78,21 +78,21 @@ test('reject direct eval expressions in Function', t => {
     return `new Function("${s}; return a;")`;
   }
 
-  const safe = `const a = 1`;
-  const safe2 = `const a = noteval('evil')`;
-  const safe3 = `const a = evalnot('evil')`;
+  const safe = 'const a = 1';
+  const safe2 = "const a = noteval('evil')";
+  const safe3 = "const a = evalnot('evil')";
 
   // "bogus" is actually direct eval syntax which ideally we could
   // reject. However, it escapes our regexp, which we allow because
   // accepting it is a future compat issue, not a security issue.
-  const bogus = `const a = (eval)('evil')`;
+  const bogus = "const a = (eval)('evil')";
 
-  const obvious = `const a = eval('evil')`;
-  const whitespace = `const a = eval ('evil')`;
-  const comment = `const a = eval/*hah*/('evil')`;
-  const doubleSlashComment = `const a = eval // hah\n('evil')`;
-  const newline = `const a = eval\n('evil')`;
-  const multiline = `\neval('a')\neval('b')`;
+  const obvious = "const a = eval('evil')";
+  const whitespace = "const a = eval ('evil')";
+  const comment = "const a = eval/*hah*/('evil')";
+  const doubleSlashComment = "const a = eval // hah\n('evil')";
+  const newline = "const a = eval\n('evil')";
+  const multiline = "\neval('a')\neval('b')";
 
   t.notThrows(() => c.evaluate(wrap(safe)), 'safe');
   t.notThrows(() => c.evaluate(wrap(safe2)), 'safe2');

--- a/packages/ses/test/reject-html-comment.test.js
+++ b/packages/ses/test/reject-html-comment.test.js
@@ -15,12 +15,12 @@ test('reject HTML comment expressions in evaluate', t => {
       }`;
   }
 
-  const htmlOpenComment1 = `const a = foo <!-- hah\n('evil')`;
-  const htmlCloseComment1 = `const a = foo --> hah\n('evil')`;
-  const htmlOpenComment2 = `const a = eval <!-- hah\n('evil')`;
-  const htmlCloseComment2 = `const a = eval --> hah\n('evil')`;
-  const htmlOpenComment3 = `const a = import <!-- hah\n('evil')`;
-  const htmlCloseComment3 = `const a = import --> hah\n('evil')`;
+  const htmlOpenComment1 = "const a = foo <!-- hah\n('evil')";
+  const htmlCloseComment1 = "const a = foo --> hah\n('evil')";
+  const htmlOpenComment2 = "const a = eval <!-- hah\n('evil')";
+  const htmlCloseComment2 = "const a = eval --> hah\n('evil')";
+  const htmlOpenComment3 = "const a = import <!-- hah\n('evil')";
+  const htmlCloseComment3 = "const a = import --> hah\n('evil')";
 
   t.throws(
     () => c.evaluate(wrap(htmlOpenComment1)),
@@ -65,12 +65,12 @@ test('reject HTML comment expressions in Function', t => {
     return `new Function("${s}; return a;")`;
   }
 
-  const htmlOpenComment1 = `const a = foo <!-- hah\n('evil')`;
-  const htmlCloseComment1 = `const a = foo --> hah\n('evil')`;
-  const htmlOpenComment2 = `const a = eval <!-- hah\n('evil')`;
-  const htmlCloseComment2 = `const a = eval --> hah\n('evil')`;
-  const htmlOpenComment3 = `const a = import <!-- hah\n('evil')`;
-  const htmlCloseComment3 = `const a = import --> hah\n('evil')`;
+  const htmlOpenComment1 = "const a = foo <!-- hah\n('evil')";
+  const htmlCloseComment1 = "const a = foo --> hah\n('evil')";
+  const htmlOpenComment2 = "const a = eval <!-- hah\n('evil')";
+  const htmlCloseComment2 = "const a = eval --> hah\n('evil')";
+  const htmlOpenComment3 = "const a = import <!-- hah\n('evil')";
+  const htmlCloseComment3 = "const a = import --> hah\n('evil')";
 
   t.throws(
     () => c.evaluate(wrap(htmlOpenComment1)),

--- a/packages/ses/test/reject-import-expression.test.js
+++ b/packages/ses/test/reject-import-expression.test.js
@@ -15,16 +15,16 @@ test('reject import expressions in evaluate', t => {
       }`;
   }
 
-  const safe = `const a = 1`;
-  const safe2 = `const a = notimport('evil')`;
-  const safe3 = `const a = importnot('evil')`;
+  const safe = 'const a = 1';
+  const safe2 = "const a = notimport('evil')";
+  const safe3 = "const a = importnot('evil')";
 
-  const obvious = `const a = import('evil')`;
-  const whitespace = `const a = import ('evil')`;
-  const comment = `const a = import/*hah*/('evil')`;
-  const doubleSlashComment = `const a = import // hah\n('evil')`;
-  const newline = `const a = import\n('evil')`;
-  const multiline = `\nimport('a')\nimport('b')`;
+  const obvious = "const a = import('evil')";
+  const whitespace = "const a = import ('evil')";
+  const comment = "const a = import/*hah*/('evil')";
+  const doubleSlashComment = "const a = import // hah\n('evil')";
+  const newline = "const a = import\n('evil')";
+  const multiline = "\nimport('a')\nimport('b')";
 
   t.notThrows(() => c.evaluate(wrap(safe)), 'safe');
   t.notThrows(() => c.evaluate(wrap(safe2)), 'safe2');
@@ -70,16 +70,16 @@ test('reject import expressions in Function', t => {
     return `new Function("${s}; return a;")`;
   }
 
-  const safe = `const a = 1`;
-  const safe2 = `const a = notimport('evil')`;
-  const safe3 = `const a = importnot('evil')`;
+  const safe = 'const a = 1';
+  const safe2 = "const a = notimport('evil')";
+  const safe3 = "const a = importnot('evil')";
 
-  const obvious = `const a = import('evil')`;
-  const whitespace = `const a = import ('evil')`;
-  const comment = `const a = import/*hah*/('evil')`;
-  const doubleSlashComment = `const a = import // hah\n('evil')`;
-  const newline = `const a = import\n('evil')`;
-  const multiline = `\nimport('a')\nimport('b')`;
+  const obvious = "const a = import('evil')";
+  const whitespace = "const a = import ('evil')";
+  const comment = "const a = import/*hah*/('evil')";
+  const doubleSlashComment = "const a = import // hah\n('evil')";
+  const newline = "const a = import\n('evil')";
+  const multiline = "\nimport('a')\nimport('b')";
 
   t.notThrows(() => c.evaluate(wrap(safe)), 'safe');
   t.notThrows(() => c.evaluate(wrap(safe2)), 'safe2');

--- a/packages/ses/test/ses.test.js
+++ b/packages/ses/test/ses.test.js
@@ -25,25 +25,25 @@ test('tamed constructors', t => {
 
   const c = new Compartment({ console });
 
-  t.throws(() => c.evaluate(`Error.__proto__.constructor('')`), {
+  t.throws(() => c.evaluate("Error.__proto__.constructor('')"), {
     instanceOf: TypeError,
   });
-  t.throws(() => c.evaluate(`Function.prototype.constructor('')`), {
+  t.throws(() => c.evaluate("Function.prototype.constructor('')"), {
     instanceOf: TypeError,
   });
 
-  t.throws(() => c.evaluate(`function F() {}; F.__proto__.constructor('')`), {
+  t.throws(() => c.evaluate("function F() {}; F.__proto__.constructor('')"), {
     instanceOf: TypeError,
   });
   t.throws(
-    () => c.evaluate(`async function AF() {}; AF.__proto__.constructor('')`),
+    () => c.evaluate("async function AF() {}; AF.__proto__.constructor('')"),
     { instanceOf: TypeError },
   );
-  t.throws(() => c.evaluate(`function* G() {}; G.__proto__.constructor('')`), {
+  t.throws(() => c.evaluate("function* G() {}; G.__proto__.constructor('')"), {
     instanceOf: TypeError,
   });
   t.throws(
-    () => c.evaluate(`async function* AG() {}; AG.__proto__.constructor('')`),
+    () => c.evaluate("async function* AG() {}; AG.__proto__.constructor('')"),
     { instanceOf: TypeError },
   );
 });
@@ -75,7 +75,7 @@ test('SES compartment also has compartments', t => {
   const c = new Compartment();
   t.is(1, 1);
   t.is(c.evaluate('1+1'), 2);
-  t.is(c.evaluate(`const s2 = new Compartment(); s2.evaluate('1+2')`), 3);
+  t.is(c.evaluate("const s2 = new Compartment(); s2.evaluate('1+2')"), 3);
 });
 
 // test('SESRealm has SES.confine', t => {
@@ -100,10 +100,10 @@ test('SES compartment also has compartments', t => {
 
 test('SES compartment has harden', t => {
   const c = new Compartment({ a: 123 });
-  const obj = c.evaluate(`harden({a})`);
-  t.is(obj.a, 123, `expected object`);
+  const obj = c.evaluate('harden({a})');
+  t.is(obj.a, 123, 'expected object');
   t.throws(() => (obj.a = 'ignored'));
-  t.is(obj.a, 123, `hardened object retains value`);
+  t.is(obj.a, 123, 'hardened object retains value');
 });
 
 // test('SESRealm.SES wraps exceptions', t => {

--- a/packages/ses/test/transforms.test.js
+++ b/packages/ses/test/transforms.test.js
@@ -17,16 +17,16 @@ test('no-import-expression regexp', t => {
   // parser to check, and a cheap regexp test will conservatively reject it.
   // So we don't assert that behavior one way or the other
 
-  const safe = `const a = 1`;
-  const safe2 = `const a = notimport('evil')`;
-  const safe3 = `const a = importnot('evil')`;
+  const safe = 'const a = 1';
+  const safe2 = "const a = notimport('evil')";
+  const safe3 = "const a = importnot('evil')";
 
-  const obvious = `const a = import('evil')`;
-  const whitespace = `const a = import ('evil')`;
-  const comment = `const a = import/*hah*/('evil')`;
-  const doubleSlashComment = `const a = import // hah\n('evil')`;
-  const newline = `const a = import\n('evil')`;
-  const multiline = `\nimport('a')\nimport('b')`;
+  const obvious = "const a = import('evil')";
+  const whitespace = "const a = import ('evil')";
+  const comment = "const a = import/*hah*/('evil')";
+  const doubleSlashComment = "const a = import // hah\n('evil')";
+  const newline = "const a = import\n('evil')";
+  const multiline = "\nimport('a')\nimport('b')";
 
   t.is(rejectImportExpressions(safe), safe, 'safe');
   t.is(rejectImportExpressions(safe2), safe2, 'safe2');
@@ -67,12 +67,12 @@ test('no-import-expression regexp', t => {
 test('no-html-comment-expression regexp', t => {
   t.plan(6);
 
-  const htmlOpenComment1 = `const a = foo <!-- hah\n('evil')`;
-  const htmlCloseComment1 = `const a = foo --> hah\n('evil')`;
-  const htmlOpenComment2 = `const a = eval <!-- hah\n('evil')`;
-  const htmlCloseComment2 = `const a = eval --> hah\n('evil')`;
-  const htmlOpenComment3 = `const a = import <!-- hah\n('evil')`;
-  const htmlCloseComment3 = `const a = import --> hah\n('evil')`;
+  const htmlOpenComment1 = "const a = foo <!-- hah\n('evil')";
+  const htmlCloseComment1 = "const a = foo --> hah\n('evil')";
+  const htmlOpenComment2 = "const a = eval <!-- hah\n('evil')";
+  const htmlCloseComment2 = "const a = eval --> hah\n('evil')";
+  const htmlOpenComment3 = "const a = import <!-- hah\n('evil')";
+  const htmlCloseComment3 = "const a = import --> hah\n('evil')";
 
   t.throws(
     () => rejectHtmlComments(htmlOpenComment1),
@@ -114,21 +114,21 @@ test('no-html-comment-expression regexp', t => {
 test('no-eval-expression regexp', t => {
   t.plan(10);
 
-  const safe = `const a = 1`;
-  const safe2 = `const a = noteval('evil')`;
-  const safe3 = `const a = evalnot('evil')`;
+  const safe = 'const a = 1';
+  const safe2 = "const a = noteval('evil')";
+  const safe3 = "const a = evalnot('evil')";
 
   // "bogus" is actually direct eval syntax which ideally we could
   // reject. However, it escapes our regexp, which we allow because
   // accepting it is a future compat issue, not a security issue.
-  const bogus = `const a = (eval)('evil')`;
+  const bogus = "const a = (eval)('evil')";
 
-  const obvious = `const a = eval('evil')`;
-  const whitespace = `const a = eval ('evil')`;
-  const comment = `const a = eval/*hah*/('evil')`;
-  const doubleSlashComment = `const a = eval // hah\n('evil')`;
-  const newline = `const a = eval\n('evil')`;
-  const multiline = `\neval('a')\neval('b')`;
+  const obvious = "const a = eval('evil')";
+  const whitespace = "const a = eval ('evil')";
+  const comment = "const a = eval/*hah*/('evil')";
+  const doubleSlashComment = "const a = eval // hah\n('evil')";
+  const newline = "const a = eval\n('evil')";
+  const multiline = "\neval('a')\neval('b')";
 
   t.is(rejectSomeDirectEvalExpressions(safe), safe, 'safe');
   t.is(rejectSomeDirectEvalExpressions(safe2), safe2, 'safe2');

--- a/packages/ses/test/whitelist.test.js
+++ b/packages/ses/test/whitelist.test.js
@@ -5,7 +5,7 @@ lockdown();
 
 test('indirect eval is possible', t => {
   const c = new Compartment();
-  t.is(c.evaluate(`(1,eval)('123')`), 123, 'indirect eval succeeds');
+  t.is(c.evaluate("(1,eval)('123')"), 123, 'indirect eval succeeds');
 });
 
 test('SharedArrayBuffer should be removed because it is not on the whitelist', t => {
@@ -64,6 +64,6 @@ const x=new X();
 x.slice;
 `),
     c.globalThis.Array.prototype.slice,
-    `prototype __proto__ inheritance works`,
+    'prototype __proto__ inheritance works',
   );
 });

--- a/packages/test262-runner/package.json
+++ b/packages/test262-runner/package.json
@@ -12,19 +12,26 @@
     "lint": "eslint '**/*.js'"
   },
   "dependencies": {
-    "tap": "14.10.5",
+    "tap": "^14.10.5",
     "test262-parser": "^2.2.0"
   },
   "devDependencies": {
     "@agoric/eslint-config": "^0.1.0",
     "sinon": "8.0.4"
   },
-  "dependencies": {
-    "test262-parser": "^2.2.0"
+  "ava": {
+    "files": [
+      "*test*/**/*.test.js"
+    ],
+    "require": []
   },
   "eslintConfig": {
     "extends": [
       "@agoric"
     ]
+  },
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
   }
 }

--- a/packages/transform-module/package.json
+++ b/packages/transform-module/package.json
@@ -4,7 +4,14 @@
   "description": "Transform for evaluating ES modules as Javascript programs",
   "author": "Agoric",
   "license": "Apache-2.0",
-  "homepage": "https://github.com/Agoric/ses-shim/packages/transform-module#readme",
+  "homepage": "https://github.com/Agoric/SES-shim/tree/master/packages/transform-module#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Agoric/SES-shim.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Agoric/SES-shim/issues"
+  },
   "type": "module",
   "main": "./dist/transform-module.cjs",
   "module": "./src/main.js",
@@ -23,14 +30,10 @@
     "build": "rollup --config rollup.config.js",
     "prepublish": "yarn run clean && yarn build",
     "lint": "eslint 'src/**/*.js'",
-    "lint-fix": "eslint --fix '**/*.js'",
+    "lint-fix": "eslint --fix 'src/**/*.js'",
     "OFF-test": "ava"
   },
-  "files": [
-    "src",
-    "dist",
-    "LICENSE*"
-  ],
+  "dependencies": {},
   "devDependencies": {
     "@agoric/make-simple-evaluate": "0.1.0",
     "@ava/babel": "^1.0.1",
@@ -42,9 +45,8 @@
   },
   "ava": {
     "files": [
-      "test/**/*.test.js"
+      "*test*/**/*.test.js"
     ],
-    "babel": true,
     "require": []
   },
   "eslintConfig": {
@@ -52,8 +54,13 @@
       "@agoric"
     ]
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Agoric/ses-shim.git"
-  }
+  "prettier": {
+    "trailingComma": "all",
+    "singleQuote": true
+  },
+  "files": [
+    "LICENSE*",
+    "dist",
+    "src"
+  ]
 }

--- a/packages/transform-module/test/export-default.test.js
+++ b/packages/transform-module/test/export-default.test.js
@@ -48,37 +48,37 @@ test('export default', async t => {
     })) {
       t.deepEqual(
         // eslint-disable-next-line no-await-in-loop
-        await myEval(`import('foo')`, {}),
+        await myEval("import('foo')", {}),
         { default: 'foo' },
         `${name} import expression works`,
       );
     }
     t.deepEqual(
-      await evaluateModule(`export default bb;`, { bb: 'bingbang' }),
+      await evaluateModule('export default bb;', { bb: 'bingbang' }),
       { default: 'bingbang' },
-      `endowed modules`,
+      'endowed modules',
     );
 
     const { default: Cls } = await evaluateModule(`\
 export default class { valueOf() { return 45; } }
 `);
-    t.is(Cls.name, 'default', `default class export is stamped`);
-    t.is(new Cls().valueOf(), 45, `valueOf returns properly`);
+    t.is(Cls.name, 'default', 'default class export is stamped');
+    t.is(new Cls().valueOf(), 45, 'valueOf returns properly');
 
     t.deepEqual(
       await evaluateModule('#! /usr/bin/env node\nexport default 123'),
       { default: 123 },
-      `shebang comment works`,
+      'shebang comment works',
     );
 
-    const ns = await evaluateModule(`\
-export default arguments;`);
+    const ns = await evaluateModule('\
+export default arguments;');
     t.is(typeof ns.default, 'object', 'arguments is an object');
     t.is(ns.default.length, 1, 'arguments has only one entry');
     t.is(typeof ns.default[0], 'string', 'arguments[0] is just string');
 
-    const ns2 = await evaluateModule(`\
-export default this;`);
+    const ns2 = await evaluateModule('\
+export default this;');
     t.is(ns2.default, undefined, 'this is undefined');
   } catch (e) {
     console.log('unexpected exception', e);

--- a/packages/transform-module/test/export-named.test.js
+++ b/packages/transform-module/test/export-named.test.js
@@ -54,10 +54,10 @@ const makeImporter = (liveVars = []) => async (srcSpec, endowments) => {
     return doImport();
   }
 
-  throw Error(`Not expecting import expression`);
+  throw Error('Not expecting import expression');
 };
 
-test(`export named`, async t => {
+test('export named', async t => {
   try {
     const importer = makeImporter(['def']);
     const transforms = [makeModuleTransformer(babel, importer)];
@@ -74,7 +74,7 @@ def ++;
 export const ghi = 789;
 `),
       { abc: 123, def: 457, def2: 456, ghi: 789 },
-      `let exports`,
+      'let exports',
     );
 
     t.deepEqual(
@@ -89,7 +89,7 @@ export const { def, nest: [, ghi, ...nestrest], ...rest } = { def: 456, nest: [ 
         rest: { other: 999, and: 998 },
         nestrest: ['a', 'b'],
       },
-      `const exports`,
+      'const exports',
     );
   } catch (e) {
     console.log('unexpected exception', e);
@@ -97,7 +97,7 @@ export const { def, nest: [, ghi, ...nestrest], ...rest } = { def: 456, nest: [ 
   }
 });
 
-test(`export hoisting`, async t => {
+test('export hoisting', async t => {
   try {
     const importer = makeImporter(['abc', 'fn']);
     const transforms = [makeModuleTransformer(babel, importer)];
@@ -111,7 +111,7 @@ const abc2 = abc;
 export const abc = 123;
 `),
       ReferenceError,
-      `const exports without hoisting`,
+      'const exports without hoisting',
     );
 
     await t.rejects(
@@ -120,7 +120,7 @@ const abc2 = abc;
 export let abc = 123;
 `),
       ReferenceError,
-      `let exports without hoisting`,
+      'let exports without hoisting',
     );
 
     const { abc, abc2, abc3 } = await evaluateModule(`\
@@ -128,9 +128,9 @@ export const abc2 = abc;
 export var abc = 123;
 export const abc3 = abc;
 `);
-    t.is(abc2, undefined, `undefined instead of tdz`);
-    t.is(abc, abc3, `var exports with hoisting`);
-    t.is(abc, 123, `abc evaluates`);
+    t.is(abc2, undefined, 'undefined instead of tdz');
+    t.is(abc, abc3, 'var exports with hoisting');
+    t.is(abc, 123, 'abc evaluates');
 
     const { fn, fn2, fn3 } = await evaluateModule(`\
 export const fn2 = fn;
@@ -139,15 +139,15 @@ export function fn() {
 }
 export const fn3 = fn;
 `);
-    t.is(fn2, fn, `function hoisting`);
-    t.is(fn, fn3, `function exports with hoisting`);
-    t.is(fn(), 'foo', `fn evaluates`);
+    t.is(fn2, fn, 'function hoisting');
+    t.is(fn, fn3, 'function exports with hoisting');
+    t.is(fn(), 'foo', 'fn evaluates');
   } catch (e) {
     t.not(e, e, 'unexpected exception');
   }
 });
 
-test(`export class`, async t => {
+test('export class', async t => {
   try {
     const importer = makeImporter(['C', 'F', 'count']);
     const transforms = [makeModuleTransformer(babel, importer)];
@@ -159,45 +159,45 @@ test(`export class`, async t => {
 export let count = 0;
 export class C {} if (C) { count += 1; }
 `);
-    t.truthy(new C(), `class exports`);
-    t.is(C.name, 'C', `class is named C`);
-    t.is(count, 1, `class C is global`);
+    t.truthy(new C(), 'class exports');
+    t.is(C.name, 'C', 'class is named C');
+    t.is(count, 1, 'class C is global');
 
     const { default: C2 } = await evaluateModule(`\
 export default class C {}
 `);
-    t.truthy(new C2(), `default class constructs`);
-    t.is(C2.name, 'C', `C class name`);
+    t.truthy(new C2(), 'default class constructs');
+    t.is(C2.name, 'C', 'C class name');
 
     const { default: C3 } = await evaluateModule(`\
 export default class {}
 `);
-    t.truthy(new C3(), `default class constructs`);
-    t.is(C3.name, 'default', `default class name`);
+    t.truthy(new C3(), 'default class constructs');
+    t.is(C3.name, 'default', 'default class name');
     const { default: C4 } = await evaluateModule(`\
 export default (class {});
 `);
-    t.truthy(new C4(), `default class expression constructs`);
-    t.is(C4.name, 'default', `default class expression name`);
+    t.truthy(new C4(), 'default class expression constructs');
+    t.is(C4.name, 'default', 'default class expression name');
 
     const { F: F0 } = await evaluateModule(`\
 F(123);
 export function F(arg) { return arg; }
 `);
-    t.is(F0.name, 'F', `F function name`);
+    t.is(F0.name, 'F', 'F function name');
 
     const { default: F } = await evaluateModule(`\
 export default async function F(arg) { return arg; }
 `);
-    t.is(F.name, 'F', `F function name`);
+    t.is(F.name, 'F', 'F function name');
     const ret = F('foo');
-    t.truthy(ret instanceof Promise, `F is async`);
-    t.is(await ret, 'foo', `F returns correctly`);
+    t.truthy(ret instanceof Promise, 'F is async');
+    t.is(await ret, 'foo', 'F returns correctly');
 
     const { default: F2 } = await evaluateModule(`\
 export default async function(arg) { return arg; };
 `);
-    t.is(F2.name, 'default', `F2 function default name`);
+    t.is(F2.name, 'default', 'F2 function default name');
   } catch (e) {
     console.log('unexpected exception', e);
     t.truthy(false, e);

--- a/packages/transform-module/test/import.test.js
+++ b/packages/transform-module/test/import.test.js
@@ -29,7 +29,7 @@ const makeImporter = () => async (srcSpec, endowments) => {
     return doImport();
   }
 
-  throw Error(`Not expecting import expression`);
+  throw Error('Not expecting import expression');
 };
 
 test('import', async t => {
@@ -40,14 +40,14 @@ test('import', async t => {
       transforms,
     });
 
-    const exportNested = `{ void 0; export default null; }`;
+    const exportNested = '{ void 0; export default null; }';
     t.throws(
       () => evaluateModule(exportNested),
       SyntaxError,
-      `non-toplevel export fails`,
+      'non-toplevel export fails',
     );
 
-    const srcNS = `import * as ns from 'module';`;
+    const srcNS = "import * as ns from 'module';";
     const importNS = await evaluateModule(srcNS);
     const fsrcNS = importNS.staticRecord.functorSource;
     t.is(typeof fsrcNS, 'string', 'namespace functor source is string');
@@ -69,7 +69,7 @@ test('import', async t => {
       'namespace static record',
     );
 
-    const srcNames = `import { foo, bar } from 'module';`;
+    const srcNames = "import { foo, bar } from 'module';";
     const importNames = await evaluateModule(srcNames);
     const fsrcNames = importNames.staticRecord.functorSource;
     t.is(typeof fsrcNames, 'string', 'names functor source is string');
@@ -97,7 +97,7 @@ test('import', async t => {
       'names static record',
     );
 
-    const srcDefault = `import myName from 'module';`;
+    const srcDefault = "import myName from 'module';";
     const importDefault = await evaluateModule(srcDefault);
     const fsrcDefault = importDefault.staticRecord.functorSource;
     t.is(typeof fsrcDefault, 'string', 'default functor source is string');

--- a/yarn.lock
+++ b/yarn.lock
@@ -73,14 +73,10 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/compat-data@^7.10.4", "@babel/compat-data@^7.11.0":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.11.0.tgz#e9f73efe09af1355b723a7f39b11bad637d7c99c"
-  integrity sha512-TPSvJfv73ng0pfnEOh17bYMPQbI95+nGWc71Ss4vZdRBHTDqmM9Z8ZV4rYz8Ks7sfzc95n30k6ODIq5UGnXcYQ==
-  dependencies:
-    browserslist "^4.12.0"
-    invariant "^2.2.4"
-    semver "^5.5.0"
+"@babel/compat-data@^7.12.5", "@babel/compat-data@^7.12.7":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.7.tgz#9329b4782a7d6bbd7eef57e11addf91ee3ef1e41"
+  integrity sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw==
 
 "@babel/core@7.7.5":
   version "7.7.5"
@@ -102,32 +98,10 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.4.4", "@babel/core@^7.5.5":
-  version "7.11.5"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.5.tgz#6ad96e2f71899ea3f9b651f0a911e85205d1ff6d"
-  integrity sha512-fsEANVOcZHzrsV6dMVWqpSeXClq3lNbYrfFGme6DE25FQWe7pyeYpXyx9guqUnpy466JLzZ8z4uwSr2iv60V5Q==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/generator" "^7.11.5"
-    "@babel/helper-module-transforms" "^7.11.0"
-    "@babel/helpers" "^7.10.4"
-    "@babel/parser" "^7.11.5"
-    "@babel/template" "^7.10.4"
-    "@babel/traverse" "^7.11.5"
-    "@babel/types" "^7.11.5"
-    convert-source-map "^1.7.0"
-    debug "^4.1.0"
-    gensync "^1.0.0-beta.1"
-    json5 "^2.1.2"
-    lodash "^4.17.19"
-    resolve "^1.3.2"
-    semver "^5.4.1"
-    source-map "^0.6.1"
-
-"@babel/core@^7.8.4":
-  version "7.12.8"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.8.tgz#8ad76c1a7d2a6a3beecc4395fa4f7b4cb88390e6"
-  integrity sha512-ra28JXL+5z73r1IC/t+FT1ApXU5LsulFDnTDntNfLQaScJUJmcHL5Qxm/IWanCToQk3bPWQo5bflbplU5r15pg==
+"@babel/core@^7.4.4", "@babel/core@^7.5.5", "@babel/core@^7.8.4":
+  version "7.12.9"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.9.tgz#fd450c4ec10cdbb980e2928b7aa7a28484593fc8"
+  integrity sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/generator" "^7.12.5"
@@ -135,7 +109,7 @@
     "@babel/helpers" "^7.12.5"
     "@babel/parser" "^7.12.7"
     "@babel/template" "^7.12.7"
-    "@babel/traverse" "^7.12.8"
+    "@babel/traverse" "^7.12.9"
     "@babel/types" "^7.12.7"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
@@ -146,7 +120,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.0.0", "@babel/generator@^7.12.5", "@babel/generator@^7.6.4", "@babel/generator@^7.7.4", "@babel/generator@^7.8.4":
+"@babel/generator@^7.0.0", "@babel/generator@^7.12.5", "@babel/generator@^7.4.0", "@babel/generator@^7.4.4", "@babel/generator@^7.6.4", "@babel/generator@^7.7.4", "@babel/generator@^7.8.4":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.5.tgz#a2c50de5c8b6d708ab95be5e6053936c1884a4de"
   integrity sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==
@@ -154,15 +128,6 @@
     "@babel/types" "^7.12.5"
     jsesc "^2.5.1"
     source-map "^0.5.0"
-
-"@babel/generator@^7.11.5", "@babel/generator@^7.4.0", "@babel/generator@^7.4.4":
-  version "7.11.5"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.11.5.tgz#a5582773425a468e4ba269d9a1f701fbca6a7a82"
-  integrity sha512-9UqHWJ4IwRTy4l0o8gq2ef8ws8UPzvtMkVKjTLAiRmza9p9V6Z+OfuNd9fB1j5Q67F+dVJtPC2sZXI8NM9br4g==
-  dependencies:
-    "@babel/types" "^7.11.5"
-    jsesc "^2.5.1"
-    source-map "^0.6.1"
 
 "@babel/helper-annotate-as-pure@^7.10.4":
   version "7.10.4"
@@ -179,14 +144,14 @@
     "@babel/helper-explode-assignable-expression" "^7.10.4"
     "@babel/types" "^7.10.4"
 
-"@babel/helper-builder-react-jsx-experimental@^7.10.4":
-  version "7.11.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.11.5.tgz#4ea43dd63857b0a35cd1f1b161dc29b43414e79f"
-  integrity sha512-Vc4aPJnRZKWfzeCBsqTBnzulVNjABVdahSPhtdMD3Vs80ykx4a87jTHtF/VR+alSrDmNvat7l13yrRHauGcHVw==
+"@babel/helper-builder-react-jsx-experimental@^7.12.4":
+  version "7.12.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.12.4.tgz#55fc1ead5242caa0ca2875dcb8eed6d311e50f48"
+  integrity sha512-AjEa0jrQqNk7eDQOo0pTfUOwQBMF+xVqrausQwT9/rTKy0g04ggFNaJpaE09IQMn9yExluigWMJcj0WC7bq+Og==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.10.4"
-    "@babel/helper-module-imports" "^7.10.4"
-    "@babel/types" "^7.11.5"
+    "@babel/helper-module-imports" "^7.12.1"
+    "@babel/types" "^7.12.1"
 
 "@babel/helper-builder-react-jsx@^7.10.4":
   version "7.10.4"
@@ -196,37 +161,34 @@
     "@babel/helper-annotate-as-pure" "^7.10.4"
     "@babel/types" "^7.10.4"
 
-"@babel/helper-compilation-targets@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.4.tgz#804ae8e3f04376607cc791b9d47d540276332bd2"
-  integrity sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==
+"@babel/helper-compilation-targets@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.5.tgz#cb470c76198db6a24e9dbc8987275631e5d29831"
+  integrity sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==
   dependencies:
-    "@babel/compat-data" "^7.10.4"
-    browserslist "^4.12.0"
-    invariant "^2.2.4"
-    levenary "^1.1.1"
+    "@babel/compat-data" "^7.12.5"
+    "@babel/helper-validator-option" "^7.12.1"
+    browserslist "^4.14.5"
     semver "^5.5.0"
 
-"@babel/helper-create-class-features-plugin@^7.10.4":
-  version "7.10.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz#9f61446ba80e8240b0a5c85c6fdac8459d6f259d"
-  integrity sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==
+"@babel/helper-create-class-features-plugin@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz#3c45998f431edd4a9214c5f1d3ad1448a6137f6e"
+  integrity sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==
   dependencies:
     "@babel/helper-function-name" "^7.10.4"
-    "@babel/helper-member-expression-to-functions" "^7.10.5"
+    "@babel/helper-member-expression-to-functions" "^7.12.1"
     "@babel/helper-optimise-call-expression" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-replace-supers" "^7.10.4"
+    "@babel/helper-replace-supers" "^7.12.1"
     "@babel/helper-split-export-declaration" "^7.10.4"
 
-"@babel/helper-create-regexp-features-plugin@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.4.tgz#fdd60d88524659a0b6959c0579925e425714f3b8"
-  integrity sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==
+"@babel/helper-create-regexp-features-plugin@^7.12.1":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.7.tgz#2084172e95443fa0a09214ba1bb328f9aea1278f"
+  integrity sha512-idnutvQPdpbduutvi3JVfEgcVIHooQnhvhx0Nk9isOINOIGYkZea1Pk2JlJRiUnMefrlvr0vkByATBY/mB4vjQ==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.10.4"
-    "@babel/helper-regex" "^7.10.4"
-    regexpu-core "^4.7.0"
+    regexpu-core "^4.7.1"
 
 "@babel/helper-define-map@^7.10.4":
   version "7.10.5"
@@ -238,11 +200,11 @@
     lodash "^4.17.19"
 
 "@babel/helper-explode-assignable-expression@^7.10.4":
-  version "7.11.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.11.4.tgz#2d8e3470252cc17aba917ede7803d4a7a276a41b"
-  integrity sha512-ux9hm3zR4WV1Y3xXxXkdG/0gxF9nvI0YVmKVhvK9AfMoaQkemL3sJpXw+Xbz65azo8qJiEz2XVDUpK3KYhH3ZQ==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.12.1.tgz#8006a466695c4ad86a2a5f2fb15b5f2c31ad5633"
+  integrity sha512-dmUwH8XmlrUpVqgtZ737tK88v07l840z9j3OEhCLwKTkjlvKpfqXVIZ0wpK3aeOxspwGrf/5AP5qLx4rO3w5rA==
   dependencies:
-    "@babel/types" "^7.10.4"
+    "@babel/types" "^7.12.1"
 
 "@babel/helper-function-name@^7.10.4":
   version "7.10.4"
@@ -267,13 +229,6 @@
   dependencies:
     "@babel/types" "^7.10.4"
 
-"@babel/helper-member-expression-to-functions@^7.10.4", "@babel/helper-member-expression-to-functions@^7.10.5":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz#ae69c83d84ee82f4b42f96e2a09410935a8f26df"
-  integrity sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==
-  dependencies:
-    "@babel/types" "^7.11.0"
-
 "@babel/helper-member-expression-to-functions@^7.12.1":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz#aa77bd0396ec8114e5e30787efa78599d874a855"
@@ -281,32 +236,12 @@
   dependencies:
     "@babel/types" "^7.12.7"
 
-"@babel/helper-module-imports@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz#4c5c54be04bd31670a7382797d75b9fa2e5b5620"
-  integrity sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==
-  dependencies:
-    "@babel/types" "^7.10.4"
-
-"@babel/helper-module-imports@^7.12.1":
+"@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz#1bfc0229f794988f76ed0a4d4e90860850b54dfb"
   integrity sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
   dependencies:
     "@babel/types" "^7.12.5"
-
-"@babel/helper-module-transforms@^7.10.4", "@babel/helper-module-transforms@^7.10.5", "@babel/helper-module-transforms@^7.11.0":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz#b16f250229e47211abdd84b34b64737c2ab2d359"
-  integrity sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==
-  dependencies:
-    "@babel/helper-module-imports" "^7.10.4"
-    "@babel/helper-replace-supers" "^7.10.4"
-    "@babel/helper-simple-access" "^7.10.4"
-    "@babel/helper-split-export-declaration" "^7.11.0"
-    "@babel/template" "^7.10.4"
-    "@babel/types" "^7.11.0"
-    lodash "^4.17.19"
 
 "@babel/helper-module-transforms@^7.12.1":
   version "7.12.1"
@@ -324,43 +259,25 @@
     lodash "^4.17.19"
 
 "@babel/helper-optimise-call-expression@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz#50dc96413d594f995a77905905b05893cd779673"
-  integrity sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.7.tgz#7f94ae5e08721a49467346aa04fd22f750033b9c"
+  integrity sha512-I5xc9oSJ2h59OwyUqjv95HRyzxj53DAubUERgQMrpcCEYQyToeHA+NEcUEsVWB4j53RDeskeBJ0SgRAYHDBckw==
   dependencies:
-    "@babel/types" "^7.10.4"
+    "@babel/types" "^7.12.7"
 
 "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz#2f75a831269d4f677de49986dff59927533cf375"
   integrity sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
 
-"@babel/helper-regex@^7.10.4":
-  version "7.10.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.10.5.tgz#32dfbb79899073c415557053a19bd055aae50ae0"
-  integrity sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==
-  dependencies:
-    lodash "^4.17.19"
-
-"@babel/helper-remap-async-to-generator@^7.10.4":
-  version "7.11.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.11.4.tgz#4474ea9f7438f18575e30b0cac784045b402a12d"
-  integrity sha512-tR5vJ/vBa9wFy3m5LLv2faapJLnDFxNWff2SAYkSE4rLUdbp7CdObYFgI7wK4T/Mj4UzpjPwzR8Pzmr5m7MHGA==
+"@babel/helper-remap-async-to-generator@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.12.1.tgz#8c4dbbf916314f6047dc05e6a2217074238347fd"
+  integrity sha512-9d0KQCRM8clMPcDwo8SevNs+/9a8yWVVmaE80FGJcEP8N1qToREmWEGnBn8BUlJhYRFz6fqxeRL1sl5Ogsed7A==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.10.4"
     "@babel/helper-wrap-function" "^7.10.4"
-    "@babel/template" "^7.10.4"
-    "@babel/types" "^7.10.4"
-
-"@babel/helper-replace-supers@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz#d585cd9388ea06e6031e4cd44b6713cbead9e6cf"
-  integrity sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==
-  dependencies:
-    "@babel/helper-member-expression-to-functions" "^7.10.4"
-    "@babel/helper-optimise-call-expression" "^7.10.4"
-    "@babel/traverse" "^7.10.4"
-    "@babel/types" "^7.10.4"
+    "@babel/types" "^7.12.1"
 
 "@babel/helper-replace-supers@^7.12.1":
   version "7.12.5"
@@ -372,27 +289,12 @@
     "@babel/traverse" "^7.12.5"
     "@babel/types" "^7.12.5"
 
-"@babel/helper-simple-access@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz#0f5ccda2945277a2a7a2d3a821e15395edcf3461"
-  integrity sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==
-  dependencies:
-    "@babel/template" "^7.10.4"
-    "@babel/types" "^7.10.4"
-
 "@babel/helper-simple-access@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz#32427e5aa61547d38eb1e6eaf5fd1426fdad9136"
   integrity sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==
   dependencies:
     "@babel/types" "^7.12.1"
-
-"@babel/helper-skip-transparent-expression-wrappers@^7.11.0":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.11.0.tgz#eec162f112c2f58d3af0af125e3bb57665146729"
-  integrity sha512-0XIdiQln4Elglgjbwo9wuJpL/K7AGCY26kmEt0+pRP0TAj4jjyNq1MjoRvikrTVqKcx4Gysxt4cXvVFXP/JO2Q==
-  dependencies:
-    "@babel/types" "^7.11.0"
 
 "@babel/helper-skip-transparent-expression-wrappers@^7.12.1":
   version "7.12.1"
@@ -413,21 +315,17 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
   integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
 
+"@babel/helper-validator-option@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.12.1.tgz#175567380c3e77d60ff98a54bb015fe78f2178d9"
+  integrity sha512-YpJabsXlJVWP0USHjnC/AQDTLlZERbON577YUVO/wLpqyj6HAtVYnWaQaN0iUN+1/tWn3c+uKKXjRut5115Y2A==
+
 "@babel/helper-wrap-function@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz#8a6f701eab0ff39f765b5a1cfef409990e624b87"
-  integrity sha512-6py45WvEF0MhiLrdxtRjKjufwLL1/ob2qDJgg5JgNdojBAZSAKnAjkyOCNug6n+OBl4VW76XjvgSFTdaMcW0Ug==
+  version "7.12.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.12.3.tgz#3332339fc4d1fbbf1c27d7958c27d34708e990d9"
+  integrity sha512-Cvb8IuJDln3rs6tzjW3Y8UeelAOdnpB8xtQ4sme2MSZ9wOxrbThporC0y/EtE16VAtoyEfLM404Xr1e0OOp+ow==
   dependencies:
     "@babel/helper-function-name" "^7.10.4"
-    "@babel/template" "^7.10.4"
-    "@babel/traverse" "^7.10.4"
-    "@babel/types" "^7.10.4"
-
-"@babel/helpers@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.10.4.tgz#2abeb0d721aff7c0a97376b9e1f6f65d7a475044"
-  integrity sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==
-  dependencies:
     "@babel/template" "^7.10.4"
     "@babel/traverse" "^7.10.4"
     "@babel/types" "^7.10.4"
@@ -450,42 +348,29 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.12.7", "@babel/parser@^7.7.5":
+"@babel/parser@^7.0.0", "@babel/parser@^7.12.7", "@babel/parser@^7.4.3", "@babel/parser@^7.4.4", "@babel/parser@^7.7.0", "@babel/parser@^7.7.5":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.7.tgz#fee7b39fe809d0e73e5b25eecaf5780ef3d73056"
   integrity sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg==
 
-"@babel/parser@^7.10.4", "@babel/parser@^7.11.5", "@babel/parser@^7.4.3", "@babel/parser@^7.4.4", "@babel/parser@^7.7.0":
-  version "7.11.5"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
-  integrity sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
-
-"@babel/plugin-proposal-async-generator-functions@^7.10.4":
-  version "7.10.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.5.tgz#3491cabf2f7c179ab820606cec27fed15e0e8558"
-  integrity sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==
+"@babel/plugin-proposal-async-generator-functions@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.1.tgz#dc6c1170e27d8aca99ff65f4925bd06b1c90550e"
+  integrity sha512-d+/o30tJxFxrA1lhzJqiUcEJdI6jKlNregCv5bASeGf2Q4MXmnwH7viDo7nhx1/ohf09oaH8j1GVYG/e3Yqk6A==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-remap-async-to-generator" "^7.10.4"
+    "@babel/helper-remap-async-to-generator" "^7.12.1"
     "@babel/plugin-syntax-async-generators" "^7.8.0"
 
-"@babel/plugin-proposal-class-properties@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz#a33bf632da390a59c7a8c570045d1115cd778807"
-  integrity sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==
+"@babel/plugin-proposal-class-properties@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz#a082ff541f2a29a4821065b8add9346c0c16e5de"
+  integrity sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.10.4"
+    "@babel/helper-create-class-features-plugin" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-proposal-dynamic-import@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.4.tgz#ba57a26cb98b37741e9d5bca1b8b0ddf8291f17e"
-  integrity sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-syntax-dynamic-import" "^7.8.0"
-
-"@babel/plugin-proposal-dynamic-import@^7.8.3":
+"@babel/plugin-proposal-dynamic-import@^7.12.1", "@babel/plugin-proposal-dynamic-import@^7.8.3":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.1.tgz#43eb5c2a3487ecd98c5c8ea8b5fdb69a2749b2dc"
   integrity sha512-a4rhUSZFuq5W8/OO8H7BL5zspjnc1FLd9hlOxIK/f7qG4a0qsqk8uvF/ywgBA8/OmjsapjpvaEOYItfGG1qIvQ==
@@ -493,39 +378,31 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-dynamic-import" "^7.8.0"
 
-"@babel/plugin-proposal-export-namespace-from@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.10.4.tgz#570d883b91031637b3e2958eea3c438e62c05f54"
-  integrity sha512-aNdf0LY6/3WXkhh0Fdb6Zk9j1NMD8ovj3F6r0+3j837Pn1S1PdNtcwJ5EG9WkVPNHPxyJDaxMaAOVq4eki0qbg==
+"@babel/plugin-proposal-export-namespace-from@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.12.1.tgz#8b9b8f376b2d88f5dd774e4d24a5cc2e3679b6d4"
+  integrity sha512-6CThGf0irEkzujYS5LQcjBx8j/4aQGiVv7J9+2f7pGfxqyKh3WnmVJYW3hdrQjyksErMGBPQrCnHfOtna+WLbw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
 
-"@babel/plugin-proposal-json-strings@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.4.tgz#593e59c63528160233bd321b1aebe0820c2341db"
-  integrity sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==
+"@babel/plugin-proposal-json-strings@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.1.tgz#d45423b517714eedd5621a9dfdc03fa9f4eb241c"
+  integrity sha512-GoLDUi6U9ZLzlSda2Df++VSqDJg3CG+dR0+iWsv6XRw1rEq+zwt4DirM9yrxW6XWaTpmai1cWJLMfM8qQJf+yw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-json-strings" "^7.8.0"
 
-"@babel/plugin-proposal-logical-assignment-operators@^7.11.0":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.11.0.tgz#9f80e482c03083c87125dee10026b58527ea20c8"
-  integrity sha512-/f8p4z+Auz0Uaf+i8Ekf1iM7wUNLcViFUGiPxKeXvxTSl63B875YPiVdUDdem7hREcI0E0kSpEhS8tF5RphK7Q==
+"@babel/plugin-proposal-logical-assignment-operators@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.12.1.tgz#f2c490d36e1b3c9659241034a5d2cd50263a2751"
+  integrity sha512-k8ZmVv0JU+4gcUGeCDZOGd0lCIamU/sMtIiX3UWnUc5yzgq6YUGyEolNYD+MLYKfSzgECPcqetVcJP9Afe/aCA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
 
-"@babel/plugin-proposal-nullish-coalescing-operator@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz#02a7e961fc32e6d5b2db0649e01bf80ddee7e04a"
-  integrity sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
-
-"@babel/plugin-proposal-nullish-coalescing-operator@^7.8.3":
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.12.1", "@babel/plugin-proposal-nullish-coalescing-operator@^7.8.3":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.1.tgz#3ed4fff31c015e7f3f1467f190dbe545cd7b046c"
   integrity sha512-nZY0ESiaQDI1y96+jk6VxMOaL4LPo/QDHBqL+SF3/vl6dHkTwHlOI8L4ZwuRBHgakRBw5zsVylel7QPbbGuYgg==
@@ -533,41 +410,32 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
 
-"@babel/plugin-proposal-numeric-separator@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.4.tgz#ce1590ff0a65ad12970a609d78855e9a4c1aef06"
-  integrity sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==
+"@babel/plugin-proposal-numeric-separator@^7.12.7":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.7.tgz#8bf253de8139099fea193b297d23a9d406ef056b"
+  integrity sha512-8c+uy0qmnRTeukiGsjLGy6uVs/TFjJchGXUeBqlG4VWYOdJWkhhVPdQ3uHwbmalfJwv2JsV0qffXP4asRfL2SQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
 
-"@babel/plugin-proposal-object-rest-spread@^7.11.0", "@babel/plugin-proposal-object-rest-spread@^7.5.5":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.11.0.tgz#bd81f95a1f746760ea43b6c2d3d62b11790ad0af"
-  integrity sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==
+"@babel/plugin-proposal-object-rest-spread@^7.12.1", "@babel/plugin-proposal-object-rest-spread@^7.5.5":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.1.tgz#def9bd03cea0f9b72283dac0ec22d289c7691069"
+  integrity sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
-    "@babel/plugin-transform-parameters" "^7.10.4"
+    "@babel/plugin-transform-parameters" "^7.12.1"
 
-"@babel/plugin-proposal-optional-catch-binding@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.4.tgz#31c938309d24a78a49d68fdabffaa863758554dd"
-  integrity sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==
+"@babel/plugin-proposal-optional-catch-binding@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.12.1.tgz#ccc2421af64d3aae50b558a71cede929a5ab2942"
+  integrity sha512-hFvIjgprh9mMw5v42sJWLI1lzU5L2sznP805zeT6rySVRA0Y18StRhDqhSxlap0oVgItRsB6WSROp4YnJTJz0g==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
 
-"@babel/plugin-proposal-optional-chaining@^7.11.0":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz#de5866d0646f6afdaab8a566382fe3a221755076"
-  integrity sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.11.0"
-    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
-
-"@babel/plugin-proposal-optional-chaining@^7.8.3":
+"@babel/plugin-proposal-optional-chaining@^7.12.7", "@babel/plugin-proposal-optional-chaining@^7.8.3":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.7.tgz#e02f0ea1b5dc59d401ec16fb824679f683d3303c"
   integrity sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==
@@ -576,20 +444,20 @@
     "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
     "@babel/plugin-syntax-optional-chaining" "^7.8.0"
 
-"@babel/plugin-proposal-private-methods@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.10.4.tgz#b160d972b8fdba5c7d111a145fc8c421fc2a6909"
-  integrity sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==
+"@babel/plugin-proposal-private-methods@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.12.1.tgz#86814f6e7a21374c980c10d38b4493e703f4a389"
+  integrity sha512-mwZ1phvH7/NHK6Kf8LP7MYDogGV+DKB1mryFOEwx5EBNQrosvIczzZFTUmWaeujd5xT6G1ELYWUz3CutMhjE1w==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.10.4"
+    "@babel/helper-create-class-features-plugin" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-proposal-unicode-property-regex@^7.10.4", "@babel/plugin-proposal-unicode-property-regex@^7.4.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.4.tgz#4483cda53041ce3413b7fe2f00022665ddfaa75d"
-  integrity sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==
+"@babel/plugin-proposal-unicode-property-regex@^7.12.1", "@babel/plugin-proposal-unicode-property-regex@^7.4.4":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.1.tgz#2a183958d417765b9eae334f47758e5d6a82e072"
+  integrity sha512-MYq+l+PvHuw/rKUz1at/vb6nCnQ2gmJBNaM62z0OgH7B2W1D9pvkpYtlti9bGtizNIU1K3zm4bZF9F91efVY0w==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.10.4"
+    "@babel/helper-create-regexp-features-plugin" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-syntax-async-generators@^7.8.0":
@@ -599,10 +467,10 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-class-properties@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz#6644e6a0baa55a61f9e3231f6c9eeb6ee46c124c"
-  integrity sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==
+"@babel/plugin-syntax-class-properties@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.1.tgz#bcb297c5366e79bebadef509549cd93b04f19978"
+  integrity sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
@@ -620,10 +488,10 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-flow@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.10.4.tgz#53351dd7ae01995e567d04ce42af1a6e0ba846a6"
-  integrity sha512-yxQsX1dJixF4qEEdzVbst3SZQ58Nrooz8NV9Z9GL4byTE25BvJgl5lf0RECUf0fh28rZBb/RYTWn/eeKwCMrZQ==
+"@babel/plugin-syntax-flow@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.12.1.tgz#a77670d9abe6d63e8acadf4c31bb1eb5a506bbdd"
+  integrity sha512-1lBLLmtxrwpm4VKmtVFselI/P3pX+G63fAtUUt6b2Nzgao77KNDwyuRt90Mj2/9pKobtt68FdvjfqohZjg/FCA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
@@ -634,10 +502,10 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.4.tgz#39abaae3cbf710c4373d8429484e6ba21340166c"
-  integrity sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==
+"@babel/plugin-syntax-jsx@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.1.tgz#9d9d357cc818aa7ae7935917c1257f67677a0926"
+  integrity sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
@@ -683,151 +551,141 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-top-level-await@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.4.tgz#4bbeb8917b54fcf768364e0a81f560e33a3ef57d"
-  integrity sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==
+"@babel/plugin-syntax-top-level-await@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz#dd6c0b357ac1bb142d98537450a319625d13d2a0"
+  integrity sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-arrow-functions@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz#e22960d77e697c74f41c501d44d73dbf8a6a64cd"
-  integrity sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==
+"@babel/plugin-transform-arrow-functions@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.12.1.tgz#8083ffc86ac8e777fbe24b5967c4b2521f3cb2b3"
+  integrity sha512-5QB50qyN44fzzz4/qxDPQMBCTHgxg3n0xRBLJUmBlLoU/sFvxVWGZF/ZUfMVDQuJUKXaBhbupxIzIfZ6Fwk/0A==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-async-to-generator@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.4.tgz#41a5017e49eb6f3cda9392a51eef29405b245a37"
-  integrity sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==
+"@babel/plugin-transform-async-to-generator@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.12.1.tgz#3849a49cc2a22e9743cbd6b52926d30337229af1"
+  integrity sha512-SDtqoEcarK1DFlRJ1hHRY5HvJUj5kX4qmtpMAm2QnhOlyuMC4TMdCRgW6WXpv93rZeYNeLP22y8Aq2dbcDRM1A==
   dependencies:
-    "@babel/helper-module-imports" "^7.10.4"
+    "@babel/helper-module-imports" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-remap-async-to-generator" "^7.10.4"
+    "@babel/helper-remap-async-to-generator" "^7.12.1"
 
-"@babel/plugin-transform-block-scoped-functions@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz#1afa595744f75e43a91af73b0d998ecfe4ebc2e8"
-  integrity sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-
-"@babel/plugin-transform-block-scoping@^7.10.4":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.11.1.tgz#5b7efe98852bef8d652c0b28144cd93a9e4b5215"
-  integrity sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==
+"@babel/plugin-transform-block-scoped-functions@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.1.tgz#f2a1a365bde2b7112e0a6ded9067fdd7c07905d9"
+  integrity sha512-5OpxfuYnSgPalRpo8EWGPzIYf0lHBWORCkj5M0oLBwHdlux9Ri36QqGW3/LR13RSVOAoUUMzoPI/jpE4ABcHoA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-classes@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.4.tgz#405136af2b3e218bc4a1926228bc917ab1a0adc7"
-  integrity sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==
+"@babel/plugin-transform-block-scoping@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.1.tgz#f0ee727874b42a208a48a586b84c3d222c2bbef1"
+  integrity sha512-zJyAC9sZdE60r1nVQHblcfCj29Dh2Y0DOvlMkcqSo0ckqjiCwNiUezUKw+RjOCwGfpLRwnAeQ2XlLpsnGkvv9w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-transform-classes@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.12.1.tgz#65e650fcaddd3d88ddce67c0f834a3d436a32db6"
+  integrity sha512-/74xkA7bVdzQTBeSUhLLJgYIcxw/dpEpCdRDiHgPJ3Mv6uC11UhjpOhl72CgqbBCmt1qtssCyB2xnJm1+PFjog==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.10.4"
     "@babel/helper-define-map" "^7.10.4"
     "@babel/helper-function-name" "^7.10.4"
     "@babel/helper-optimise-call-expression" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-replace-supers" "^7.10.4"
+    "@babel/helper-replace-supers" "^7.12.1"
     "@babel/helper-split-export-declaration" "^7.10.4"
     globals "^11.1.0"
 
-"@babel/plugin-transform-computed-properties@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz#9ded83a816e82ded28d52d4b4ecbdd810cdfc0eb"
-  integrity sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==
+"@babel/plugin-transform-computed-properties@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.12.1.tgz#d68cf6c9b7f838a8a4144badbe97541ea0904852"
+  integrity sha512-vVUOYpPWB7BkgUWPo4C44mUQHpTZXakEqFjbv8rQMg7TC6S6ZhGZ3otQcRH6u7+adSlE5i0sp63eMC/XGffrzg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-destructuring@^7.10.4", "@babel/plugin-transform-destructuring@^7.5.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz#70ddd2b3d1bea83d01509e9bb25ddb3a74fc85e5"
-  integrity sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==
+"@babel/plugin-transform-destructuring@^7.12.1", "@babel/plugin-transform-destructuring@^7.5.0":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.12.1.tgz#b9a570fe0d0a8d460116413cb4f97e8e08b2f847"
+  integrity sha512-fRMYFKuzi/rSiYb2uRLiUENJOKq4Gnl+6qOv5f8z0TZXg3llUwUhsNNwrwaT/6dUhJTzNpBr+CUvEWBtfNY1cw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-dotall-regex@^7.10.4", "@babel/plugin-transform-dotall-regex@^7.4.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.4.tgz#469c2062105c1eb6a040eaf4fac4b488078395ee"
-  integrity sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==
+"@babel/plugin-transform-dotall-regex@^7.12.1", "@babel/plugin-transform-dotall-regex@^7.4.4":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.1.tgz#a1d16c14862817b6409c0a678d6f9373ca9cd975"
+  integrity sha512-B2pXeRKoLszfEW7J4Hg9LoFaWEbr/kzo3teWHmtFCszjRNa/b40f9mfeqZsIDLLt/FjwQ6pz/Gdlwy85xNckBA==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.10.4"
+    "@babel/helper-create-regexp-features-plugin" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-duplicate-keys@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.4.tgz#697e50c9fee14380fe843d1f306b295617431e47"
-  integrity sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==
+"@babel/plugin-transform-duplicate-keys@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.1.tgz#745661baba295ac06e686822797a69fbaa2ca228"
+  integrity sha512-iRght0T0HztAb/CazveUpUQrZY+aGKKaWXMJ4uf9YJtqxSUe09j3wteztCUDRHs+SRAL7yMuFqUsLoAKKzgXjw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-exponentiation-operator@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.4.tgz#5ae338c57f8cf4001bdb35607ae66b92d665af2e"
-  integrity sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==
+"@babel/plugin-transform-exponentiation-operator@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.1.tgz#b0f2ed356ba1be1428ecaf128ff8a24f02830ae0"
+  integrity sha512-7tqwy2bv48q+c1EHbXK0Zx3KXd2RVQp6OC7PbwFNt/dPTAV3Lu5sWtWuAj8owr5wqtWnqHfl2/mJlUmqkChKug==
   dependencies:
     "@babel/helper-builder-binary-assignment-operator-visitor" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-flow-strip-types@^7.4.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.10.4.tgz#c497957f09e86e3df7296271e9eb642876bf7788"
-  integrity sha512-XTadyuqNst88UWBTdLjM+wEY7BFnY2sYtPyAidfC7M/QaZnSuIZpMvLxqGT7phAcnGyWh/XQFLKcGf04CnvxSQ==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.12.1.tgz#8430decfa7eb2aea5414ed4a3fa6e1652b7d77c4"
+  integrity sha512-8hAtkmsQb36yMmEtk2JZ9JnVyDSnDOdlB+0nEGzIDLuK4yR3JcEjfuFPYkdEPSh8Id+rAMeBEn+X0iVEyho6Hg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-syntax-flow" "^7.10.4"
+    "@babel/plugin-syntax-flow" "^7.12.1"
 
-"@babel/plugin-transform-for-of@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz#c08892e8819d3a5db29031b115af511dbbfebae9"
-  integrity sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==
+"@babel/plugin-transform-for-of@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.12.1.tgz#07640f28867ed16f9511c99c888291f560921cfa"
+  integrity sha512-Zaeq10naAsuHo7heQvyV0ptj4dlZJwZgNAtBYBnu5nNKJoW62m0zKcIEyVECrUKErkUkg6ajMy4ZfnVZciSBhg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-function-name@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.4.tgz#6a467880e0fc9638514ba369111811ddbe2644b7"
-  integrity sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==
+"@babel/plugin-transform-function-name@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.1.tgz#2ec76258c70fe08c6d7da154003a480620eba667"
+  integrity sha512-JF3UgJUILoFrFMEnOJLJkRHSk6LUSXLmEFsA23aR2O5CSLUxbeUX1IZ1YQ7Sn0aXb601Ncwjx73a+FVqgcljVw==
   dependencies:
     "@babel/helper-function-name" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-literals@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz#9f42ba0841100a135f22712d0e391c462f571f3c"
-  integrity sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==
+"@babel/plugin-transform-literals@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.1.tgz#d73b803a26b37017ddf9d3bb8f4dc58bfb806f57"
+  integrity sha512-+PxVGA+2Ag6uGgL0A5f+9rklOnnMccwEBzwYFL3EUaKuiyVnUipyXncFcfjSkbimLrODoqki1U9XxZzTvfN7IQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-member-expression-literals@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.4.tgz#b1ec44fcf195afcb8db2c62cd8e551c881baf8b7"
-  integrity sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==
+"@babel/plugin-transform-member-expression-literals@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.12.1.tgz#496038602daf1514a64d43d8e17cbb2755e0c3ad"
+  integrity sha512-1sxePl6z9ad0gFMB9KqmYofk34flq62aqMt9NqliS/7hPEpURUCMbyHXrMPlo282iY7nAvUB1aQd5mg79UD9Jg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-modules-amd@^7.10.4":
-  version "7.10.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.5.tgz#1b9cddaf05d9e88b3aad339cb3e445c4f020a9b1"
-  integrity sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==
+"@babel/plugin-transform-modules-amd@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.12.1.tgz#3154300b026185666eebb0c0ed7f8415fefcf6f9"
+  integrity sha512-tDW8hMkzad5oDtzsB70HIQQRBiTKrhfgwC/KkJeGsaNFTdWhKNt/BiE8c5yj19XiGyrxpbkOfH87qkNg1YGlOQ==
   dependencies:
-    "@babel/helper-module-transforms" "^7.10.5"
+    "@babel/helper-module-transforms" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
     babel-plugin-dynamic-import-node "^2.3.3"
 
-"@babel/plugin-transform-modules-commonjs@^7.10.4", "@babel/plugin-transform-modules-commonjs@^7.4.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.4.tgz#66667c3eeda1ebf7896d41f1f16b17105a2fbca0"
-  integrity sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==
-  dependencies:
-    "@babel/helper-module-transforms" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-simple-access" "^7.10.4"
-    babel-plugin-dynamic-import-node "^2.3.3"
-
-"@babel/plugin-transform-modules-commonjs@^7.8.3":
+"@babel/plugin-transform-modules-commonjs@^7.12.1", "@babel/plugin-transform-modules-commonjs@^7.4.4", "@babel/plugin-transform-modules-commonjs@^7.8.3":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.12.1.tgz#fa403124542636c786cf9b460a0ffbb48a86e648"
   integrity sha512-dY789wq6l0uLY8py9c1B48V8mVL5gZh/+PQ5ZPrylPYsnAvnEMjqsUXkuoDVPeVK+0VyGar+D08107LzDQ6pag==
@@ -837,162 +695,161 @@
     "@babel/helper-simple-access" "^7.12.1"
     babel-plugin-dynamic-import-node "^2.3.3"
 
-"@babel/plugin-transform-modules-systemjs@^7.10.4":
-  version "7.10.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.5.tgz#6270099c854066681bae9e05f87e1b9cadbe8c85"
-  integrity sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==
+"@babel/plugin-transform-modules-systemjs@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.1.tgz#663fea620d593c93f214a464cd399bf6dc683086"
+  integrity sha512-Hn7cVvOavVh8yvW6fLwveFqSnd7rbQN3zJvoPNyNaQSvgfKmDBO9U1YL9+PCXGRlZD9tNdWTy5ACKqMuzyn32Q==
   dependencies:
     "@babel/helper-hoist-variables" "^7.10.4"
-    "@babel/helper-module-transforms" "^7.10.5"
+    "@babel/helper-module-transforms" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-validator-identifier" "^7.10.4"
     babel-plugin-dynamic-import-node "^2.3.3"
 
-"@babel/plugin-transform-modules-umd@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.4.tgz#9a8481fe81b824654b3a0b65da3df89f3d21839e"
-  integrity sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==
+"@babel/plugin-transform-modules-umd@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.12.1.tgz#eb5a218d6b1c68f3d6217b8fa2cc82fec6547902"
+  integrity sha512-aEIubCS0KHKM0zUos5fIoQm+AZUMt1ZvMpqz0/H5qAQ7vWylr9+PLYurT+Ic7ID/bKLd4q8hDovaG3Zch2uz5Q==
   dependencies:
-    "@babel/helper-module-transforms" "^7.10.4"
+    "@babel/helper-module-transforms" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-named-capturing-groups-regex@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.10.4.tgz#78b4d978810b6f3bcf03f9e318f2fc0ed41aecb6"
-  integrity sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==
+"@babel/plugin-transform-named-capturing-groups-regex@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.12.1.tgz#b407f5c96be0d9f5f88467497fa82b30ac3e8753"
+  integrity sha512-tB43uQ62RHcoDp9v2Nsf+dSM8sbNodbEicbQNA53zHz8pWUhsgHSJCGpt7daXxRydjb0KnfmB+ChXOv3oADp1Q==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.10.4"
+    "@babel/helper-create-regexp-features-plugin" "^7.12.1"
 
-"@babel/plugin-transform-new-target@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.4.tgz#9097d753cb7b024cb7381a3b2e52e9513a9c6888"
-  integrity sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==
+"@babel/plugin-transform-new-target@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.12.1.tgz#80073f02ee1bb2d365c3416490e085c95759dec0"
+  integrity sha512-+eW/VLcUL5L9IvJH7rT1sT0CzkdUTvPrXC2PXTn/7z7tXLBuKvezYbGdxD5WMRoyvyaujOq2fWoKl869heKjhw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-transform-object-super@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.1.tgz#4ea08696b8d2e65841d0c7706482b048bed1066e"
+  integrity sha512-AvypiGJH9hsquNUn+RXVcBdeE3KHPZexWRdimhuV59cSoOt5kFBmqlByorAeUlGG2CJWd0U+4ZtNKga/TB0cAw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-replace-supers" "^7.12.1"
+
+"@babel/plugin-transform-parameters@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.12.1.tgz#d2e963b038771650c922eff593799c96d853255d"
+  integrity sha512-xq9C5EQhdPK23ZeCdMxl8bbRnAgHFrw5EOC3KJUsSylZqdkCaFEXxGSBuTSObOpiiHHNyb82es8M1QYgfQGfNg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-object-super@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.4.tgz#d7146c4d139433e7a6526f888c667e314a093894"
-  integrity sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-replace-supers" "^7.10.4"
-
-"@babel/plugin-transform-parameters@^7.10.4":
-  version "7.10.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz#59d339d58d0b1950435f4043e74e2510005e2c4a"
-  integrity sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==
-  dependencies:
-    "@babel/helper-get-function-arity" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
-
-"@babel/plugin-transform-property-literals@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.4.tgz#f6fe54b6590352298785b83edd815d214c42e3c0"
-  integrity sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==
+"@babel/plugin-transform-property-literals@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.12.1.tgz#41bc81200d730abb4456ab8b3fbd5537b59adecd"
+  integrity sha512-6MTCR/mZ1MQS+AwZLplX4cEySjCpnIF26ToWo942nqn8hXSm7McaHQNeGx/pt7suI1TWOWMfa/NgBhiqSnX0cQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-react-jsx@^7.0.0", "@babel/plugin-transform-react-jsx@^7.3.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.4.tgz#673c9f913948764a4421683b2bef2936968fddf2"
-  integrity sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.7.tgz#8b14d45f6eccd41b7f924bcb65c021e9f0a06f7f"
+  integrity sha512-YFlTi6MEsclFAPIDNZYiCRbneg1MFGao9pPG9uD5htwE0vDbPaMUMeYd6itWjw7K4kro4UbdQf3ljmFl9y48dQ==
   dependencies:
     "@babel/helper-builder-react-jsx" "^7.10.4"
-    "@babel/helper-builder-react-jsx-experimental" "^7.10.4"
+    "@babel/helper-builder-react-jsx-experimental" "^7.12.4"
     "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-syntax-jsx" "^7.10.4"
+    "@babel/plugin-syntax-jsx" "^7.12.1"
 
-"@babel/plugin-transform-regenerator@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.4.tgz#2015e59d839074e76838de2159db421966fd8b63"
-  integrity sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==
+"@babel/plugin-transform-regenerator@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.1.tgz#5f0a28d842f6462281f06a964e88ba8d7ab49753"
+  integrity sha512-gYrHqs5itw6i4PflFX3OdBPMQdPbF4bj2REIUxlMRUFk0/ZOAIpDFuViuxPjUL7YC8UPnf+XG7/utJvqXdPKng==
   dependencies:
     regenerator-transform "^0.14.2"
 
-"@babel/plugin-transform-reserved-words@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.4.tgz#8f2682bcdcef9ed327e1b0861585d7013f8a54dd"
-  integrity sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==
+"@babel/plugin-transform-reserved-words@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.12.1.tgz#6fdfc8cc7edcc42b36a7c12188c6787c873adcd8"
+  integrity sha512-pOnUfhyPKvZpVyBHhSBoX8vfA09b7r00Pmm1sH+29ae2hMTKVmSp4Ztsr8KBKjLjx17H0eJqaRC3bR2iThM54A==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-shorthand-properties@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz#9fd25ec5cdd555bb7f473e5e6ee1c971eede4dd6"
-  integrity sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==
+"@babel/plugin-transform-shorthand-properties@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.1.tgz#0bf9cac5550fce0cfdf043420f661d645fdc75e3"
+  integrity sha512-GFZS3c/MhX1OusqB1MZ1ct2xRzX5ppQh2JU1h2Pnfk88HtFTM+TWQqJNfwkmxtPQtb/s1tk87oENfXJlx7rSDw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-spread@^7.11.0":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.11.0.tgz#fa84d300f5e4f57752fe41a6d1b3c554f13f17cc"
-  integrity sha512-UwQYGOqIdQJe4aWNyS7noqAnN2VbaczPLiEtln+zPowRNlD+79w3oi2TWfYe0eZgd+gjZCbsydN7lzWysDt+gw==
+"@babel/plugin-transform-spread@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.12.1.tgz#527f9f311be4ec7fdc2b79bb89f7bf884b3e1e1e"
+  integrity sha512-vuLp8CP0BE18zVYjsEBZ5xoCecMK6LBMMxYzJnh01rxQRvhNhH1csMMmBfNo5tGpGO+NhdSNW2mzIvBu3K1fng==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.11.0"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
 
-"@babel/plugin-transform-sticky-regex@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.4.tgz#8f3889ee8657581130a29d9cc91d7c73b7c4a28d"
-  integrity sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-regex" "^7.10.4"
-
-"@babel/plugin-transform-template-literals@^7.10.4":
-  version "7.10.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz#78bc5d626a6642db3312d9d0f001f5e7639fde8c"
-  integrity sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
-
-"@babel/plugin-transform-typeof-symbol@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.4.tgz#9509f1a7eec31c4edbffe137c16cc33ff0bc5bfc"
-  integrity sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==
+"@babel/plugin-transform-sticky-regex@^7.12.7":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.7.tgz#560224613ab23987453948ed21d0b0b193fa7fad"
+  integrity sha512-VEiqZL5N/QvDbdjfYQBhruN0HYjSPjC4XkeqW4ny/jNtH9gcbgaqBIXYEZCNnESMAGs0/K/R7oFGMhOyu/eIxg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-unicode-escapes@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.10.4.tgz#feae523391c7651ddac115dae0a9d06857892007"
-  integrity sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==
+"@babel/plugin-transform-template-literals@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.12.1.tgz#b43ece6ed9a79c0c71119f576d299ef09d942843"
+  integrity sha512-b4Zx3KHi+taXB1dVRBhVJtEPi9h1THCeKmae2qP0YdUHIFhVjtpqqNfxeVAa1xeHVhAy4SbHxEwx5cltAu5apw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-unicode-regex@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.4.tgz#e56d71f9282fac6db09c82742055576d5e6d80a8"
-  integrity sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==
+"@babel/plugin-transform-typeof-symbol@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.1.tgz#9ca6be343d42512fbc2e68236a82ae64bc7af78a"
+  integrity sha512-EPGgpGy+O5Kg5pJFNDKuxt9RdmTgj5sgrus2XVeMp/ZIbOESadgILUbm50SNpghOh3/6yrbsH+NB5+WJTmsA7Q==
   dependencies:
-    "@babel/helper-create-regexp-features-plugin" "^7.10.4"
+    "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-transform-unicode-escapes@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.1.tgz#5232b9f81ccb07070b7c3c36c67a1b78f1845709"
+  integrity sha512-I8gNHJLIc7GdApm7wkVnStWssPNbSRMPtgHdmH3sRM1zopz09UWPS4x5V4n1yz/MIWTVnJ9sp6IkuXdWM4w+2Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-transform-unicode-regex@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.1.tgz#cc9661f61390db5c65e3febaccefd5c6ac3faecb"
+  integrity sha512-SqH4ClNngh/zGwHZOOQMTD+e8FGWexILV+ePMyiDJttAWRh5dhDL8rcl5lSgU3Huiq6Zn6pWTMvdPAb21Dwdyg==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/preset-env@^7.4.4":
-  version "7.11.5"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.11.5.tgz#18cb4b9379e3e92ffea92c07471a99a2914e4272"
-  integrity sha512-kXqmW1jVcnB2cdueV+fyBM8estd5mlNfaQi6lwLgRwCby4edpavgbFhiBNjmWA3JpB/yZGSISa7Srf+TwxDQoA==
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.12.7.tgz#54ea21dbe92caf6f10cb1a0a576adc4ebf094b55"
+  integrity sha512-OnNdfAr1FUQg7ksb7bmbKoby4qFOHw6DKWWUNB9KqnnCldxhxJlP+21dpyaWFmf2h0rTbOkXJtAGevY3XW1eew==
   dependencies:
-    "@babel/compat-data" "^7.11.0"
-    "@babel/helper-compilation-targets" "^7.10.4"
-    "@babel/helper-module-imports" "^7.10.4"
+    "@babel/compat-data" "^7.12.7"
+    "@babel/helper-compilation-targets" "^7.12.5"
+    "@babel/helper-module-imports" "^7.12.5"
     "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-proposal-async-generator-functions" "^7.10.4"
-    "@babel/plugin-proposal-class-properties" "^7.10.4"
-    "@babel/plugin-proposal-dynamic-import" "^7.10.4"
-    "@babel/plugin-proposal-export-namespace-from" "^7.10.4"
-    "@babel/plugin-proposal-json-strings" "^7.10.4"
-    "@babel/plugin-proposal-logical-assignment-operators" "^7.11.0"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.10.4"
-    "@babel/plugin-proposal-numeric-separator" "^7.10.4"
-    "@babel/plugin-proposal-object-rest-spread" "^7.11.0"
-    "@babel/plugin-proposal-optional-catch-binding" "^7.10.4"
-    "@babel/plugin-proposal-optional-chaining" "^7.11.0"
-    "@babel/plugin-proposal-private-methods" "^7.10.4"
-    "@babel/plugin-proposal-unicode-property-regex" "^7.10.4"
+    "@babel/helper-validator-option" "^7.12.1"
+    "@babel/plugin-proposal-async-generator-functions" "^7.12.1"
+    "@babel/plugin-proposal-class-properties" "^7.12.1"
+    "@babel/plugin-proposal-dynamic-import" "^7.12.1"
+    "@babel/plugin-proposal-export-namespace-from" "^7.12.1"
+    "@babel/plugin-proposal-json-strings" "^7.12.1"
+    "@babel/plugin-proposal-logical-assignment-operators" "^7.12.1"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.12.1"
+    "@babel/plugin-proposal-numeric-separator" "^7.12.7"
+    "@babel/plugin-proposal-object-rest-spread" "^7.12.1"
+    "@babel/plugin-proposal-optional-catch-binding" "^7.12.1"
+    "@babel/plugin-proposal-optional-chaining" "^7.12.7"
+    "@babel/plugin-proposal-private-methods" "^7.12.1"
+    "@babel/plugin-proposal-unicode-property-regex" "^7.12.1"
     "@babel/plugin-syntax-async-generators" "^7.8.0"
-    "@babel/plugin-syntax-class-properties" "^7.10.4"
+    "@babel/plugin-syntax-class-properties" "^7.12.1"
     "@babel/plugin-syntax-dynamic-import" "^7.8.0"
     "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
     "@babel/plugin-syntax-json-strings" "^7.8.0"
@@ -1002,45 +859,42 @@
     "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
     "@babel/plugin-syntax-optional-chaining" "^7.8.0"
-    "@babel/plugin-syntax-top-level-await" "^7.10.4"
-    "@babel/plugin-transform-arrow-functions" "^7.10.4"
-    "@babel/plugin-transform-async-to-generator" "^7.10.4"
-    "@babel/plugin-transform-block-scoped-functions" "^7.10.4"
-    "@babel/plugin-transform-block-scoping" "^7.10.4"
-    "@babel/plugin-transform-classes" "^7.10.4"
-    "@babel/plugin-transform-computed-properties" "^7.10.4"
-    "@babel/plugin-transform-destructuring" "^7.10.4"
-    "@babel/plugin-transform-dotall-regex" "^7.10.4"
-    "@babel/plugin-transform-duplicate-keys" "^7.10.4"
-    "@babel/plugin-transform-exponentiation-operator" "^7.10.4"
-    "@babel/plugin-transform-for-of" "^7.10.4"
-    "@babel/plugin-transform-function-name" "^7.10.4"
-    "@babel/plugin-transform-literals" "^7.10.4"
-    "@babel/plugin-transform-member-expression-literals" "^7.10.4"
-    "@babel/plugin-transform-modules-amd" "^7.10.4"
-    "@babel/plugin-transform-modules-commonjs" "^7.10.4"
-    "@babel/plugin-transform-modules-systemjs" "^7.10.4"
-    "@babel/plugin-transform-modules-umd" "^7.10.4"
-    "@babel/plugin-transform-named-capturing-groups-regex" "^7.10.4"
-    "@babel/plugin-transform-new-target" "^7.10.4"
-    "@babel/plugin-transform-object-super" "^7.10.4"
-    "@babel/plugin-transform-parameters" "^7.10.4"
-    "@babel/plugin-transform-property-literals" "^7.10.4"
-    "@babel/plugin-transform-regenerator" "^7.10.4"
-    "@babel/plugin-transform-reserved-words" "^7.10.4"
-    "@babel/plugin-transform-shorthand-properties" "^7.10.4"
-    "@babel/plugin-transform-spread" "^7.11.0"
-    "@babel/plugin-transform-sticky-regex" "^7.10.4"
-    "@babel/plugin-transform-template-literals" "^7.10.4"
-    "@babel/plugin-transform-typeof-symbol" "^7.10.4"
-    "@babel/plugin-transform-unicode-escapes" "^7.10.4"
-    "@babel/plugin-transform-unicode-regex" "^7.10.4"
+    "@babel/plugin-syntax-top-level-await" "^7.12.1"
+    "@babel/plugin-transform-arrow-functions" "^7.12.1"
+    "@babel/plugin-transform-async-to-generator" "^7.12.1"
+    "@babel/plugin-transform-block-scoped-functions" "^7.12.1"
+    "@babel/plugin-transform-block-scoping" "^7.12.1"
+    "@babel/plugin-transform-classes" "^7.12.1"
+    "@babel/plugin-transform-computed-properties" "^7.12.1"
+    "@babel/plugin-transform-destructuring" "^7.12.1"
+    "@babel/plugin-transform-dotall-regex" "^7.12.1"
+    "@babel/plugin-transform-duplicate-keys" "^7.12.1"
+    "@babel/plugin-transform-exponentiation-operator" "^7.12.1"
+    "@babel/plugin-transform-for-of" "^7.12.1"
+    "@babel/plugin-transform-function-name" "^7.12.1"
+    "@babel/plugin-transform-literals" "^7.12.1"
+    "@babel/plugin-transform-member-expression-literals" "^7.12.1"
+    "@babel/plugin-transform-modules-amd" "^7.12.1"
+    "@babel/plugin-transform-modules-commonjs" "^7.12.1"
+    "@babel/plugin-transform-modules-systemjs" "^7.12.1"
+    "@babel/plugin-transform-modules-umd" "^7.12.1"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.12.1"
+    "@babel/plugin-transform-new-target" "^7.12.1"
+    "@babel/plugin-transform-object-super" "^7.12.1"
+    "@babel/plugin-transform-parameters" "^7.12.1"
+    "@babel/plugin-transform-property-literals" "^7.12.1"
+    "@babel/plugin-transform-regenerator" "^7.12.1"
+    "@babel/plugin-transform-reserved-words" "^7.12.1"
+    "@babel/plugin-transform-shorthand-properties" "^7.12.1"
+    "@babel/plugin-transform-spread" "^7.12.1"
+    "@babel/plugin-transform-sticky-regex" "^7.12.7"
+    "@babel/plugin-transform-template-literals" "^7.12.1"
+    "@babel/plugin-transform-typeof-symbol" "^7.12.1"
+    "@babel/plugin-transform-unicode-escapes" "^7.12.1"
+    "@babel/plugin-transform-unicode-regex" "^7.12.1"
     "@babel/preset-modules" "^0.1.3"
-    "@babel/types" "^7.11.5"
-    browserslist "^4.12.0"
-    core-js-compat "^3.6.2"
-    invariant "^2.2.2"
-    levenary "^1.1.1"
+    "@babel/types" "^7.12.7"
+    core-js-compat "^3.7.0"
     semver "^5.5.0"
 
 "@babel/preset-modules@^0.1.3":
@@ -1062,30 +916,14 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.4.4", "@babel/runtime@^7.8.4":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.4.4", "@babel/runtime@^7.8.4":
-  version "7.11.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
-  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/template@^7.10.4", "@babel/template@^7.4.0", "@babel/template@^7.4.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
-  integrity sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/parser" "^7.10.4"
-    "@babel/types" "^7.10.4"
-
-"@babel/template@^7.12.7", "@babel/template@^7.7.4":
+"@babel/template@^7.10.4", "@babel/template@^7.12.7", "@babel/template@^7.4.0", "@babel/template@^7.4.4", "@babel/template@^7.7.4":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.7.tgz#c817233696018e39fbb6c491d2fb684e05ed43bc"
   integrity sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==
@@ -1094,37 +932,7 @@
     "@babel/parser" "^7.12.7"
     "@babel/types" "^7.12.7"
 
-"@babel/traverse@^7.10.4", "@babel/traverse@^7.11.5", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.4", "@babel/traverse@^7.7.0":
-  version "7.11.5"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.11.5.tgz#be777b93b518eb6d76ee2e1ea1d143daa11e61c3"
-  integrity sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/generator" "^7.11.5"
-    "@babel/helper-function-name" "^7.10.4"
-    "@babel/helper-split-export-declaration" "^7.11.0"
-    "@babel/parser" "^7.11.5"
-    "@babel/types" "^7.11.5"
-    debug "^4.1.0"
-    globals "^11.1.0"
-    lodash "^4.17.19"
-
-"@babel/traverse@^7.12.1", "@babel/traverse@^7.12.5", "@babel/traverse@^7.12.8":
-  version "7.12.8"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.8.tgz#c1c2983bf9ba0f4f0eaa11dff7e77fa63307b2a4"
-  integrity sha512-EIRQXPTwFEGRZyu6gXbjfpNORN1oZvwuzJbxcXjAgWV0iqXYDszN1Hx3FVm6YgZfu1ZQbCVAk3l+nIw95Xll9Q==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/generator" "^7.12.5"
-    "@babel/helper-function-name" "^7.10.4"
-    "@babel/helper-split-export-declaration" "^7.11.0"
-    "@babel/parser" "^7.12.7"
-    "@babel/types" "^7.12.7"
-    debug "^4.1.0"
-    globals "^11.1.0"
-    lodash "^4.17.19"
-
-"@babel/traverse@^7.7.4":
+"@babel/traverse@^7.10.4", "@babel/traverse@^7.12.1", "@babel/traverse@^7.12.5", "@babel/traverse@^7.12.9", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.4", "@babel/traverse@^7.7.0", "@babel/traverse@^7.7.4":
   version "7.12.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.9.tgz#fad26c972eabbc11350e0b695978de6cc8e8596f"
   integrity sha512-iX9ajqnLdoU1s1nHt36JDI9KG4k+vmI8WgjK5d+aDTwQbL2fUnzedNedssA645Ede3PM2ma1n8Q4h2ohwXgMXw==
@@ -1139,16 +947,7 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.11.5", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
-  version "7.11.5"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.11.5.tgz#d9de577d01252d77c6800cee039ee64faf75662d"
-  integrity sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.10.4"
-    lodash "^4.17.19"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.12.1", "@babel/types@^7.12.5", "@babel/types@^7.12.7", "@babel/types@^7.7.4":
+"@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.12.1", "@babel/types@^7.12.5", "@babel/types@^7.12.7", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.7.4":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.7.tgz#6039ff1e242640a29452c9ae572162ec9a8f5d13"
   integrity sha512-MNyI92qZq6jrQkXvtIiykvl4WtoRrVV9MPn+ZfsoEENjiWcBQ3ZSHrkxnJWgWtLX3XXqX5hrSQ+X69wkmesXuQ==
@@ -1963,20 +1762,25 @@
     fastq "^1.6.0"
 
 "@octokit/auth-token@^2.4.0":
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.2.tgz#10d0ae979b100fa6b72fa0e8e63e27e6d0dbff8a"
-  integrity sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.4.4.tgz#ee31c69b01d0378c12fd3ffe406030f3d94d3b56"
+  integrity sha512-LNfGu3Ro9uFAYh10MUZVaT7X2CnNm2C8IDQmabx+3DygYIQjs9FwzFAHN/0t6mu5HEPhxcb1XOuxdpY82vCg2Q==
   dependencies:
-    "@octokit/types" "^5.0.0"
+    "@octokit/types" "^6.0.0"
 
 "@octokit/endpoint@^6.0.1":
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.5.tgz#43a6adee813c5ffd2f719e20cfd14a1fee7c193a"
-  integrity sha512-70K5u6zd45ItOny6aHQAsea8HHQjlQq85yqOMe+Aj8dkhN2qSJ9T+Q3YjUjEYfPRBcuUWNgMn62DQnP/4LAIiQ==
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.10.tgz#741ce1fa2f4fb77ce8ebe0c6eaf5ce63f565f8e8"
+  integrity sha512-9+Xef8nT7OKZglfkOMm7IL6VwxXUQyR7DUSU0LH/F7VNqs8vyd7es5pTfz9E7DwUIx7R3pGscxu1EBhYljyu7Q==
   dependencies:
-    "@octokit/types" "^5.0.0"
-    is-plain-object "^4.0.0"
+    "@octokit/types" "^6.0.0"
+    is-plain-object "^5.0.0"
     universal-user-agent "^6.0.0"
+
+"@octokit/openapi-types@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-2.0.0.tgz#6d8f8ad9db3b75a39115f5def2654df8bed39f28"
+  integrity sha512-J4bfM7lf8oZvEAdpS71oTvC1ofKxfEZgU5vKVwzZKi4QPiL82udjpseJwxPid9Pu2FNmyRQOX4iEj6W1iOSnPw==
 
 "@octokit/plugin-enterprise-rest@^6.0.1":
   version "6.0.1"
@@ -1991,9 +1795,9 @@
     "@octokit/types" "^2.0.1"
 
 "@octokit/plugin-request-log@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz#eef87a431300f6148c39a7f75f8cfeb218b2547e"
-  integrity sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.2.tgz#394d59ec734cd2f122431fbaf05099861ece3c44"
+  integrity sha512-oTJSNAmBqyDR41uSMunLQKMX0jmEXbwD1fpz8FG27lScV3RhtGfBa1/BBLym+PxcC16IBlF7KH9vP1BUYxA+Eg==
 
 "@octokit/plugin-rest-endpoint-methods@2.4.0":
   version "2.4.0"
@@ -2013,25 +1817,25 @@
     once "^1.4.0"
 
 "@octokit/request-error@^2.0.0":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.0.2.tgz#0e76b83f5d8fdda1db99027ea5f617c2e6ba9ed0"
-  integrity sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.0.4.tgz#07dd5c0521d2ee975201274c472a127917741262"
+  integrity sha512-LjkSiTbsxIErBiRh5wSZvpZqT4t0/c9+4dOe0PII+6jXR+oj/h66s7E4a/MghV7iT8W9ffoQ5Skoxzs96+gBPA==
   dependencies:
-    "@octokit/types" "^5.0.1"
+    "@octokit/types" "^6.0.0"
     deprecation "^2.0.0"
     once "^1.4.0"
 
 "@octokit/request@^5.2.0":
-  version "5.4.7"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.7.tgz#fd703ee092e0463ceba49ff7a3e61cb4cf8a0fde"
-  integrity sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==
+  version "5.4.12"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.12.tgz#b04826fa934670c56b135a81447be2c1723a2ffc"
+  integrity sha512-MvWYdxengUWTGFpfpefBBpVmmEYfkwMoxonIB3sUGp5rhdgwjXL1ejo6JbgzG/QD9B/NYt/9cJX1pxXeSIUCkg==
   dependencies:
     "@octokit/endpoint" "^6.0.1"
     "@octokit/request-error" "^2.0.0"
-    "@octokit/types" "^5.0.0"
+    "@octokit/types" "^6.0.3"
     deprecation "^2.0.0"
-    is-plain-object "^4.0.0"
-    node-fetch "^2.3.0"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.1"
     once "^1.4.0"
     universal-user-agent "^6.0.0"
 
@@ -2064,11 +1868,12 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@octokit/types@^5.0.0", "@octokit/types@^5.0.1":
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-5.4.1.tgz#d5d5f2b70ffc0e3f89467c3db749fa87fc3b7031"
-  integrity sha512-OlMlSySBJoJ6uozkr/i03nO5dlYQyE05vmQNZhAh9MyO4DPBP88QlwsDVLmVjIMFssvIZB6WO0ctIGMRG+xsJQ==
+"@octokit/types@^6.0.0", "@octokit/types@^6.0.3":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.1.0.tgz#126197ceb802220fee920d5ea6d568c2c63365cc"
+  integrity sha512-bMWBmg77MQTiRkOVyf50qK3QECWOEy43rLy/6fTWZ4HEwAhNfqzMcjiBDZAowkILwTrFvzE1CpP6gD0MuPHS+A==
   dependencies:
+    "@octokit/openapi-types" "^2.0.0"
     "@types/node" ">= 8"
 
 "@parcel/fs@^1.11.0":
@@ -2205,11 +2010,6 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@types/color-name@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
-  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
-
 "@types/estree@*":
   version "0.0.45"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.45.tgz#e9387572998e5ecdac221950dab3e8c3b16af884"
@@ -2239,14 +2039,14 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/minimist@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
-  integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
+  integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
 "@types/node@*", "@types/node@>= 8":
-  version "14.6.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.2.tgz#264b44c5a28dfa80198fc2f7b6d3c8a054b9491f"
-  integrity sha512-onlIwbaeqvZyniGPfdw/TEhKIh79pz66L1q06WUQqJLnAb6wbjvOtepLYTGHTqzdXgBYIE3ZdmqHDGsRsbBz7A==
+  version "14.14.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.10.tgz#5958a82e41863cfc71f2307b3748e3491ba03785"
+  integrity sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -2264,9 +2064,9 @@
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
 "@types/react@^16.9.16":
-  version "16.9.49"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.49.tgz#09db021cf8089aba0cdb12a49f8021a69cce4872"
-  integrity sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==
+  version "16.14.2"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.2.tgz#85dcc0947d0645349923c04ccef6018a1ab7538c"
+  integrity sha512-BzzcAlyDxXl2nANlabtT4thtvbbnhee8hMmH/CcJrISDBVcJS1iOsP1f0OAgSdGE0MsY9tqcrb9YoZcOFv9dbQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -2508,9 +2308,9 @@ JSONStream@^1.0.3, JSONStream@^1.0.4, JSONStream@^1.3.4:
     through ">=2.2.7 <3"
 
 abab@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.4.tgz#6dfa57b417ca06d21b2478f0e638302f99c2405c"
-  integrity sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ==
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
+  integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
 
 abbrev@1:
   version "1.1.1"
@@ -2526,9 +2326,9 @@ acorn-globals@^4.3.0:
     acorn-walk "^6.0.1"
 
 acorn-jsx@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
-  integrity sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
+  integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
 
 acorn-node@^1.2.0, acorn-node@^1.3.0, acorn-node@^1.5.2, acorn-node@^1.6.1:
   version "1.8.2"
@@ -2555,14 +2355,14 @@ acorn-walk@^8.0.0:
   integrity sha512-oZRad/3SMOI/pxbbmqyurIx7jHw1wZDcR9G44L8pUVFEomX/0dH89SrM1KaDXuv1NpzAXz6Op/Xu/Qd5XXzdEA==
 
 acorn@^6.0.1, acorn@^6.0.4, acorn@^6.4.1:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
-  integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
+  integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
 
 acorn@^7.0.0, acorn@^7.1.0, acorn@^7.1.1:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.0.tgz#e1ad486e6c54501634c6c397c5c121daa383607c"
-  integrity sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
+  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 acorn@^8.0.1:
   version "8.0.4"
@@ -2609,9 +2409,9 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
 ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3:
-  version "6.12.4"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.4.tgz#0614facc4522127fa713445c6bfd3ebd376e2234"
-  integrity sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==
+  version "6.12.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -2674,15 +2474,7 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.0.0, ansi-styles@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
-  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
-  dependencies:
-    "@types/color-name" "^1.1.1"
-    color-convert "^2.0.1"
-
-ansi-styles@^4.2.1:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0, ansi-styles@^4.2.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -2808,12 +2600,14 @@ array-ify@^1.0.0:
   integrity sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=
 
 array-includes@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.1.tgz#cdd67e6852bdf9c1215460786732255ed2459348"
-  integrity sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.2.tgz#a8db03e0b88c8c6aeddc49cb132f9bcab4ebf9c8"
+  integrity sha512-w2GspexNQpx+PutG3QpT437/BenZBj0M/MZGn5mzv/MofYqo0xmRHzn4lFsoDlWJ+THYsGJmFlW68WlDFx7VRw==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.0"
+    es-abstract "^1.18.0-next.1"
+    get-intrinsic "^1.0.1"
     is-string "^1.0.5"
 
 array-union@^1.0.1, array-union@^1.0.2:
@@ -2839,12 +2633,13 @@ array-unique@^0.3.2:
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
 array.prototype.flat@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz#0de82b426b0318dbfdb940089e38b043d37f6c7b"
-  integrity sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz#6ef638b43312bd401b4c6199fdec7e2dc9e9a123"
+  integrity sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
+    es-abstract "^1.18.0-next.1"
 
 array.prototype.flatmap@^1.2.3:
   version "1.2.4"
@@ -3043,9 +2838,9 @@ aws-sign2@~0.7.0:
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
 aws4@^1.8.0:
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.1.tgz#e1e82e4f3e999e2cfd61b161280d16a111f86428"
-  integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
+  integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
 axe-core@^4.0.2:
   version "4.1.1"
@@ -3122,9 +2917,9 @@ balanced-match@^1.0.0:
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
 base64-js@^1.0.2:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
-  integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
 base@^0.11.1:
   version "0.11.2"
@@ -3198,7 +2993,7 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.4.0:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
   integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
 
-bn.js@^5.1.1:
+bn.js@^5.0.0, bn.js@^5.1.1:
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.3.tgz#beca005408f642ebebea80b042b4d18d2ac0ee6b"
   integrity sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==
@@ -3324,11 +3119,11 @@ browserify-des@^1.0.0:
     safe-buffer "^5.1.2"
 
 browserify-rsa@^4.0.0, browserify-rsa@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/browserify-rsa/-/browserify-rsa-4.0.1.tgz#21e0abfaf6f2029cf2fafb133567a701d4135524"
-  integrity sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/browserify-rsa/-/browserify-rsa-4.1.0.tgz#b2fd06b5b75ae297f7ce2dc651f918f5be158c8d"
+  integrity sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==
   dependencies:
-    bn.js "^4.1.0"
+    bn.js "^5.0.0"
     randombytes "^2.0.1"
 
 browserify-sign@^4.0.0:
@@ -3407,15 +3202,16 @@ browserify@^16.2.3:
     vm-browserify "^1.0.0"
     xtend "^4.0.0"
 
-browserslist@^4.0.0, browserslist@^4.1.0, browserslist@^4.12.0, browserslist@^4.8.5:
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.0.tgz#2908951abfe4ec98737b72f34c3bcedc8d43b000"
-  integrity sha512-pUsXKAF2lVwhmtpeA3LJrZ76jXuusrNyhduuQs7CDFf9foT4Y38aQOserd2lMe5DSSrjf3fx34oHwryuvxAUgQ==
+browserslist@^4.0.0, browserslist@^4.1.0, browserslist@^4.14.5, browserslist@^4.14.7:
+  version "4.15.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.15.0.tgz#3d48bbca6a3f378e86102ffd017d9a03f122bdb0"
+  integrity sha512-IJ1iysdMkGmjjYeRlDU8PQejVwxvVO5QOfXH7ylW31GO6LwNRSmm/SgRXtNsEXqMLl2e+2H5eEJ7sfynF8TCaQ==
   dependencies:
-    caniuse-lite "^1.0.30001111"
-    electron-to-chromium "^1.3.523"
-    escalade "^3.0.2"
-    node-releases "^1.1.60"
+    caniuse-lite "^1.0.30001164"
+    colorette "^1.2.1"
+    electron-to-chromium "^1.3.612"
+    escalade "^3.1.1"
+    node-releases "^1.1.67"
 
 btoa-lite@^1.0.0:
   version "1.0.0"
@@ -3651,10 +3447,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001111:
-  version "1.0.30001122"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001122.tgz#2c8ff631330d986a07a7ba7125cce77a1373b475"
-  integrity sha512-pxjw28CThdrqfz06nJkpAc5SXM404TXB/h5f4UJX+rrXJKE/1bu/KAILc2AY+O6cQIFtRjV9qOR2vaEp9LDGUA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001164:
+  version "1.0.30001164"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001164.tgz#5bbfd64ca605d43132f13cc7fdabb17c3036bfdc"
+  integrity sha512-G+A/tkf4bu0dSp9+duNiXc7bGds35DioCyC6vgK2m/rjA4Krpy5WeZgZyfH2f0wj2kI6yAWWucyap6oOwmY1mg==
 
 cardinal@^2.1.1:
   version "2.1.1"
@@ -3729,22 +3525,7 @@ chokidar@^2.1.5, chokidar@^2.1.8:
   optionalDependencies:
     fsevents "^1.2.7"
 
-chokidar@^3.3.0, chokidar@^3.4.1:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.2.tgz#38dc8e658dec3809741eb3ef7bb0a47fe424232d"
-  integrity sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==
-  dependencies:
-    anymatch "~3.1.1"
-    braces "~3.0.2"
-    glob-parent "~5.1.0"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.4.0"
-  optionalDependencies:
-    fsevents "~2.1.2"
-
-chokidar@^3.4.2:
+chokidar@^3.3.0, chokidar@^3.4.1, chokidar@^3.4.2:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.3.tgz#c1df38231448e45ca4ac588e6c79573ba6a57d5b"
   integrity sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==
@@ -3967,10 +3748,10 @@ color-name@^1.0.0, color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-string@^1.5.2:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.3.tgz#c9bbc5f01b58b5492f3d6857459cb6590ce204cc"
-  integrity sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==
+color-string@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.4.tgz#dd51cd25cfee953d138fe4002372cc3d0e504cb6"
+  integrity sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==
   dependencies:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
@@ -3981,12 +3762,17 @@ color-support@^1.1.0:
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
 color@^3.0.0:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/color/-/color-3.1.2.tgz#68148e7f85d41ad7649c5fa8c8106f098d229e10"
-  integrity sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.1.3.tgz#ca67fb4e7b97d611dcde39eceed422067d91596e"
+  integrity sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==
   dependencies:
     color-convert "^1.9.1"
-    color-string "^1.5.2"
+    color-string "^1.5.4"
+
+colorette@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
+  integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
 
 colors@^1.4.0:
   version "1.4.0"
@@ -4142,11 +3928,6 @@ confusing-browser-globals@^1.0.10:
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz#30d1e7f3d1b882b25ec4933d1d1adac353d20a59"
   integrity sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==
 
-confusing-browser-globals@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz#72bc13b483c0276801681871d4898516f8f54fdd"
-  integrity sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==
-
 console-browserify@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
@@ -4168,9 +3949,9 @@ contains-path@^0.1.0:
   integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
 
 conventional-changelog-angular@^5.0.3:
-  version "5.0.11"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-5.0.11.tgz#99a3ca16e4a5305e0c2c2fae3ef74fd7631fc3fb"
-  integrity sha512-nSLypht/1yEflhuTogC03i7DX7sOrXGsRn14g131Potqi6cbGbGEE9PSDEHKldabB6N76HiSyw9Ph+kLmC04Qw==
+  version "5.0.12"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-angular/-/conventional-changelog-angular-5.0.12.tgz#c979b8b921cbfe26402eb3da5bbfda02d865a2b9"
+  integrity sha512-5GLsbnkR/7A89RyHLvvoExbiGbd9xKdKqDTrArnPbOqBqG/2wIosu0fHwpeIRI8Tl94MhVNBXcLJZl92ZQ5USw==
   dependencies:
     compare-func "^2.0.0"
     q "^1.5.1"
@@ -4200,40 +3981,40 @@ conventional-changelog-preset-loader@^2.1.1:
   integrity sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==
 
 conventional-changelog-writer@^4.0.6:
-  version "4.0.17"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-4.0.17.tgz#4753aaa138bf5aa59c0b274cb5937efcd2722e21"
-  integrity sha512-IKQuK3bib/n032KWaSb8YlBFds+aLmzENtnKtxJy3+HqDq5kohu3g/UdNbIHeJWygfnEbZjnCKFxAW0y7ArZAw==
+  version "4.0.18"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-4.0.18.tgz#10b73baa59c7befc69b360562f8b9cd19e63daf8"
+  integrity sha512-mAQDCKyB9HsE8Ko5cCM1Jn1AWxXPYV0v8dFPabZRkvsiWUul2YyAqbIaoMKF88Zf2ffnOPSvKhboLf3fnjo5/A==
   dependencies:
     compare-func "^2.0.0"
-    conventional-commits-filter "^2.0.6"
+    conventional-commits-filter "^2.0.7"
     dateformat "^3.0.0"
     handlebars "^4.7.6"
     json-stringify-safe "^5.0.1"
     lodash "^4.17.15"
-    meow "^7.0.0"
+    meow "^8.0.0"
     semver "^6.0.0"
     split "^1.0.0"
-    through2 "^3.0.0"
+    through2 "^4.0.0"
 
-conventional-commits-filter@^2.0.2, conventional-commits-filter@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/conventional-commits-filter/-/conventional-commits-filter-2.0.6.tgz#0935e1240c5ca7698329affee1b6a46d33324c4c"
-  integrity sha512-4g+sw8+KA50/Qwzfr0hL5k5NWxqtrOVw4DDk3/h6L85a9Gz0/Eqp3oP+CWCNfesBvZZZEFHF7OTEbRe+yYSyKw==
+conventional-commits-filter@^2.0.2, conventional-commits-filter@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz#f8d9b4f182fce00c9af7139da49365b136c8a0b3"
+  integrity sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==
   dependencies:
     lodash.ismatch "^4.4.0"
     modify-values "^1.0.0"
 
 conventional-commits-parser@^3.0.3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/conventional-commits-parser/-/conventional-commits-parser-3.1.0.tgz#10140673d5e7ef5572633791456c5d03b69e8be4"
-  integrity sha512-RSo5S0WIwXZiRxUGTPuYFbqvrR4vpJ1BDdTlthFgvHt5kEdnd1+pdvwWphWn57/oIl4V72NMmOocFqqJ8mFFhA==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/conventional-commits-parser/-/conventional-commits-parser-3.2.0.tgz#9e261b139ca4b7b29bcebbc54460da36894004ca"
+  integrity sha512-XmJiXPxsF0JhAKyfA2Nn+rZwYKJ60nanlbSWwwkGwLQFbugsc0gv1rzc7VbbUWAzJfR1qR87/pNgv9NgmxtBMQ==
   dependencies:
     JSONStream "^1.0.4"
     is-text-path "^1.0.1"
     lodash "^4.17.15"
-    meow "^7.0.0"
+    meow "^8.0.0"
     split2 "^2.0.0"
-    through2 "^3.0.0"
+    through2 "^4.0.0"
     trim-off-newlines "^1.0.0"
 
 conventional-recommended-bump@^5.0.0:
@@ -4284,12 +4065,12 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-js-compat@^3.6.2:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.6.5.tgz#2a51d9a4e25dfd6e690251aa81f99e3c05481f1c"
-  integrity sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==
+core-js-compat@^3.7.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.8.0.tgz#3248c6826f4006793bd637db608bca6e4cd688b1"
+  integrity sha512-o9QKelQSxQMYWHXc/Gc4L8bx/4F7TTraE5rhuN8I7mKBt5dBIUpXpIR3omv70ebr8ST5R3PqbDQr+ZI3+Tt1FQ==
   dependencies:
-    browserslist "^4.8.5"
+    browserslist "^4.14.7"
     semver "7.0.0"
 
 core-js-pure@^3.0.0:
@@ -4298,9 +4079,9 @@ core-js-pure@^3.0.0:
   integrity sha512-fRjhg3NeouotRoIV0L1FdchA6CK7ZD+lyINyMoz19SyV+ROpC4noS1xItWHFtwZdlqfMfVPJEyEGdfri2bD1pA==
 
 core-js@^2.0.0, core-js@^2.4.0, core-js@^2.6.5:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
-  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
+  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -4472,18 +4253,18 @@ css-tree@1.0.0-alpha.37:
     mdn-data "2.0.4"
     source-map "^0.6.1"
 
-css-tree@1.0.0-alpha.39:
-  version "1.0.0-alpha.39"
-  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha.39.tgz#2bff3ffe1bb3f776cf7eefd91ee5cba77a149eeb"
-  integrity sha512-7UvkEYgBAHRG9Nt980lYxjsTrCyHFN53ky3wVsDkiMdVqylqRt+Zc+jm5qw7/qyOvN2dHSYtX0e4MbCCExSvnA==
+css-tree@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.1.2.tgz#9ae393b5dafd7dae8a622475caec78d3d8fbd7b5"
+  integrity sha512-wCoWush5Aeo48GLhfHPbmvZs59Z+M7k5+B1xDnXbdWNcEF423DoFdqSWE0PM5aNk5nI5cp1q7ms36zGApY/sKQ==
   dependencies:
-    mdn-data "2.0.6"
+    mdn-data "2.0.14"
     source-map "^0.6.1"
 
 css-what@^3.2.1:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.3.0.tgz#10fec696a9ece2e591ac772d759aacabac38cd39"
-  integrity sha512-pv9JPyatiPaQ6pf4OvD/dbfm0o5LviWmwxNWzblYf/1u9QZd0ihV+PMwy5jdQWQ3349kZmKEx9WXuSka2dM4cg==
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.4.2.tgz#ea7026fcb01777edbde52124e21f327e7ae950e4"
+  integrity sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -4559,11 +4340,11 @@ cssnano@^4.0.0, cssnano@^4.1.10:
     postcss "^7.0.0"
 
 csso@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/csso/-/csso-4.0.3.tgz#0d9985dc852c7cc2b2cacfbbe1079014d1a8e903"
-  integrity sha512-NL3spysxUkcrOgnpsT4Xdl2aiEiBG6bXswAABQVHcMrfjjBisFOKwLDOmf4wf32aPdcJws1zds2B0Rg+jqMyHQ==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/csso/-/csso-4.2.0.tgz#ea3a561346e8dc9f546d6febedd50187cf389529"
+  integrity sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==
   dependencies:
-    css-tree "1.0.0-alpha.39"
+    css-tree "^1.1.2"
 
 cssom@0.3.x, cssom@^0.3.4:
   version "0.3.8"
@@ -4578,9 +4359,9 @@ cssstyle@^1.1.1:
     cssom "0.3.x"
 
 csstype@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.3.tgz#2b410bbeba38ba9633353aff34b05d9755d065f8"
-  integrity sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.5.tgz#7fdec6a28a67ae18647c51668a9ff95bb2fa7bb8"
+  integrity sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ==
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -4647,9 +4428,9 @@ dateformat@^3.0.0:
   integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
 
 deasync@^0.1.14:
-  version "0.1.20"
-  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.20.tgz#546fd2660688a1eeed55edce2308c5cf7104f9da"
-  integrity sha512-E1GI7jMI57hL30OX6Ht/hfQU8DO4AuB9m72WFm4c38GNbUD4Q03//XZaOIHZiY+H1xUaomcot5yk2q/qIZQkGQ==
+  version "0.1.21"
+  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.21.tgz#bb11eabd4466c0d8776f0d82deb8a6126460d30f"
+  integrity sha512-kUmM8Y+PZpMpQ+B4AuOW9k2Pfx/mSupJtxOsLzmnHY2WqZUYRFccFn2RhzPAqt3Xb+sorK/badW2D4zNzqZz5w==
   dependencies:
     bindings "^1.5.0"
     node-addon-api "^1.7.1"
@@ -4669,20 +4450,13 @@ debug@3.1.0:
     ms "2.0.0"
 
 debug@^3.1.0, debug@^3.1.1:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.2.0:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -4770,7 +4544,7 @@ defer-to-connect@^1.0.1:
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"
   integrity sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==
 
-define-properties@^1.1.2, define-properties@^1.1.3:
+define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
@@ -4970,9 +4744,9 @@ domelementtype@1, domelementtype@^1.3.1:
   integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
 
 domelementtype@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
-  integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.1.0.tgz#a851c080a6d1c3d94344aed151d99f669edf585e"
+  integrity sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==
 
 domexception@^1.0.1:
   version "1.0.1"
@@ -5004,9 +4778,9 @@ dot-prop@^4.2.0:
     is-obj "^1.0.0"
 
 dot-prop@^5.1.0, dot-prop@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.2.0.tgz#c34ecc29556dc45f1f4c22697b6f4904e0cc4fcb"
-  integrity sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
+  integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
   dependencies:
     is-obj "^2.0.0"
 
@@ -5070,10 +4844,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.523:
-  version "1.3.557"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.557.tgz#00cafeed4397a6a9d1036911e434bc7404dc5e7c"
-  integrity sha512-M2p3nWulBqSEIisykYUVYnaSuRikHvxv8Wf209/Vg/sjrOew12hBQv2JvNGy+i+eDeJU9uQ3dbUbCCQ/CkudEg==
+electron-to-chromium@^1.3.612:
+  version "1.3.615"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.615.tgz#50f523be4a04449410e9f3a694490814e602cd54"
+  integrity sha512-fNYTQXoUhNc6RmHDlGN4dgcLURSBIqQCN7ls6MuQ741+NJyLNRz8DxAC+pZpOKfRs6cfY0lv2kWdy8Oxf9j4+A==
 
 elliptic@^6.5.3:
   version "6.5.3"
@@ -5155,9 +4929,9 @@ entities@^1.1.1, entities@^1.1.2:
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
 entities@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
-  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
+  integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
 
 env-paths@^2.2.0:
   version "2.2.0"
@@ -5193,20 +4967,20 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.17.5:
-  version "1.17.6"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.6.tgz#9142071707857b2cacc7b89ecb670316c3e2d52a"
-  integrity sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==
+es-abstract@^1.17.0-next.1, es-abstract@^1.17.2:
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.7.tgz#a4de61b2f66989fc7421676c1cb9787573ace54c"
+  integrity sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==
   dependencies:
     es-to-primitive "^1.2.1"
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
-    is-callable "^1.2.0"
-    is-regex "^1.1.0"
-    object-inspect "^1.7.0"
+    is-callable "^1.2.2"
+    is-regex "^1.1.1"
+    object-inspect "^1.8.0"
     object-keys "^1.1.1"
-    object.assign "^4.1.0"
+    object.assign "^4.1.1"
     string.prototype.trimend "^1.0.1"
     string.prototype.trimstart "^1.0.1"
 
@@ -5253,11 +5027,6 @@ es6-promisify@^5.0.0:
   integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
   dependencies:
     es6-promise "^4.0.3"
-
-escalade@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.0.2.tgz#6a580d70edb87880f22b4c91d0d56078df6962c4"
-  integrity sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ==
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -5313,16 +5082,7 @@ escodegen@~1.9.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-airbnb-base@^14.0.0:
-  version "14.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.0.tgz#fe89c24b3f9dc8008c9c0d0d88c28f95ed65e9c4"
-  integrity sha512-Snswd5oC6nJaevs3nZoLSTvGJBvzTfnBqOIArkf3cbyTyq9UD79wOk8s+RiL6bhca0p/eRO6veczhf6A/7Jy8Q==
-  dependencies:
-    confusing-browser-globals "^1.0.9"
-    object.assign "^4.1.0"
-    object.entries "^1.1.2"
-
-eslint-config-airbnb-base@^14.2.1:
+eslint-config-airbnb-base@^14.0.0, eslint-config-airbnb-base@^14.2.1:
   version "14.2.1"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz#8a2eb38455dc5a312550193b319cdaeef042cd1e"
   integrity sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==
@@ -5346,13 +5106,13 @@ eslint-config-jessie@^0.0.4:
   integrity sha512-jmWq+A7iAKev6nfqpQj/HqC+SMqje7r1HzXqqbInzKOO1OEd9b9MtLJaIe1VpqftS5kDztSubSc9ygzUZCgGaA==
 
 eslint-config-prettier@^6.9.0:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz#f6d2238c1290d01c859a8b5c1f7d352a0b0da8b1"
-  integrity sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz#7f93f6cb7d45a92f1537a70ecc06366e1ac6fed9"
+  integrity sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-import-resolver-node@^0.3.3, eslint-import-resolver-node@^0.3.4:
+eslint-import-resolver-node@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz#85ffa81942c25012d8231096ddf679c03042c717"
   integrity sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==
@@ -5376,26 +5136,7 @@ eslint-plugin-eslint-comments@^3.1.2:
     escape-string-regexp "^1.0.5"
     ignore "^5.0.5"
 
-eslint-plugin-import@^2.19.1:
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz#92f7736fe1fde3e2de77623c838dd992ff5ffb7e"
-  integrity sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==
-  dependencies:
-    array-includes "^3.1.1"
-    array.prototype.flat "^1.2.3"
-    contains-path "^0.1.0"
-    debug "^2.6.9"
-    doctrine "1.5.0"
-    eslint-import-resolver-node "^0.3.3"
-    eslint-module-utils "^2.6.0"
-    has "^1.0.3"
-    minimatch "^3.0.4"
-    object.values "^1.1.1"
-    read-pkg-up "^2.0.0"
-    resolve "^1.17.0"
-    tsconfig-paths "^3.9.0"
-
-eslint-plugin-import@^2.20.0:
+eslint-plugin-import@^2.19.1, eslint-plugin-import@^2.20.0:
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz#0896c7e6a0cf44109a2d97b95903c2bb689d7702"
   integrity sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==
@@ -5445,9 +5186,9 @@ eslint-plugin-jsx-a11y@^6.2.3:
     language-tags "^1.0.5"
 
 eslint-plugin-prettier@^3.1.2:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.4.tgz#168ab43154e2ea57db992a2cd097c828171f75c2"
-  integrity sha512-jZDa8z76klRqo+TdGDTFJSavwbnWK2ZpqGKNZ+VvweMW516pDUMmQ2koXvxEE4JhzNvTv+radye/bWGBmA6jmg==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.2.0.tgz#af391b2226fa0e15c96f36c733f6e9035dbd952c"
+  integrity sha512-kOUSJnFjAUFKwVxuzy6sA5yyMx6+o9ino4gCdShzBNx4eyFRudWRYKCFolKjoM40PEiuU6Cn7wBLfq3WsGg7qg==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
@@ -5482,11 +5223,11 @@ eslint-scope@^4.0.3:
     estraverse "^4.1.1"
 
 eslint-scope@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.0.tgz#d0f971dfe59c69e0cada684b23d49dbf82600ce5"
-  integrity sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
   dependencies:
-    esrecurse "^4.1.0"
+    esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
 eslint-utils@^1.4.3:
@@ -5597,7 +5338,7 @@ esquery@^1.0.1:
   dependencies:
     estraverse "^5.1.0"
 
-esrecurse@^4.1.0:
+esrecurse@^4.1.0, esrecurse@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
   integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
@@ -5969,17 +5710,17 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-parser@^0.132.0:
-  version "0.132.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.132.0.tgz#68c9aea4cfd84577337559a6f121ef3ab687a251"
-  integrity sha512-y1P37zDCPSdphlk+w+roCqcOar6iQdNaAJldJ6xx5/2r4ZRv4KHO+qL+AXwPWp+34eN+oPxPjWnU7GybJnyISQ==
+flow-parser@^0.138.0:
+  version "0.138.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.138.0.tgz#2d9818f6b804d66f90949dfa8b4892f3a0af546d"
+  integrity sha512-LFnTyjrv39UvCWl8NOcpByr/amj8a5k5z7isO2wv4T43nNrUnHQwX3rarTz9zcpHXkDAQv6X4MfQ4ZzJUptpbw==
 
 flow-remove-types@^2.112.0:
-  version "2.132.0"
-  resolved "https://registry.yarnpkg.com/flow-remove-types/-/flow-remove-types-2.132.0.tgz#7adc416336f96eb00a8603df4aef919e8b648e28"
-  integrity sha512-J1EfutfdC68xEZ8i44Hdlaa3MnONuQQB4/+wtnw/ontdcwuz/yGAVQ/O35dFIqNaQoCUWNDN1mHHagbRYLfihQ==
+  version "2.138.0"
+  resolved "https://registry.yarnpkg.com/flow-remove-types/-/flow-remove-types-2.138.0.tgz#afa56af28d4a53440fed34a4b00360d6653f17f7"
+  integrity sha512-gWZYpCAcpX5SD7j1S5DrWLWm+ir5LXkkRTrCokTdO5aW6M1cqQmHN5lxwoQTqkP8PfgXI8ILD810TL9CvexpgA==
   dependencies:
-    flow-parser "^0.132.0"
+    flow-parser "^0.138.0"
     pirates "^3.0.2"
     vlq "^0.2.1"
 
@@ -6148,9 +5889,9 @@ genfun@^5.0.0:
   integrity sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA==
 
 gensync@^1.0.0-beta.1:
-  version "1.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
-  integrity sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
+  integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
 get-assigned-identifiers@^1.2.0:
   version "1.2.0"
@@ -6162,7 +5903,7 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.0.0:
+get-intrinsic@^1.0.0, get-intrinsic@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.0.1.tgz#94a9768fcbdd0595a1c9273aacf4c89d075631be"
   integrity sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==
@@ -6264,9 +6005,9 @@ git-up@^4.0.0:
     parse-url "^5.0.0"
 
 git-url-parse@^11.1.2:
-  version "11.1.3"
-  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.1.3.tgz#03625b6fc09905e9ad1da7bb2b84be1bf9123143"
-  integrity sha512-GPsfwticcu52WQ+eHp0IYkAyaOASgYdtsQDIt4rUp6GbiNt1P9ddrh3O0kQB0eD4UJZszVqNT3+9Zwcg40fywA==
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/git-url-parse/-/git-url-parse-11.4.0.tgz#f2bb1f2b00f05552540e95a62e31399a639a6aa6"
+  integrity sha512-KlIa5jvMYLjXMQXkqpFzobsyD/V2K5DRHl5OAf+6oDFPlPLxrGDVQlIdI63c4/Kt6kai4kALENSALlzTGST3GQ==
   dependencies:
     git-up "^4.0.0"
 
@@ -6492,7 +6233,7 @@ has-glob@^1.0.0:
   dependencies:
     is-glob "^3.0.0"
 
-has-symbols@^1.0.0, has-symbols@^1.0.1:
+has-symbols@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
@@ -6608,6 +6349,13 @@ hosted-git-info@^2.1.4, hosted-git-info@^2.7.1:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
   integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
 
+hosted-git-info@^3.0.6:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-3.0.7.tgz#a30727385ea85acfcee94e0aad9e368c792e036c"
+  integrity sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
 hsl-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hsl-regex/-/hsl-regex-1.0.0.tgz#d49330c789ed819e276a4c0d272dffa30b18fe6e"
@@ -6646,17 +6394,19 @@ htmlescape@^1.1.0:
   integrity sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=
 
 htmlnano@^0.2.2:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/htmlnano/-/htmlnano-0.2.6.tgz#d36e39729faa1dd5f8709d8963c67c7502e578b1"
-  integrity sha512-HUY/99maFsWX2LRoGJpZ/8QRLCkyY0UU1El3wgLLFAHQlD3mCxCJJNcWJk5SBqaU49MLhIWVDW6cGBeuemvaPQ==
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/htmlnano/-/htmlnano-0.2.8.tgz#d9c22daa18c8ea7675a0bf07cc904793ccaeb56f"
+  integrity sha512-q5gbo4SIDAE5sfJ5V0UD6uu+n1dcO/Mpr0B6SlDlJBoV7xKPne4uG4UwrT8vUWjdjIPJl95TY8EDuEbBW2TG0A==
   dependencies:
     cssnano "^4.1.10"
-    normalize-html-whitespace "^1.0.0"
-    posthtml "^0.13.1"
-    posthtml-render "^1.2.2"
+    posthtml "^0.13.4"
+    posthtml-render "^1.3.0"
     purgecss "^2.3.0"
+    relateurl "^0.2.7"
+    srcset "^3.0.0"
     svgo "^1.3.2"
     terser "^4.8.0"
+    timsort "^0.3.0"
     uncss "^0.17.3"
 
 htmlparser2@^3.9.2:
@@ -6774,9 +6524,9 @@ icss-replace-symbols@1.1.0, icss-replace-symbols@^1.1.0:
   integrity sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=
 
 ieee754@^1.1.4:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
-  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 iferr@^0.1.5:
   version "0.1.5"
@@ -6819,9 +6569,9 @@ import-fresh@^2.0.0:
     resolve-from "^3.0.0"
 
 import-fresh@^3.0.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
-  integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.2.tgz#fc129c160c5d68235507f4331a6baad186bdbc3e"
+  integrity sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
@@ -6965,9 +6715,9 @@ inline-source-map@~0.6.0:
     source-map "~0.5.3"
 
 inquirer-autocomplete-prompt@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/inquirer-autocomplete-prompt/-/inquirer-autocomplete-prompt-1.1.0.tgz#e7745b49122e56b483659c91328a2c3fca33ffd6"
-  integrity sha512-mrSeUSFGnTSid/DCKG+E+IcN4MaOnT2bW7NuSagZAguD4k3hZ0UladdYNP4EstZOwgeqv0C3M1zYa1QIIf0Oyg==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/inquirer-autocomplete-prompt/-/inquirer-autocomplete-prompt-1.3.0.tgz#fcbba926be2d3cf338e3dd24380ae7c408113b46"
+  integrity sha512-zvAc+A6SZdcN+earG5SsBu1RnQdtBS4o8wZ/OqJiCfL34cfOx+twVRq7wumYix6Rkdjn1N2nVCcO3wHqKqgdGg==
   dependencies:
     ansi-escapes "^4.3.1"
     chalk "^4.0.0"
@@ -7014,9 +6764,9 @@ inquirer@^7.0.0:
     through "^2.3.6"
 
 insert-module-globals@^7.0.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/insert-module-globals/-/insert-module-globals-7.2.0.tgz#ec87e5b42728479e327bd5c5c71611ddfb4752ba"
-  integrity sha512-VE6NlW+WGn2/AeOMd496AHFYmE7eLKkUY6Ty31k4og5vmA3Fjuwe9v6ifH6Xx/Hz27QvdoMoviw1/pqWRB09Sw==
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/insert-module-globals/-/insert-module-globals-7.2.1.tgz#d5e33185181a4e1f33b15f7bf100ee91890d5cb3"
+  integrity sha512-ufS5Qq9RZN+Bu899eA9QCAYThY+gGW7oRkmb0vC93Vlyu/CFGcH0OYPEjVkDXA5FEbTt1+VWzdoOD3Ny9N+8tg==
   dependencies:
     JSONStream "^1.0.3"
     acorn-node "^1.5.2"
@@ -7042,13 +6792,6 @@ interpret@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
-
-invariant@^2.2.2, invariant@^2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
-  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
-  dependencies:
-    loose-envify "^1.0.0"
 
 ip@1.1.5:
   version "1.1.5"
@@ -7118,12 +6861,7 @@ is-buffer@^1.1.0, is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
-  integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
-
-is-callable@^1.2.2:
+is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.2.tgz#c7c6715cd22d4ddb48d3e19970223aceabb080d9"
   integrity sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==
@@ -7338,11 +7076,6 @@ is-plain-object@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-3.0.1.tgz#662d92d24c0aa4302407b0d45d21f2251c85f85b"
   integrity sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==
 
-is-plain-object@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-4.1.1.tgz#1a14d6452cbd50790edc7fdaa0aed5a40a35ebb5"
-  integrity sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==
-
 is-plain-object@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
@@ -7365,7 +7098,7 @@ is-reference@^1.1.2:
   dependencies:
     "@types/estree" "*"
 
-is-regex@^1.0.4, is-regex@^1.1.0, is-regex@^1.1.1:
+is-regex@^1.0.4, is-regex@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
   integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
@@ -7658,9 +7391,9 @@ json-parse-better-errors@^1.0.0, json-parse-better-errors@^1.0.1, json-parse-bet
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
 json-parse-even-better-errors@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.0.tgz#371873c5ffa44304a6ba12419bcfa95f404ae081"
-  integrity sha512-o3aP+RsWDJZayj1SbHNQAI8x0v3T3SKiGoZlNYfbUP1S3omJQ6i9CnqADqkSPaOAxwua4/1YWx5CM7oiChJt2Q==
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
+  integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -7739,9 +7472,9 @@ jsprim@^1.2.2:
     object.assign "^4.1.1"
 
 just-extend@^4.0.2:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.1.0.tgz#7278a4027d889601640ee0ce0e5a00b992467da4"
-  integrity sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.1.1.tgz#158f1fdb01f128c411dc8b286a7b4837b3545282"
+  integrity sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==
 
 keyv@^3.0.0:
   version "3.1.0"
@@ -7845,18 +7578,6 @@ lerna@^3.19.0:
     "@lerna/version" "3.22.1"
     import-local "^2.0.0"
     npmlog "^4.1.2"
-
-leven@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
-  integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
-
-levenary@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/levenary/-/levenary-1.1.1.tgz#842a9ee98d2075aa7faeedbe32679e9205f46f77"
-  integrity sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==
-  dependencies:
-    leven "^3.1.0"
 
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
@@ -8075,7 +7796,7 @@ lolex@^5.0.1, lolex@^5.1.2:
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -8114,6 +7835,13 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
 
 macos-release@^2.2.0:
   version "2.4.1"
@@ -8259,15 +7987,15 @@ md5.js@^1.3.4:
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
 
+mdn-data@2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
+  integrity sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==
+
 mdn-data@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.4.tgz#699b3c38ac6f1d728091a64650b65d388502fd5b"
   integrity sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==
-
-mdn-data@2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.6.tgz#852dc60fcaa5daa2e8cf6c9189c440ed3e042978"
-  integrity sha512-rQvjv71olwNHgiTbfPZFkJtjNMciWgswYeciZhtvWLO8bmX3TnhyA62I6sTWOyZssWHJJjY6/KiWwqQsWWsqOA==
 
 mem@^6.1.1:
   version "6.1.1"
@@ -8324,22 +8052,22 @@ meow@^4.0.0:
     redent "^2.0.0"
     trim-newlines "^2.0.0"
 
-meow@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/meow/-/meow-7.1.1.tgz#7c01595e3d337fcb0ec4e8eed1666ea95903d306"
-  integrity sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==
+meow@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-8.0.0.tgz#1aa10ee61046719e334ffdc038bb5069250ec99a"
+  integrity sha512-nbsTRz2fwniJBFgUkcdISq8y/q9n9VbiHYbfwklFh5V4V2uAcxtKQkDc0yCLPM/kP0d+inZBewn3zJqewHE7kg==
   dependencies:
     "@types/minimist" "^1.2.0"
     camelcase-keys "^6.2.2"
     decamelize-keys "^1.1.0"
     hard-rejection "^2.1.0"
     minimist-options "4.1.0"
-    normalize-package-data "^2.5.0"
+    normalize-package-data "^3.0.0"
     read-pkg-up "^7.0.1"
     redent "^3.0.0"
     trim-newlines "^3.0.0"
-    type-fest "^0.13.1"
-    yargs-parser "^18.1.3"
+    type-fest "^0.18.0"
+    yargs-parser "^20.2.3"
 
 merge-source-map@1.0.4:
   version "1.0.4"
@@ -8639,9 +8367,9 @@ mz@^2.5.0:
     thenify-all "^1.0.0"
 
 nan@^2.12.1:
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
-  integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
+  integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -8706,7 +8434,7 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@^2.3.0, node-fetch@^2.5.0:
+node-fetch@^2.5.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -8767,10 +8495,10 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-releases@^1.1.60:
-  version "1.1.60"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.60.tgz#6948bdfce8286f0b5d0e5a88e8384e954dfe7084"
-  integrity sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA==
+node-releases@^1.1.67:
+  version "1.1.67"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.67.tgz#28ebfcccd0baa6aad8e8d4d8fe4cbc49ae239c12"
+  integrity sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==
 
 nopt@^4.0.1:
   version "4.0.3"
@@ -8780,11 +8508,6 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
-normalize-html-whitespace@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-html-whitespace/-/normalize-html-whitespace-1.0.0.tgz#5e3c8e192f1b06c3b9eee4b7e7f28854c7601e34"
-  integrity sha512-9ui7CGtOOlehQu0t/OhhlmDyc71mKVlv+4vF+me4iZLPrNtRL2xoquEdfZxasC/bdQi/Hr3iTrpyRKIG+ocabA==
-
 normalize-package-data@^2.0.0, normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5, normalize-package-data@^2.4.0, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -8793,6 +8516,16 @@ normalize-package-data@^2.0.0, normalize-package-data@^2.3.0, normalize-package-
     hosted-git-info "^2.1.4"
     resolve "^1.10.0"
     semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+
+normalize-package-data@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-3.0.0.tgz#1f8a7c423b3d2e85eb36985eaf81de381d01301a"
+  integrity sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==
+  dependencies:
+    hosted-git-info "^3.0.6"
+    resolve "^1.17.0"
+    semver "^7.3.2"
     validate-npm-package-license "^3.0.1"
 
 normalize-path@^2.1.1:
@@ -8955,11 +8688,6 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
-  integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
-
 object-inspect@^1.8.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a"
@@ -8976,14 +8704,14 @@ object-inspect@~1.7.0:
   integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
 
 object-is@^1.0.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.2.tgz#c5d2e87ff9e119f78b7a088441519e2eec1573b6"
-  integrity sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.4.tgz#63d6c83c00a43f4cbc9434eb9757c8a5b8565068"
+  integrity sha512-1ZvAZ4wlF7IyPVOcE1Omikt7UpaFlOQq0HlSti+ZvDH3UiD2brwGMwDbyV43jao2bKJ+4+WdPJHSd7kgzKYVqg==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.5"
 
-object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.0.6, object-keys@^1.1.1:
+object-keys@^1.0.12, object-keys@^1.0.6, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -8995,17 +8723,7 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
-  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
-  dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.1.1"
-    has-symbols "^1.0.0"
-    object-keys "^1.0.11"
-
-object.assign@^4.1.1, object.assign@^4.1.2:
+object.assign@^4.1.0, object.assign@^4.1.1, object.assign@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
   integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
@@ -9016,12 +8734,13 @@ object.assign@^4.1.1, object.assign@^4.1.2:
     object-keys "^1.1.1"
 
 object.entries@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.2.tgz#bc73f00acb6b6bb16c203434b10f9a7e797d3add"
-  integrity sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.3.tgz#c601c7f168b62374541a07ddbd3e2d5e4f7711a6"
+  integrity sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.5"
+    es-abstract "^1.18.0-next.1"
     has "^1.0.3"
 
 object.fromentries@^2.0.2:
@@ -9035,12 +8754,13 @@ object.fromentries@^2.0.2:
     has "^1.0.3"
 
 object.getownpropertydescriptors@^2.0.3, object.getownpropertydescriptors@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz#369bf1f9592d8ab89d712dced5cb81c7c5352649"
-  integrity sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.1.tgz#0dfda8d108074d9c563e80490c883b6661091544"
+  integrity sha512-6DtXgZ/lIZ9hqx4GtZETobXLR/ZLaa0aqV0kzbn80Rf8Z2e/XFnhA0I7p07N2wH8bBBltr2xQPi6sbKWAY2Eng==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
+    es-abstract "^1.18.0-next.1"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -9050,13 +8770,13 @@ object.pick@^1.3.0:
     isobject "^3.0.1"
 
 object.values@^1.1.0, object.values@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.1.tgz#68a99ecde356b7e9295a3c5e0ce31dc8c953de5e"
-  integrity sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.2.tgz#7a2015e06fcb0f546bd652486ce8583a4731c731"
+  integrity sha512-MYC0jvJopr8EK6dPBiO8Nb9mvjdypOachO5REGk6MXzujbBrAisKo3HmdEI6kZDL6fC31Mwee/5YbtMebixeag==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    function-bind "^1.1.1"
+    es-abstract "^1.18.0-next.1"
     has "^1.0.3"
 
 octokit-pagination-methods@^1.1.0:
@@ -9717,9 +9437,9 @@ posix-character-classes@^0.1.0:
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
 postcss-calc@^7.0.1:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-7.0.4.tgz#5e177ddb417341e6d4a193c5d9fd8ada79094f8b"
-  integrity sha512-0I79VRAd1UTkaHzY9w83P39YGO/M3bG7/tNLrHGEunBolfoGM0hSjrGvjoeaj0JE/zIw5GsI2KZ0UwDJqv5hjw==
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-7.0.5.tgz#f8a6e99f12e619c2ebc23cf6c486fdc15860933e"
+  integrity sha512-1tKHutbGtLtEZF6PT4JSihCHfIVldU72mZ8SdZHIYriIZ9fh9k9aWSppaT8rHsyI3dX+KSR+W+Ix9BMY3AODrg==
   dependencies:
     postcss "^7.0.27"
     postcss-selector-parser "^6.0.2"
@@ -9975,7 +9695,7 @@ postcss-reduce-transforms@^4.0.2:
     postcss "^7.0.0"
     postcss-value-parser "^3.0.0"
 
-postcss-selector-parser@6.0.2, postcss-selector-parser@^6.0.2:
+postcss-selector-parser@6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz#934cf799d016c83411859e09dcecade01286ec5c"
   integrity sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==
@@ -9992,6 +9712,16 @@ postcss-selector-parser@^3.0.0:
     dot-prop "^5.2.0"
     indexes-of "^1.0.1"
     uniq "^1.0.1"
+
+postcss-selector-parser@^6.0.2:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz#56075a1380a04604c38b063ea7767a129af5c2b3"
+  integrity sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==
+  dependencies:
+    cssesc "^3.0.0"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+    util-deprecate "^1.0.2"
 
 postcss-svgo@^4.0.2:
   version "4.0.2"
@@ -10031,7 +9761,7 @@ postcss@6.0.1:
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@7.0.32, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.11, postcss@^7.0.17, postcss@^7.0.27:
+postcss@7.0.32:
   version "7.0.32"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.32.tgz#4310d6ee347053da3433db2be492883d62cec59d"
   integrity sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==
@@ -10049,6 +9779,15 @@ postcss@^6.0.1:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
+postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.11, postcss@^7.0.17, postcss@^7.0.27:
+  version "7.0.35"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.35.tgz#d2be00b998f7f211d8a276974079f2e92b970e24"
+  integrity sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
 posthtml-parser@^0.4.0, posthtml-parser@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/posthtml-parser/-/posthtml-parser-0.4.2.tgz#a132bbdf0cd4bc199d34f322f5c1599385d7c6c1"
@@ -10057,16 +9796,16 @@ posthtml-parser@^0.4.0, posthtml-parser@^0.4.1:
     htmlparser2 "^3.9.2"
 
 posthtml-parser@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/posthtml-parser/-/posthtml-parser-0.5.0.tgz#571058a3b63c1704964ffc25bbe69ffda213244e"
-  integrity sha512-BsZFAqOeX9lkJJPKG2JmGgtm6t++WibU7FeS40FNNGZ1KS2szRSRQ8Wr2JLvikDgAecrQ/9V4sjugTAin2+KVw==
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/posthtml-parser/-/posthtml-parser-0.5.3.tgz#e95b92e57d98da50b443e116fcee39466cd9012e"
+  integrity sha512-uHosRn0y+1wbnlYKrqMjBPoo/kK5LPYImLtiETszNFYfFwAD3cQdD1R2E13Mh5icBxkHj+yKtlIHozCsmVWD/Q==
   dependencies:
     htmlparser2 "^3.9.2"
 
-posthtml-render@^1.1.3, posthtml-render@^1.1.5, posthtml-render@^1.2.2, posthtml-render@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/posthtml-render/-/posthtml-render-1.2.3.tgz#da1cf7ba4efb42cfe9c077f4f41669745de99b6d"
-  integrity sha512-rGGayND//VwTlsYKNqdILsA7U/XP0WJa6SMcdAEoqc2WRM5QExplGg/h9qbTuHz7mc2PvaXU+6iNxItvr5aHMg==
+posthtml-render@^1.1.3, posthtml-render@^1.1.5, posthtml-render@^1.2.3, posthtml-render@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/posthtml-render/-/posthtml-render-1.4.0.tgz#40114070c45881cacb93347dae3eff53afbcff13"
+  integrity sha512-W1779iVHGfq0Fvh2PROhCe2QhB8mEErgqzo1wpIt36tCgChafP+hbXIhLDOM8ePJrZcFs0vkNEtdibEWVqChqw==
 
 posthtml@^0.11.2:
   version "0.11.6"
@@ -10076,10 +9815,10 @@ posthtml@^0.11.2:
     posthtml-parser "^0.4.1"
     posthtml-render "^1.1.5"
 
-posthtml@^0.13.1:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/posthtml/-/posthtml-0.13.3.tgz#9702d745108d532a9d5808985e0dafd81b09f7bd"
-  integrity sha512-5NL2bBc4ihAyoYnY0EAQrFQbJNE1UdvgC1wjYts0hph7jYeU2fa5ki3/9U45ce9V6M1vLMEgUX2NXe/bYL+bCQ==
+posthtml@^0.13.4:
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/posthtml/-/posthtml-0.13.4.tgz#ad81b3fa62b85f81ccdb5710f4ec375a4ed94934"
+  integrity sha512-i2oTo/+dwXGC6zaAQSF6WZEQSbEqu10hsvg01DWzGAfZmy31Iiy9ktPh9nnXDfZiYytjxTIvxoK4TI0uk4QWpw==
   dependencies:
     posthtml-parser "^0.5.0"
     posthtml-render "^1.2.3"
@@ -10372,9 +10111,9 @@ react-reconciler@^0.24.0:
     scheduler "^0.18.0"
 
 react@^16.12.0:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
-  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
+  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -10511,7 +10250,7 @@ read@1, read@~1.0.1:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-"readable-stream@2 || 3", readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.6.0:
+"readable-stream@2 || 3", readable-stream@3, readable-stream@^3.0.2, readable-stream@^3.1.1, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -10538,13 +10277,6 @@ readdirp@^2.2.1:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
-
-readdirp@~3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.4.0.tgz#9fdccdf9e9155805449221ac645e8303ab5b9ada"
-  integrity sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==
-  dependencies:
-    picomatch "^2.2.1"
 
 readdirp@~3.5.0:
   version "3.5.0"
@@ -10592,9 +10324,9 @@ regenerate-unicode-properties@^8.2.0:
     regenerate "^1.4.0"
 
 regenerate@^1.4.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.1.tgz#cad92ad8e6b591773485fbe05a485caf4f457e6f"
-  integrity sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
+  integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"
@@ -10634,10 +10366,10 @@ regexpp@^2.0.1:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
-regexpu-core@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.7.0.tgz#fcbf458c50431b0bb7b45d6967b8192d91f3d938"
-  integrity sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==
+regexpu-core@^4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-4.7.1.tgz#2dea5a9a07233298fbf0db91fa9abc4c6e0f8ad6"
+  integrity sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==
   dependencies:
     regenerate "^1.4.0"
     regenerate-unicode-properties "^8.2.0"
@@ -10676,6 +10408,11 @@ regjsparser@^0.6.4:
   integrity sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==
   dependencies:
     jsesc "~0.5.0"
+
+relateurl@^0.2.7:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
+  integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
 
 release-zalgo@^1.0.0:
   version "1.0.0"
@@ -10805,14 +10542,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.4, resolve@^1.1.5, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.4.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
-  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
-  dependencies:
-    path-parse "^1.0.6"
-
-resolve@^1.18.1:
+resolve@^1.1.4, resolve@^1.1.5, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.4.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
   integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
@@ -10938,14 +10668,14 @@ rollup-plugin-replace@^2.1.0:
     rollup-pluginutils "^2.6.0"
 
 rollup-plugin-terser@^5.1.3:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-5.3.0.tgz#9c0dd33d5771df9630cd027d6a2559187f65885e"
-  integrity sha512-XGMJihTIO3eIBsVGq7jiNYOdDMb3pVxuzY0uhOE/FM4x/u9nQgr3+McsjzqBn3QfHIpNSZmFnpoKAwHBEcsT7g==
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-5.3.1.tgz#8c650062c22a8426c64268548957463bf981b413"
+  integrity sha512-1pkwkervMJQGFYvM9nscrUoncPwiKR/K+bHdjv6PFgRo3cgPHoRT83y2Aa3GvINj4539S15t/tpFPb775TDs6w==
   dependencies:
     "@babel/code-frame" "^7.5.5"
     jest-worker "^24.9.0"
     rollup-pluginutils "^2.8.2"
-    serialize-javascript "^2.1.2"
+    serialize-javascript "^4.0.0"
     terser "^4.6.2"
 
 rollup-pluginutils@^2.6.0, rollup-pluginutils@^2.8.1, rollup-pluginutils@^2.8.2:
@@ -10965,9 +10695,9 @@ rollup@1.31.0:
     acorn "^7.1.0"
 
 rollup@^2.0.0:
-  version "2.28.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.28.1.tgz#ceedca3cdb013c2fa8f22f958a29c203368159ea"
-  integrity sha512-DOtVoqOZt3+FjPJWLU8hDIvBjUylc9s6IZvy76XklxzcLvAQLtVAG/bbhsMhcWnYxC0TKKcf1QQ/tg29zeID0Q==
+  version "2.34.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.34.1.tgz#a387230df02c58b242794a213dfb68b42de2c8fb"
+  integrity sha512-tGveB6NU5x4MS/iXaIsjfUkEv4hxzJJ4o0FRy5LO62Ndx3R2cmE1qsLYlSfRkvHUUPqWiFoxEm8pRftzh1a5HA==
   optionalDependencies:
     fsevents "~2.1.2"
 
@@ -10989,9 +10719,9 @@ run-queue@^1.0.0, run-queue@^1.0.3:
     aproba "^1.1.1"
 
 rxjs@^6.4.0, rxjs@^6.6.0, rxjs@^6.6.2:
-  version "6.6.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.2.tgz#8096a7ac03f2cc4fe5860ef6e572810d9e01c0d2"
-  integrity sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
+  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
   dependencies:
     tslib "^1.9.0"
 
@@ -11079,9 +10809,11 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
 semver@^7.3.2:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
-  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+  version "7.3.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.4.tgz#27aaa7d2e4ca76452f98d3add093a72c943edc97"
+  integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.17.1:
   version "0.17.1"
@@ -11106,11 +10838,6 @@ serialize-error@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-2.1.0.tgz#50b679d5635cdf84667bdc8e59af4e5b81d5f60a"
   integrity sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=
-
-serialize-javascript@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
-  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
 
 serialize-javascript@^4.0.0:
   version "4.0.0"
@@ -11423,9 +11150,9 @@ spdx-expression-parse@^3.0.0, spdx-expression-parse@^3.0.1:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
-  integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz#e9c18a410e5ed7e12442a549fbd8afa767038d65"
+  integrity sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
@@ -11452,6 +11179,11 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+srcset@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/srcset/-/srcset-3.0.0.tgz#8afd8b971362dfc129ae9c1a99b3897301ce6441"
+  integrity sha512-D59vF08Qzu/C4GAOXVgMTLfgryt5fyWo93FZyhEWANo0PokFz/iWdDe13mX3O5TRf6l8vMTqckAfR4zPiaH0yQ==
 
 sshpk@^1.7.0:
   version "1.16.1"
@@ -11480,12 +11212,7 @@ stable@^0.1.8:
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
 
-stack-utils@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
-  integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
-
-stack-utils@^1.0.3:
+stack-utils@^1.0.2, stack-utils@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.4.tgz#4b600971dcfc6aed0cbdf2a8268177cc916c87c8"
   integrity sha512-IPDJfugEGbfizBwBZRZ3xpccMdRyP5lqsBWXGQWimVjua/ccLCeMOAVjlc1R7LxFjo5sEDhyNIXd8mo/AiDS9w==
@@ -11659,29 +11386,29 @@ string.prototype.matchall@^4.0.2:
     side-channel "^1.0.3"
 
 string.prototype.trim@~1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz#141233dff32c82bfad80684d7e5f0869ee0fb782"
-  integrity sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.3.tgz#d23a22fde01c1e6571a7fadcb9be11decd8061a7"
+  integrity sha512-16IL9pIBA5asNOSukPfxX2W68BaBvxyiRK16H3RA/lWW9BDosh+w7f+LhomPHpXJ82QEe7w7/rY/S1CV97raLg==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
-    function-bind "^1.1.1"
+    es-abstract "^1.18.0-next.1"
 
 string.prototype.trimend@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
-  integrity sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz#a22bd53cca5c7cf44d7c9d5c732118873d6cd18b"
+  integrity sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.5"
 
 string.prototype.trimstart@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz#14af6d9f34b053f7cfc89b72f8f2ee14b9039a54"
-  integrity sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz#9b4cb590e123bb36564401d59824298de50fd5aa"
+  integrity sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.5"
 
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.3.0"
@@ -12187,6 +11914,13 @@ through2@^3.0.0:
     inherits "^2.0.4"
     readable-stream "2 || 3"
 
+through2@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-4.0.2.tgz#a7ce3ac2a7a8b0b966c80e7c49f0484c3b239764"
+  integrity sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==
+  dependencies:
+    readable-stream "3"
+
 through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@~2.3.4, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -12205,9 +11939,9 @@ timers-browserify@^1.0.1:
     process "~0.11.0"
 
 timers-browserify@^2.0.4:
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.11.tgz#800b1f3eee272e5bc53ee465a04d0e804c31211f"
-  integrity sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.12.tgz#44a45c11fbf407f34f97bccd1577c652361b00ee"
+  integrity sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==
   dependencies:
     setimmediate "^1.0.4"
 
@@ -12360,15 +12094,10 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1:
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^1.9.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
-  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
 tsutils@^3.17.1:
   version "3.17.1"
@@ -12416,10 +12145,10 @@ type-fest@^0.11.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
 
-type-fest@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
-  integrity sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
+type-fest@^0.18.0:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f"
+  integrity sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==
 
 type-fest@^0.3.0:
   version "0.3.1"
@@ -12454,14 +12183,14 @@ typescript@^3.7.2:
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typescript@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
-  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
+  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
 
 uglify-js@^3.1.4:
-  version "3.10.3"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.10.3.tgz#f0d2f99736c14de46d2d24649ba328be3e71c3bf"
-  integrity sha512-Lh00i69Uf6G74mvYpHCI9KVVXLcHW/xu79YTvH7Mkc9zyKUeSPz0owW0dguj0Scavns3ZOh3wY63J0Zb97Za2g==
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.12.1.tgz#78307f539f7b9ca5557babb186ea78ad30cc0375"
+  integrity sha512-o8lHP20KjIiQe5b/67Rh68xEGRrc2SRsCuuoYclXXoC74AfSRGblU1HKzJWH3HxPZ+Ort85fWHpSX7KwBUC9CQ==
 
 uid-number@0.0.6:
   version "0.0.6"
@@ -12682,7 +12411,7 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-util-deprecate@^1.0.1, util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
@@ -12731,9 +12460,9 @@ uuid@^3.0.1, uuid@^3.3.2:
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
 v8-compile-cache@^2.0.0, v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"
-  integrity sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"
+  integrity sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==
 
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3:
   version "3.0.4"
@@ -12790,23 +12519,23 @@ w3c-xmlserializer@^1.1.2:
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
 
-watchpack-chokidar2@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz#9948a1866cbbd6cb824dea13a7ed691f6c8ddff0"
-  integrity sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==
+watchpack-chokidar2@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz#38500072ee6ece66f3769936950ea1771be1c957"
+  integrity sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==
   dependencies:
     chokidar "^2.1.8"
 
 watchpack@^1.7.4:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.4.tgz#6e9da53b3c80bb2d6508188f5b200410866cd30b"
-  integrity sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
+  integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
   optionalDependencies:
     chokidar "^3.4.1"
-    watchpack-chokidar2 "^2.0.0"
+    watchpack-chokidar2 "^2.0.1"
 
 wcwidth@^1.0.0, wcwidth@^1.0.1:
   version "1.0.1"
@@ -12846,9 +12575,9 @@ webpack-sources@^1.4.0, webpack-sources@^1.4.1:
     source-map "~0.6.1"
 
 webpack@^4.29.6:
-  version "4.44.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.44.1.tgz#17e69fff9f321b8f117d1fda714edfc0b939cc21"
-  integrity sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==
+  version "4.44.2"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.44.2.tgz#6bfe2b0af055c8b2d1e90ed2cd9363f841266b72"
+  integrity sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==
   dependencies:
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/helper-module-context" "1.9.0"
@@ -13090,9 +12819,9 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
-  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
+  integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
 
 y18n@^5.0.5:
   version "5.0.5"
@@ -13140,15 +12869,7 @@ yargs-parser@^15.0.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^18.1.3:
-  version "18.1.3"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
-  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^20.2.2:
+yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   version "20.2.4"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
@@ -13213,8 +12934,8 @@ yn@3.1.1:
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yoga-layout-prebuilt@^1.9.3:
-  version "1.9.6"
-  resolved "https://registry.yarnpkg.com/yoga-layout-prebuilt/-/yoga-layout-prebuilt-1.9.6.tgz#98dde95bbf8e6e12835876e9305f1e995c4bb801"
-  integrity sha512-Wursw6uqLXLMjBAO4SEShuzj8+EJXhCF71/rJ7YndHTkRAYSU0GY3OghRqfAk9HPUAAFMuqp3U1Wl+01vmGRQQ==
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/yoga-layout-prebuilt/-/yoga-layout-prebuilt-1.10.0.tgz#2936fbaf4b3628ee0b3e3b1df44936d6c146faa6"
+  integrity sha512-YnOmtSbv4MTf7RGJMK0FvZ+KD8OEe/J5BNnR0GHhD8J/XcG/Qvxgszm0Un6FTHWW4uHlTgP0IztiXQnGyIR45g==
   dependencies:
     "@types/yoga-layout" "1.9.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4322,7 +4322,7 @@ cosmiconfig@^5.0.0, cosmiconfig@^5.1.0:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
-coveralls@^3.0.8:
+coveralls@^3.0.11, coveralls@^3.0.8:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.1.0.tgz#13c754d5e7a2dd8b44fe5269e21ca394fb4d615b"
   integrity sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==
@@ -11485,6 +11485,13 @@ stack-utils@^1.0.2:
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
 
+stack-utils@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.4.tgz#4b600971dcfc6aed0cbdf2a8268177cc916c87c8"
+  integrity sha512-IPDJfugEGbfizBwBZRZ3xpccMdRyP5lqsBWXGQWimVjua/ccLCeMOAVjlc1R7LxFjo5sEDhyNIXd8mo/AiDS9w==
+  dependencies:
+    escape-string-regexp "^2.0.0"
+
 stack-utils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.3.tgz#cd5f030126ff116b78ccb3c027fe302713b61277"
@@ -11960,6 +11967,55 @@ tap@14.10.5:
     yaml "^1.7.2"
     yapool "^1.0.0"
 
+tap@^14.10.5:
+  version "14.11.0"
+  resolved "https://registry.yarnpkg.com/tap/-/tap-14.11.0.tgz#64f1f50b10280d5149690c9a7059d859f2bbcd24"
+  integrity sha512-z8qnNFVyIjLh/bNoTLFRkEk09XZUDAZbCkz/BjvHHly3ao5H+y60gPnedALfheEjA6dA4tpp/mrKq2NWlMuq0A==
+  dependencies:
+    "@types/react" "^16.9.16"
+    async-hook-domain "^1.1.3"
+    bind-obj-methods "^2.0.0"
+    browser-process-hrtime "^1.0.0"
+    chokidar "^3.3.0"
+    color-support "^1.1.0"
+    coveralls "^3.0.11"
+    diff "^4.0.1"
+    esm "^3.2.25"
+    findit "^2.0.0"
+    flow-remove-types "^2.112.0"
+    foreground-child "^1.3.3"
+    fs-exists-cached "^1.0.0"
+    function-loop "^1.0.2"
+    glob "^7.1.6"
+    import-jsx "^3.1.0"
+    ink "^2.6.0"
+    isexe "^2.0.0"
+    istanbul-lib-processinfo "^1.0.0"
+    jackspeak "^1.4.0"
+    minipass "^3.1.1"
+    mkdirp "^0.5.4"
+    nyc "^14.1.1"
+    opener "^1.5.1"
+    own-or "^1.0.0"
+    own-or-env "^1.0.1"
+    react "^16.12.0"
+    rimraf "^2.7.1"
+    signal-exit "^3.0.0"
+    source-map-support "^0.5.16"
+    stack-utils "^1.0.3"
+    tap-mocha-reporter "^5.0.0"
+    tap-parser "^10.0.1"
+    tap-yaml "^1.0.0"
+    tcompare "^3.0.0"
+    treport "^1.0.2"
+    trivial-deferred "^1.0.1"
+    ts-node "^8.5.2"
+    typescript "^3.7.2"
+    which "^2.0.2"
+    write-file-atomic "^3.0.1"
+    yaml "^1.7.2"
+    yapool "^1.0.0"
+
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
@@ -12244,7 +12300,7 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-treport@^1.0.1:
+treport@^1.0.1, treport@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/treport/-/treport-1.0.2.tgz#5f99e68198982984415434a2a84df2af2dd7171d"
   integrity sha512-QCAbFtzIjQN+9k+alo8e6oo8j0eSLsttdahAgNLoC3U36rls8XRy/R11QOhHmPz7CDcB2ar29eLe4OFJoPnsPA==


### PR DESCRIPTION
This a large mostly-mechanical change to converge the SES-shim repository on the dominant single quotes and dangling commas style favored by Agoric SDK. To do this, each package.json needs to adopt a small `prettier` block that must be aligned with the same rules in the `eslint-config` package. Further work to ease incremental re-scaffolding left as a future exercise.

I also used a tool over each of the package.json files that makes them more regular and applies learning better across the packages, making some of them slightly more portable.