### PR TITLE
Add missing ts-checks. Fix resulting type errors

### DIFF
--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -53,32 +53,7 @@ freeze(quote);
  */
 const hiddenDetailsMap = new WeakMap();
 
-// TODO Move this type declaration to types.js as a separate @callback type,
-// without breaking the meaning of the type. As currently written, if it is
-// moved into a separate @callback type, it no longer understands that `args`
-// is a rest parameter. I have not yet figured out how to declare that it is,
-// except by having it here directly annotating the `details` function.
-/**
- * Use the `details` function as a template literal tag to create
- * informative error messages. The assertion functions take such messages
- * as optional arguments:
- * ```js
- * assert(sky.isBlue(), details`${sky.color} should be "blue"`);
- * ```
- * The details template tag returns an object that can print itself with the
- * formatted message in two ways. It will report the real details to
- * the console but include only the typeof information in the thrown error
- * to prevent revealing secrets up the exceptional path. In the example
- * above, the thrown error may reveal only that `sky.color` is a string,
- * whereas the same diagnostic printed to the console reveals that the
- * sky was green.
- *
- * @param {TemplateStringsArray | string[]} template The template to format.
- * The `raw` member of a `TemplateStringsArray` is ignored, so a simple
- * `string[]` can also be used as a template.
- * @param {any[]} args Arguments to the template
- * @returns {DetailsToken} The token associated with for these details
- */
+/** @type {DetailsTag} */
 const details = (template, ...args) => {
   // Keep in mind that the vast majority of calls to `details` creates
   // a details token that is never used, so this path must remain as fast as

--- a/packages/ses/src/error/internal-types.js
+++ b/packages/ses/src/error/internal-types.js
@@ -1,3 +1,4 @@
+// @ts-check
 /// <reference types="ses"/>
 
 /**

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -1,3 +1,4 @@
+// @ts-check
 /// <reference types="ses"/>
 
 // Much of this file is duplicated at
@@ -198,6 +199,28 @@
  *
  * @param {*} payload What to declassify
  * @returns {StringablePayload} The declassified payload
+ */
+
+/**
+ * @typedef {(template: TemplateStringsArray | string[], ...args: any) => DetailsToken} DetailsTag
+ *
+ * Use the `details` function as a template literal tag to create
+ * informative error messages. The assertion functions take such messages
+ * as optional arguments:
+ * ```js
+ * assert(sky.isBlue(), details`${sky.color} should be "blue"`);
+ * ```
+ * The details template tag returns a `DetailsToken` object that can print
+ * itself with the formatted message in two ways.
+ * It will report the real details to
+ * the console but include only the typeof information in the thrown error
+ * to prevent revealing secrets up the exceptional path. In the example
+ * above, the thrown error may reveal only that `sky.color` is a string,
+ * whereas the same diagnostic printed to the console reveals that the
+ * sky was green.
+ *
+ * The `raw` member of a `template` is ignored, so a simple
+ * `string[]` can also be used as a template.
  */
 
 /**


### PR DESCRIPTION
`packages/ses/src/error/types.js` was missing an `// @ts-check` and so we didn't catch that it also had bad TypeScript types. 

In particular, it no longer had a `DetailsTag` type. The reason that was missing is because I (MarkM) couldn't figure out how to get a `...` rest argument type to work in an `@param` or a `@callback` type. The answer that I found that worked for me is to use a `@typedef` type rather than a `@callback` type.

I'm not sure what the intended scope of #161 is, but it at least reduces the remaining problem some.