### PR TITLE
fix: remove "debugger;" statement

### DIFF
--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -165,10 +165,6 @@ const makeError = (
   const messageString = getMessageString(hiddenDetails);
   const error = new ErrorConstructor(messageString);
   hiddenMessageLogArgs.set(error, getLogArgs(hiddenDetails));
-  // TODO Having a `debugger` statement in production code is
-  // controversial
-  // eslint-disable-next-line no-debugger
-  debugger;
   // If we get rid of the `debugger` statement above, the next line is a
   // particularly fruitful place to put a breakpoint.
   return error;


### PR DESCRIPTION
Just found out that a `debugger;` statement in source causes node (or v8 in general?) to deoptimize. Setting a breakpoint on line 170 as already suggested by the comment accomplishes much the same thing. Do removed the `debugger;` statement.