### PR TITLE
WIP Stop enabling O.p.constructor

### DIFF
--- a/packages/ses/src/enablements.js
+++ b/packages/ses/src/enablements.js
@@ -58,7 +58,6 @@
 
 export const moderateEnablements = {
   '%ObjectPrototype%': {
-    constructor: true, // set by "acorn" v7.
     hasOwnProperty: true, // set by "vega-util".
     toString: true,
     valueOf: true,

--- a/packages/ses/test/test-enable-property-overrides.js
+++ b/packages/ses/test/test-enable-property-overrides.js
@@ -91,12 +91,7 @@ test('enablePropertyOverrides - on', t => {
 
   harden(intrinsics);
 
-  testOverriding(t, 'Object', {}, [
-    'constructor',
-    'hasOwnProperty',
-    'toString',
-    'valueOf',
-  ]);
+  testOverriding(t, 'Object', {}, ['hasOwnProperty', 'toString', 'valueOf']);
   // We allow 'length' *not* because it is in enablements; it is not;
   // but because each array instance has its own.
   testOverriding(t, 'Array', [], ['toString', 'length']);


### PR DESCRIPTION
***DO NOT MERGE.*** Blocked by https://github.com/Agoric/agoric-sdk/issues/2324

SES by default currently enables `Object.prototype.constructor` to be overridden. This PR would like to retire that as it causes the Node console to display objects in a confusing manner, like
```js
[Function (anonymous)] Function <Function <[Object: null prototype] {}>>
```
However, agoric-sdk is currently not compatible with this improvement for two reasons.
   * It depends on an old version of acorn with a bug. https://github.com/Agoric/agoric-sdk/pull/2303 upgrades agoric-sdk to an acorn without that bug.
   * Something having to do with the xsnap integration, which is not yet diagnosed.

Until that later problem is diagnosed and fixed, this PR remains a WIP Draft. 

