### PR TITLE
Add missing assert.error method

### DIFF
--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -361,7 +361,7 @@ const makeAssert = (optRaise = undefined) => {
   // Note that "assert === baseAssert"
   /** @type {Assert} */
   const assert = assign(baseAssert, {
-    makeError,
+    error: makeError,
     fail,
     equal,
     typeof: assertTypeof,

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -147,11 +147,21 @@ const getLogArgs = ({ template, args }) => {
 const hiddenMessageLogArgs = new WeakMap();
 
 /**
- * @param {HiddenDetails} hiddenDetails
- * @param {ErrorConstructor} ErrorConstructor
- * @returns {Error}
+ * @type {AssertMakeError}
  */
-const makeDetailedError = (hiddenDetails, ErrorConstructor) => {
+const makeError = (
+  optDetails = details`Assert failed`,
+  ErrorConstructor = Error,
+) => {
+  if (typeof optDetails === 'string') {
+    // If it is a string, use it as the literal part of the template so
+    // it doesn't get quoted.
+    optDetails = details([optDetails]);
+  }
+  const hiddenDetails = hiddenDetailsMap.get(optDetails);
+  if (hiddenDetails === undefined) {
+    throw new Error(`unrecognized details ${optDetails}`);
+  }
   const messageString = getMessageString(hiddenDetails);
   const error = new ErrorConstructor(messageString);
   hiddenMessageLogArgs.set(error, getLogArgs(hiddenDetails));
@@ -163,6 +173,7 @@ const makeDetailedError = (hiddenDetails, ErrorConstructor) => {
   // particularly fruitful place to put a breakpoint.
   return error;
 };
+freeze(makeError);
 
 // /////////////////////////////////////////////////////////////////////////////
 
@@ -291,16 +302,7 @@ const makeAssert = (optRaise = undefined) => {
     optDetails = details`Assert failed`,
     ErrorConstructor = Error,
   ) => {
-    if (typeof optDetails === 'string') {
-      // If it is a string, use it as the literal part of the template so
-      // it doesn't get quoted.
-      optDetails = details([optDetails]);
-    }
-    const hiddenDetails = hiddenDetailsMap.get(optDetails);
-    if (hiddenDetails === undefined) {
-      throw new Error(`unrecognized details ${optDetails}`);
-    }
-    const error = makeDetailedError(hiddenDetails, ErrorConstructor);
+    const error = makeError(optDetails, ErrorConstructor);
     if (optRaise !== undefined) {
       optRaise(error);
     }
@@ -359,6 +361,7 @@ const makeAssert = (optRaise = undefined) => {
   // Note that "assert === baseAssert"
   /** @type {Assert} */
   const assert = assign(baseAssert, {
+    makeError,
     fail,
     equal,
     typeof: assertTypeof,

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -16,6 +16,18 @@
  */
 
 /**
+ * @callback AssertMakeError
+ *
+ * The `assert.makeError` method, recording details for the console.
+ *
+ * The optional `optDetails` can be a string.
+ * @param {Details=} optDetails The details of what was asserted
+ * @param {ErrorConstructor=} ErrorConstructor An optional alternate error
+ * constructor to use.
+ * @returns {Error}
+ */
+
+/**
  * @callback AssertFail
  *
  * The `assert.fail` method.
@@ -208,6 +220,7 @@
  *
  * @typedef { BaseAssert & {
  *   typeof: AssertTypeof,
+ *   makeError: AssertMakeError,
  *   fail: AssertFail,
  *   equal: AssertEqual,
  *   string: AssertString,

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -18,7 +18,7 @@
 /**
  * @callback AssertMakeError
  *
- * The `assert.makeError` method, recording details for the console.
+ * The `assert.error` method, recording details for the console.
  *
  * The optional `optDetails` can be a string.
  * @param {Details=} optDetails The details of what was asserted
@@ -220,7 +220,7 @@
  *
  * @typedef { BaseAssert & {
  *   typeof: AssertTypeof,
- *   makeError: AssertMakeError,
+ *   error: AssertMakeError,
  *   fail: AssertFail,
  *   equal: AssertEqual,
  *   string: AssertString,

--- a/packages/ses/test/error/assert-log.test.js
+++ b/packages/ses/test/error/assert-log.test.js
@@ -272,8 +272,8 @@ test('assert typeof', t => {
   ]);
 });
 
-test('assert makeError default', t => {
-  const err = assert.makeError(d`<${'bar'},${q('baz')}>`);
+test('assert error default', t => {
+  const err = assert.error(d`<${'bar'},${q('baz')}>`);
   t.is(err.message, '<(a string),"baz">');
   t.is(err.name, 'Error');
   throwsAndLogs(
@@ -301,8 +301,8 @@ test('assert makeError default', t => {
   );
 });
 
-test('assert makeError explicit', t => {
-  const err = assert.makeError(d`<${'bar'},${q('baz')}>`, URIError);
+test('assert error explicit', t => {
+  const err = assert.error(d`<${'bar'},${q('baz')}>`, URIError);
   t.is(err.message, '<(a string),"baz">');
   t.is(err.name, 'URIError');
   throwsAndLogs(

--- a/packages/ses/test/error/assert-log.test.js
+++ b/packages/ses/test/error/assert-log.test.js
@@ -272,6 +272,64 @@ test('assert typeof', t => {
   ]);
 });
 
+test('assert makeError default', t => {
+  const err = assert.makeError(d`<${'bar'},${q('baz')}>`);
+  t.is(err.message, '<(a string),"baz">');
+  t.is(err.name, 'Error');
+  throwsAndLogs(
+    t,
+    () => {
+      throw err;
+    },
+    /<\(a string\),"baz">/,
+    [['log', 'Caught', Error]],
+  );
+  throwsAndLogs(
+    t,
+    () => {
+      throw err;
+    },
+    /<\(a string\),"baz">/,
+    [
+      ['log', 'Caught', '(Error#1)'],
+      ['groupCollapsed', ''],
+      ['debug', 'Error#1:', '<', 'bar', ',', 'baz', '>'],
+      ['debug', '', 'stack of Error\n'],
+      ['groupEnd'],
+    ],
+    { wrapWithCausal: true },
+  );
+});
+
+test('assert makeError explicit', t => {
+  const err = assert.makeError(d`<${'bar'},${q('baz')}>`, URIError);
+  t.is(err.message, '<(a string),"baz">');
+  t.is(err.name, 'URIError');
+  throwsAndLogs(
+    t,
+    () => {
+      throw err;
+    },
+    /<\(a string\),"baz">/,
+    [['log', 'Caught', URIError]],
+  );
+  throwsAndLogs(
+    t,
+    () => {
+      throw err;
+    },
+    /<\(a string\),"baz">/,
+    [
+      ['log', 'Caught', '(URIError#1)'],
+      ['groupCollapsed', ''],
+      ['debug', 'URIError#1:', '<', 'bar', ',', 'baz', '>'],
+      ['debug', '', 'stack of URIError\n'],
+      ['groupEnd'],
+    ],
+    { wrapWithCausal: true },
+  );
+});
+
 test('assert q', t => {
   throwsAndLogs(
     t,


### PR DESCRIPTION
`assert.error` is an obviously missing method. Exactly like `assert.fail` for making an error with associated details. But unlike `assert.fail` it just returns the error rather than throwing it.

Currently the only way to get this effect from outside the assert module is

```js
let err;
try {
  assert.fail(d`...`);
} catch (e) {
  err = e;
}
```
which would be just horrible.

Motivation:
While debugging a change to https://github.com/Agoric/agoric-sdk/pull/1905 I'm seeing places where we're not logging info we should be due to the lack of this method. 