### PR TITLE
DO NOT MERGE Diagnostic monkey patch Object.entries to detect symbol breakage

### DIFF
--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -39,6 +39,14 @@ const { details: d, quote: q } = assert;
 const altObjMethods = {
   entries(obj) {
     const ownKeys = Reflect.ownKeys(obj);
+    if (Array.isArray(obj)) {
+      const index = ownKeys.indexOf('length');
+      if (index >= 0) {
+        // Arrays have a builtin non-enumerable `length` that `entries`
+        // would normally skip, and is unsurprising.
+        ownKeys.splice(index, 1);
+      }
+    }
     return ownKeys.map(ownKey => {
       assert(
         typeof ownKey !== 'symbol',

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -33,6 +33,21 @@ import { assert } from './error/assert.js';
 
 const { details: d, quote: q } = assert;
 
+// Special case monkey patch to detect whether we ever hit a particular
+// problematic situation: Object.entries ignoring an own symbol-named
+// property.
+const altObjMethods = {
+  entries(obj) {
+    const ownKeys = Reflect.ownKeys(obj);
+    return ownKeys.map(ownKey => {
+      assert(typeof ownKey !== 'symbol', `Unexpected symbol ${String(ownKey)}`);
+      return [ownKey, obj[ownKey]];
+    });
+  },
+};
+
+Object.defineProperty(Object, 'entries', { value: altObjMethods.entries });
+
 let firstOptions;
 
 // A successful lockdown call indicates that `harden` can be called and

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -40,7 +40,16 @@ const altObjMethods = {
   entries(obj) {
     const ownKeys = Reflect.ownKeys(obj);
     return ownKeys.map(ownKey => {
-      assert(typeof ownKey !== 'symbol', `Unexpected symbol ${String(ownKey)}`);
+      assert(
+        typeof ownKey !== 'symbol',
+        d`Unexpected symbol ${q(String(ownKey))}.`,
+      );
+      const desc = Object.getOwnPropertyDescriptor(obj, ownKey);
+      assert(
+        desc.enumerable,
+        d`Unexpected non-enumerable property ${q(ownKey)}.`,
+      );
+      assert(!('get' in desc), d`Unexpected accessor property ${q(ownKey)}.`);
       return [ownKey, obj[ownKey]];
     });
   },


### PR DESCRIPTION
DO NOT MERGE

At the beginning of evaluating the `lockdown` module, this PR first monkey patches `Object.entries` so that if it sees a symbol-named own property, it throws. THIS IS NOT CORRECT. It is useful only for rerunning our test suites and seeing where this causes breakage. The good news is that SES-shim tests run all the way through with no breakage. The breakage seen so far in agoric-sdk is in `passStyleOf` exactly where we expected it due to https://github.com/Agoric/agoric-sdk/pull/2331

See https://github.com/Agoric/SES-shim/issues/573
See https://tc39.es/ecma262/#sec-enumerableownpropertynames

I just extended the diagnostic to also reject non-enumerables and accessors. Thus, this very narrow version of `entries` only works if applied to objects in which all own properties are only string-named enumerable data properties. Which is an invariant that agoric-sdk is supposed to enforce for pass-by-copy objects --- but doesn't yet because I misunderstood `entries`.

The fact that this PR passes CI means that all uses of `entries` during these tests stayed within those restrictions.