### PR TITLE
Friendlier nested console output for browsers

### DIFF
--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -216,13 +216,22 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
   /**
    * Logs the `subErrors` within a group named `label`.
    *
-   * @param {string} label
+   * @param {string | undefined} optTag
    * @param {Error[]} subErrors
    * @returns {void}
    */
-  const logSubErrors = (label, subErrors) => {
+  const logSubErrors = (optTag = undefined, subErrors) => {
     if (subErrors.length >= 1) {
-      baseConsole.groupCollapsed(label);
+      let label;
+      if (subErrors.length === 1) {
+        label = `Nested error`;
+      } else {
+        label = `Nested ${subErrors.length} errors`;
+      }
+      if (optTag !== undefined) {
+        label = `${label} under ${optTag}`;
+      }
+      baseConsole.group(label);
       try {
         for (const subError of subErrors) {
           // eslint-disable-next-line no-use-before-define
@@ -288,7 +297,7 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
       const argTags = extractErrorArgs(logArgs, subErrors);
       // @ts-ignore
       baseConsole[level](...argTags);
-      logSubErrors('', subErrors);
+      logSubErrors(undefined, subErrors);
     };
     defineProperty(levelMethod, 'name', { value: level });
     return [level, freeze(levelMethod)];

--- a/packages/ses/test/error/assert-log.test.js
+++ b/packages/ses/test/error/assert-log.test.js
@@ -29,7 +29,7 @@ test('throwsAndLogs with data', t => {
     [
       ['error', 'what', obj],
       ['log', 'Caught', '(TypeError#1)'],
-      ['groupCollapsed', ''],
+      ['group', 'Nested error'],
       ['debug', 'TypeError#1:', 'foo'],
       ['debug', '', 'stack of TypeError\n'],
       ['groupEnd'],
@@ -66,7 +66,7 @@ test('assert', t => {
     /Check failed/,
     [
       ['log', 'Caught', '(Error#1)'],
-      ['groupCollapsed', ''],
+      ['group', 'Nested error'],
       ['debug', 'Error#1:', 'Check failed'],
       ['debug', '', 'stack of Error\n'],
       ['groupEnd'],
@@ -114,13 +114,13 @@ test('causal tree', t => {
     /because/,
     [
       ['log', 'Caught', '(Error#1)'],
-      ['groupCollapsed', ''],
+      ['group', 'Nested error'],
       ['debug', 'Error#1:', 'because', '(Error#2)'],
       ['debug', '', 'stack of Error\n'],
-      ['groupCollapsed', 'Error#1'],
+      ['group', 'Nested error under Error#1'],
       ['debug', 'Error#2:', 'synful', '(SyntaxError#3)'],
       ['debug', '', 'stack of Error\n'],
-      ['groupCollapsed', 'Error#2'],
+      ['group', 'Nested error under Error#2'],
       ['debug', 'SyntaxError#3:', 'foo'],
       ['debug', '', 'stack of SyntaxError\n'],
       ['groupEnd'],
@@ -208,7 +208,7 @@ test('assert equals', t => {
     /Expected \(a number\) is same as \(a number\)/,
     [
       ['log', 'Caught', '(RangeError#1)'],
-      ['groupCollapsed', ''],
+      ['group', 'Nested error'],
       ['debug', 'RangeError#1:', 'Expected', 5, 'is same as', 6],
       ['debug', '', 'stack of RangeError\n'],
       ['groupEnd'],
@@ -224,7 +224,7 @@ test('assert equals', t => {
     /foo/,
     [
       ['log', 'Caught', '(RangeError#1)'],
-      ['groupCollapsed', ''],
+      ['group', 'Nested error'],
       ['debug', 'RangeError#1:', 'foo'],
       ['debug', '', 'stack of RangeError\n'],
       ['groupEnd'],
@@ -250,7 +250,7 @@ test('assert equals', t => {
     /Expected \(a number\) is same as \(a number\)/,
     [
       ['log', 'Caught', '(RangeError#1)'],
-      ['groupCollapsed', ''],
+      ['group', 'Nested error'],
       ['debug', 'RangeError#1:', 'Expected', -0, 'is same as', 0],
       ['debug', '', 'stack of RangeError\n'],
       ['groupEnd'],
@@ -292,7 +292,7 @@ test('assert error default', t => {
     /<\(a string\),"baz">/,
     [
       ['log', 'Caught', '(Error#1)'],
-      ['groupCollapsed', ''],
+      ['group', 'Nested error'],
       ['debug', 'Error#1:', '<', 'bar', ',', 'baz', '>'],
       ['debug', '', 'stack of Error\n'],
       ['groupEnd'],
@@ -321,7 +321,7 @@ test('assert error explicit', t => {
     /<\(a string\),"baz">/,
     [
       ['log', 'Caught', '(URIError#1)'],
-      ['groupCollapsed', ''],
+      ['group', 'Nested error'],
       ['debug', 'URIError#1:', '<', 'bar', ',', 'baz', '>'],
       ['debug', '', 'stack of URIError\n'],
       ['groupEnd'],
@@ -343,7 +343,7 @@ test('assert q', t => {
     /<\(a string\),"baz">/,
     [
       ['log', 'Caught', '(Error#1)'],
-      ['groupCollapsed', ''],
+      ['group', 'Nested error'],
       ['debug', 'Error#1:', '<', 'bar', ',', 'baz', '>'],
       ['debug', '', 'stack of Error\n'],
       ['groupEnd'],

--- a/packages/ses/test/error/tame-console.test.js
+++ b/packages/ses/test/error/tame-console.test.js
@@ -40,8 +40,8 @@ test('console', t => {
 // where any error objects are shown with a unique tag like "(SyntaxError#2)"
 // followed by simlarly-enhanced information about those errors, recursively.
 // The information about these nested errors is shown indented by
-// `console.groupCollapsed`, and thus also collapsed and expandable for console
-// displays that support such interaction.
+// `console.group`, and thus also expanded but collapsible for console
+// displays (like some browsers) that support such interaction.
 test('assert - safe', t => {
   try {
     const obj = {};


### PR DESCRIPTION
To reduce verbosity in interactive console logs, like the browser's, we had been using `groupCollapsed` for nesting output. This was in addition to logging using `console.debug` which requires verbose output to be turned on. We left the nested output at `console.debug` level, which is adequate to make the normal experience concise. Given that, this PR changes from `groupCollapsed` to `group` so that nested output starts expanded by default but can still be collapsed.

In addition, the label for a group was not terribly informative, and sometimes empty, making it mysterious what to click on. This PR also improves the labels.