### PR TITLE
docs(ses): Adjust error search fragments

### DIFF
--- a/packages/ses/ERRORS.md
+++ b/packages/ses/ERRORS.md
@@ -1,5 +1,5 @@
 
-## SES1: Possible eval expression reject
+## SESERR1: Possible eval expression reject
 
 The SES shim cannot virtualize dynamic eval.
 
@@ -61,7 +61,7 @@ eval(code);
 (0, eval)(code);
 ```
 
-## SES1: Possible import expression rejected
+## SESERR2: Possible import expression rejected
 
 Calling `import` as function, like direct `eval`, is JavaScript syntax
 and doesn't depend on `import` being in the lexical scope.
@@ -101,7 +101,7 @@ also use a comma expression.
 (0, compartment.import)(specifier);
 ```
 
-## SES2: Possible HTML comment rejected
+## SESERR3: Possible HTML comment rejected
 
 When web browsers first introduced `<script>` tags and JavaScript, earlier
 versions of the browser would how the script instead of running it.

--- a/packages/ses/src/transforms.js
+++ b/packages/ses/src/transforms.js
@@ -40,7 +40,7 @@ export function rejectHtmlComments(src) {
   }
   const name = getSourceURL(src);
   throw new SyntaxError(
-    `SES3: Possible HTML comment rejected at ${name}:${lineNumber}`,
+    `Possible HTML comment rejected (SESERR3) at ${name}:${lineNumber}`,
   );
 }
 
@@ -75,7 +75,7 @@ export function rejectImportExpressions(src) {
   }
   const name = getSourceURL(src);
   throw new SyntaxError(
-    `SES2: Possible import expression rejected at ${name}:${lineNumber}`,
+    `Possible import expression rejected (SESERR2) at ${name}:${lineNumber}`,
   );
 }
 
@@ -106,7 +106,7 @@ export function rejectSomeDirectEvalExpressions(src) {
   }
   const name = getSourceURL(src);
   throw new SyntaxError(
-    `SES1: Possible direct eval expression rejected at ${name}:${lineNumber}`,
+    `Possible direct eval expression rejected (SESERR1) at ${name}:${lineNumber}`,
   );
 }
 

--- a/packages/ses/test/reject-direct-eval.test.js
+++ b/packages/ses/test/reject-direct-eval.test.js
@@ -141,7 +141,8 @@ test('reject direct eval expressions with name', t => {
     () => c.evaluate('eval("evil")'),
     {
       name: 'SyntaxError',
-      message: 'SES1: Possible direct eval expression rejected at <unknown>:1',
+      message:
+        'Possible direct eval expression rejected (SESERR1) at <unknown>:1',
     },
     'newline with name',
   );
@@ -154,7 +155,7 @@ test('reject direct eval expressions with name', t => {
     {
       name: 'SyntaxError',
       message:
-        'SES1: Possible direct eval expression rejected at contrived://example:1',
+        'Possible direct eval expression rejected (SESERR1) at contrived://example:1',
     },
     'newline with name',
   );

--- a/packages/ses/test/reject-html-comment.test.js
+++ b/packages/ses/test/reject-html-comment.test.js
@@ -115,7 +115,7 @@ test('reject HTML comment expressions with name', t => {
     () => c.evaluate('\n<!-- -->'),
     {
       name: 'SyntaxError',
-      message: 'SES3: Possible HTML comment rejected at <unknown>:2',
+      message: 'Possible HTML comment rejected (SESERR3) at <unknown>:2',
     },
     'htmlCloseComment without name',
   );
@@ -127,7 +127,8 @@ test('reject HTML comment expressions with name', t => {
       ),
     {
       name: 'SyntaxError',
-      message: 'SES3: Possible HTML comment rejected at bogus://contrived:3',
+      message:
+        'Possible HTML comment rejected (SESERR3) at bogus://contrived:3',
     },
     'htmlCloseComment with name',
   );

--- a/packages/ses/test/reject-import-expression.test.js
+++ b/packages/ses/test/reject-import-expression.test.js
@@ -125,7 +125,7 @@ test('reject import expressions with error messages', t => {
     () => c.evaluate(code),
     {
       name: 'SyntaxError',
-      message: 'SES2: Possible import expression rejected at <unknown>:1',
+      message: 'Possible import expression rejected (SESERR2) at <unknown>:1',
     },
     'without name',
   );
@@ -134,7 +134,8 @@ test('reject import expressions with error messages', t => {
     () => c.evaluate(`\n${code}//#sourceURL= never://land`),
     {
       name: 'SyntaxError',
-      message: 'SES2: Possible import expression rejected at never://land:2',
+      message:
+        'Possible import expression rejected (SESERR2) at never://land:2',
     },
     'with name',
   );


### PR DESCRIPTION
This fixes a typo in SES/ERRORS.md and improves the searchability of our current three error search fragments.