### PR TITLE
Effectively export makeAssert by putting it on assert

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -2,7 +2,14 @@ User-visible changes in SES:
 
 ## Next release
 
-* No changes yet
+* The `assert.js` module in the `ses` package of this repository exports
+  a `makeAssert` function, to make other `assert` functions with a different
+  failure scope. Inadvertantly, this did not enable the `@agoric/assert`
+  package (currently defined in the agoric-sdk repository) to reexport
+  the same `makeAssert` function as originally intended, and now
+  [needed](https://github.com/Agoric/agoric-sdk/pull/2515).
+  As of this release the `assert` object exported by the `assert.js` module
+  now carries this function as a `makeAssert` property.
 
 ## Release 0.12.2 (5-Feb-2021)
 

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -249,22 +249,7 @@ export { loggedErrorHandler };
 // /////////////////////////////////////////////////////////////////////////////
 
 /**
- * Makes and returns an `assert` function object that shares the bookkeeping
- * state defined by this module with other `assert` function objects make by
- * `makeAssert`. This state is per-module-instance and is exposed by the
- * `loggedErrorHandler` above. We refer to `assert` as a "function object"
- * because it can be called directly as a function, but also has methods that
- * can be called.
- *
- * If `optRaise` is provided, the returned `assert` function object will call
- * `optRaise(error)` before throwing the error. This enables `optRaise` to
- * engage in even more violent termination behavior, like terminating the vat,
- * that prevents execution from reaching the following throw. However, if
- * `optRaise` returns normally, which would be unusual, the throw following
- * `optRaise(error)` would still happen.
- *
- * @param {((error: Error) => void)=} optRaise
- * @returns {Assert}
+ * @type {MakeAssert}
  */
 const makeAssert = (optRaise = undefined) => {
   /** @type {AssertFail} */
@@ -272,11 +257,11 @@ const makeAssert = (optRaise = undefined) => {
     optDetails = details`Assert failed`,
     ErrorConstructor = Error,
   ) => {
-    const error = makeError(optDetails, ErrorConstructor);
+    const reason = makeError(optDetails, ErrorConstructor);
     if (optRaise !== undefined) {
-      optRaise(error);
+      optRaise(reason);
     }
-    throw error;
+    throw reason;
   };
   freeze(fail);
 

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -339,6 +339,7 @@ const makeAssert = (optRaise = undefined) => {
     note,
     details,
     quote,
+    makeAssert,
   });
   return freeze(assert);
 };

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -183,6 +183,8 @@
  * );
  * ```
  *
+ * // TODO Update SES-shim to new convention, where `details` is
+ * // renamed to `X` rather than `d`.
  * The normal convention is to locally rename `quote` to `q` and
  * `details` to `d`
  * ```js
@@ -199,6 +201,39 @@
  *
  * @param {*} payload What to declassify
  * @returns {StringablePayload} The declassified payload
+ */
+
+/**
+ * @callback Raise
+ *
+ * To make an `assert` which terminates some larger unit of computation
+ * like a transaction, vat, or process, call `makeAssert` with a `Raise`
+ * callback, where that callback actually performs that larger termination.
+ * If possible, the callback should also report its `reason` parameter as
+ * the alleged reason for the termination.
+ *
+ * @param {Error} reason
+ */
+
+/**
+ * @callback MakeAssert
+ *
+ * Makes and returns an `assert` function object that shares the bookkeeping
+ * state defined by this module with other `assert` function objects make by
+ * `makeAssert`. This state is per-module-instance and is exposed by the
+ * `loggedErrorHandler` above. We refer to `assert` as a "function object"
+ * because it can be called directly as a function, but also has methods that
+ * can be called.
+ *
+ * If `optRaise` is provided, the returned `assert` function object will call
+ * `optRaise(reason)` before throwing the error. This enables `optRaise` to
+ * engage in even more violent termination behavior, like terminating the vat,
+ * that prevents execution from reaching the following throw. However, if
+ * `optRaise` returns normally, which would be unusual, the throw following
+ * `optRaise(reason)` would still happen.
+ *
+ * @param {Raise=} optRaise
+ * @returns {Assert}
  */
 
 /**
@@ -249,7 +284,8 @@
  *   string: AssertString,
  *   note: AssertNote,
  *   details: DetailsTag,
- *   quote: AssertQuote
+ *   quote: AssertQuote,
+ *   makeAssert: MakeAssert,
  * } } Assert
  */
 

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -162,8 +162,6 @@
  */
 
 /**
- * @callback AssertQuote
- *
  * To "declassify" and quote a substitution value used in a
  * details`...` template literal, enclose that substitution expression
  * in a call to `quote`. This states that the argument should appear quoted
@@ -199,6 +197,7 @@
  * );
  * ```
  *
+ * @callback AssertQuote
  * @param {*} payload What to declassify
  * @returns {StringablePayload} The declassified payload
  */


### PR DESCRIPTION
Needed by https://github.com/Agoric/agoric-sdk/pull/2515

The local `assert` module exports a `makeAssert` function precisely in order to enable uses like https://github.com/Agoric/agoric-sdk/pull/2515 . However, due to an oversight, it is not reexported by the `@agoric/assert` module. It is not clear what the right way is to enable `@agoric/assert` to reexport it. So this PR is just a temporary kludge that works with the kludge in https://github.com/Agoric/agoric-sdk/pull/2515 when `yarn link`ed together.