### PR TITLE
assert's q function is a better best efforts stringify

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -17,6 +17,10 @@ User-visible changes in SES:
   renderings of values problematic for `JSON.stringify`, still including
   cycles, but now also functions, promises, `undefined`, `NaN`, `Infinity`,
   bigints, and symbols.
+* The `q` function now has an optional second `spaces` parameter which is
+  passed through to the underlying `JSON.stringfiy`. Passing in a space or
+  two spaces makes the output much more readable using indentation and other
+  whitespace, but takes multiple lines.
 
 ## Release 0.12.2 (5-Feb-2021)
 

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -19,7 +19,7 @@ User-visible changes in SES:
   bigints, and symbols. To distinguish this from
   strings in the input, these synthesized strings always begin and
   end with square brackets. To distinguish those strings from an
-  input string with square brackets, and input string that starts
+  input string with square brackets, an input string that starts
   with an open square bracket `[` is itself placed in square brackets.
 * The `q` function now has an optional second `spaces` parameter which is
   passed through to the underlying `JSON.stringfiy`. Passing in a space or

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -10,6 +10,13 @@ User-visible changes in SES:
   [needed](https://github.com/Agoric/agoric-sdk/pull/2515).
   As of this release the `assert` object exported by the `assert.js` module
   now carries this function as a `makeAssert` property.
+* The `assert.quote` function re-exported by `@agoric/assert` as `q`
+  has always done only a best effort stringify, intended only to
+  be interpreted by a human under benign conditions. Within that constraint
+  its best effort is now better, providing informative though ambiguous
+  renderings of values problematic for `JSON.stringify`, still including
+  cycles, but now also functions, promises, `undefined`, `NaN`, `Infinity`,
+  bigints, and symbols.
 
 ## Release 0.12.2 (5-Feb-2021)
 

--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -16,7 +16,11 @@ User-visible changes in SES:
   its best effort is now better, providing informative though ambiguous
   renderings of values problematic for `JSON.stringify`, still including
   cycles, but now also functions, promises, `undefined`, `NaN`, `Infinity`,
-  bigints, and symbols.
+  bigints, and symbols. To distinguish this from
+  strings in the input, these synthesized strings always begin and
+  end with square brackets. To distinguish those strings from an
+  input string with square brackets, and input string that starts
+  with an open square bracket `[` is itself placed in square brackets.
 * The `q` function now has an optional second `spaces` parameter which is
   passed through to the underlying `JSON.stringfiy`. Passing in a space or
   two spaces makes the output much more readable using indentation and other

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -12,7 +12,7 @@
 // module should not be observably impure.
 
 import { freeze, is, assign } from '../commons.js';
-import { an, cycleTolerantStringify } from './stringify-utils.js';
+import { an, bestEffortStringify } from './stringify-utils.js';
 import './types.js';
 import './internal-types.js';
 
@@ -27,7 +27,7 @@ const declassifiers = new WeakMap();
 /** @type {AssertQuote} */
 const quote = payload => {
   const result = freeze({
-    toString: freeze(() => cycleTolerantStringify(payload)),
+    toString: freeze(() => bestEffortStringify(payload)),
   });
   declassifiers.set(result, payload);
   return result;

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -25,9 +25,9 @@ import './internal-types.js';
 const declassifiers = new WeakMap();
 
 /** @type {AssertQuote} */
-const quote = payload => {
+const quote = (payload, spaces = undefined) => {
   const result = freeze({
-    toString: freeze(() => bestEffortStringify(payload)),
+    toString: freeze(() => bestEffortStringify(payload, spaces)),
   });
   declassifiers.set(result, payload);
   return result;

--- a/packages/ses/src/error/stringify-utils.js
+++ b/packages/ses/src/error/stringify-utils.js
@@ -80,17 +80,19 @@ const bestEffortStringify = (payload, spaces = undefined) => {
         return `[Function ${val.name || '<anon>'}]`;
       }
       case 'undefined':
-      case 'bigint':
       case 'symbol': {
-        return String(val);
+        return `[${String(val)}]`;
+      }
+      case 'bigint': {
+        return `[${val}n]`;
       }
       case 'number': {
         if (Object.is(val, NaN)) {
-          return 'NaN';
+          return '[NaN]';
         } else if (val === Infinity) {
-          return 'Infinity';
+          return '[Infinity]';
         } else if (val === -Infinity) {
-          return '-Infinity';
+          return '[-Infinity]';
         }
         return val;
       }

--- a/packages/ses/src/error/stringify-utils.js
+++ b/packages/ses/src/error/stringify-utils.js
@@ -36,9 +36,11 @@ export { an };
  * As a best effort only for diagnostic interpretation by humans,
  * `bestEffortStringify` also turns various cases that normal
  * `JSON.stringify` skips or errors on, like `undefined` or bigints,
- * into strings that convey their meaning. However, if these strings appear
- * in the input they will also appear in the output, so the output is
- * ambiguous in the face of these collisions.
+ * into strings that convey their meaning. To distinguish this from
+ * strings in the input, these synthesized strings always begin and
+ * end with square brackets. To distinguish those strings from an
+ * input string with square brackets, and input string that starts
+ * with an open square bracket `[` is itself placed in square brackets.
  *
  * @param {any} payload
  * @param {(string|number)=} spaces
@@ -53,7 +55,7 @@ const bestEffortStringify = (payload, spaces = undefined) => {
           return null;
         }
         if (seenSet.has(val)) {
-          return '[Circular]';
+          return '[Seen]';
         }
         seenSet.add(val);
         if (Promise.resolve(val) === val) {
@@ -78,6 +80,12 @@ const bestEffortStringify = (payload, spaces = undefined) => {
       }
       case 'function': {
         return `[Function ${val.name || '<anon>'}]`;
+      }
+      case 'string': {
+        if (val.startsWith('[')) {
+          return `[${val}]`;
+        }
+        return val;
       }
       case 'undefined':
       case 'symbol': {

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -199,6 +199,7 @@
  *
  * @callback AssertQuote
  * @param {*} payload What to declassify
+ * @param {(string|number)=} spaces
  * @returns {StringablePayload} The declassified payload
  */
 

--- a/packages/ses/test/error/test-assert-log.js
+++ b/packages/ses/test/error/test-assert-log.js
@@ -420,7 +420,7 @@ test('q as best efforts stringify', t => {
   ];
   t.is(
     `${q(challenges)}`,
-    '["[Promise]","[Function foo]","undefined","undefined","[URIError: wut?]",["33","Symbol(foo)","Symbol(bar)","Symbol(Symbol.asyncIterator)"],{"NaN":"NaN","Infinity":"Infinity","neg":"-Infinity"},18014398509481984,{"superTagged":"[Tagged]","subTagged":"[Tagged]","subTaggedNonEmpty":{"foo":"x"}}]',
+    '["[Promise]","[Function foo]","[undefined]","undefined","[URIError: wut?]",["[33n]","[Symbol(foo)]","[Symbol(bar)]","[Symbol(Symbol.asyncIterator)]"],{"NaN":"[NaN]","Infinity":"[Infinity]","neg":"[-Infinity]"},18014398509481984,{"superTagged":"[Tagged]","subTagged":"[Tagged]","subTaggedNonEmpty":{"foo":"x"}}]',
   );
   t.is(
     `${q(challenges, '  ')}`,

--- a/packages/ses/test/error/test-assert-log.js
+++ b/packages/ses/test/error/test-assert-log.js
@@ -402,7 +402,7 @@ test('q as best efforts stringify', t => {
 
   const challenges = [
     Promise.resolve('x'),
-    function foo() { },
+    function foo() {},
     '[hilbert]',
     undefined,
     'undefined',

--- a/packages/ses/test/error/test-assert-log.js
+++ b/packages/ses/test/error/test-assert-log.js
@@ -376,3 +376,32 @@ test('assert q', t => {
     [['log', 'Caught', Error]],
   );
 });
+
+test('q as best efforts stringify', t => {
+  t.is(`${q('baz')}`, '"baz"');
+  const list = ['a', 'b', 'c'];
+  t.is(`${q(list)}`, '["a","b","c"]');
+  const repeat = { x: list, y: list };
+  t.is(`${q(repeat)}`, '{"x":["a","b","c"],"y":"<**seen**>"}');
+  list[1] = list;
+  t.is(`${q(list)}`, '["a","<**seen**>","c"]');
+  t.is(`${q(repeat)}`, '{"x":["a","<**seen**>","c"],"y":"<**seen**>"}');
+
+  t.is(
+    `${q([
+      Promise.resolve('x'),
+      function foo() {},
+      undefined,
+      'undefined',
+      33n,
+      Symbol('foo'),
+      Symbol.for('bar'),
+      Symbol.asyncIterator,
+      NaN,
+      Infinity,
+      -Infinity,
+      2 ** 54,
+    ])}`,
+    '["a promise","function foo","undefined","undefined","33","Symbol(foo)","Symbol(bar)","Symbol(Symbol.asyncIterator)","NaN","Infinity","-Infinity",18014398509481984]',
+  );
+});

--- a/packages/ses/test/error/test-assert-log.js
+++ b/packages/ses/test/error/test-assert-log.js
@@ -358,21 +358,18 @@ test('assert q', t => {
   throwsAndLogs(
     t,
     () => assert.fail(d`${q(repeat)}`),
-    /{"x":\["a","b","c"\],"y":"\[Circular\]"}/,
+    /{"x":\["a","b","c"\],"y":"\[Seen\]"}/,
     [['log', 'Caught', Error]],
   );
   // Make it into a cycle
   list[1] = list;
-  throwsAndLogs(
-    t,
-    () => assert.fail(d`${q(list)}`),
-    /\["a","\[Circular\]","c"\]/,
-    [['log', 'Caught', Error]],
-  );
+  throwsAndLogs(t, () => assert.fail(d`${q(list)}`), /\["a","\[Seen\]","c"\]/, [
+    ['log', 'Caught', Error],
+  ]);
   throwsAndLogs(
     t,
     () => assert.fail(d`${q(repeat)}`),
-    /{"x":\["a","\[Circular\]","c"\],"y":"\[Circular\]"}/,
+    /{"x":\["a","\[Seen\]","c"\],"y":"\[Seen\]"}/,
     [['log', 'Caught', Error]],
   );
 });
@@ -382,20 +379,20 @@ test('q as best efforts stringify', t => {
   const list = ['a', 'b', 'c'];
   t.is(`${q(list)}`, '["a","b","c"]');
   const repeat = { x: list, y: list };
-  t.is(`${q(repeat)}`, '{"x":["a","b","c"],"y":"[Circular]"}');
+  t.is(`${q(repeat)}`, '{"x":["a","b","c"],"y":"[Seen]"}');
   list[1] = list;
-  t.is(`${q(list)}`, '["a","[Circular]","c"]');
-  t.is(`${q(repeat)}`, '{"x":["a","[Circular]","c"],"y":"[Circular]"}');
+  t.is(`${q(list)}`, '["a","[Seen]","c"]');
+  t.is(`${q(repeat)}`, '{"x":["a","[Seen]","c"],"y":"[Seen]"}');
   t.is(
     `${q(repeat, ' ')}`,
     `\
 {
  "x": [
   "a",
-  "[Circular]",
+  "[Seen]",
   "c"
  ],
- "y": "[Circular]"
+ "y": "[Seen]"
 }`,
   );
 
@@ -405,7 +402,8 @@ test('q as best efforts stringify', t => {
 
   const challenges = [
     Promise.resolve('x'),
-    function foo() {},
+    function foo() { },
+    '[hilbert]',
     undefined,
     'undefined',
     URIError('wut?'),
@@ -420,7 +418,7 @@ test('q as best efforts stringify', t => {
   ];
   t.is(
     `${q(challenges)}`,
-    '["[Promise]","[Function foo]","[undefined]","undefined","[URIError: wut?]",["[33n]","[Symbol(foo)]","[Symbol(bar)]","[Symbol(Symbol.asyncIterator)]"],{"NaN":"[NaN]","Infinity":"[Infinity]","neg":"[-Infinity]"},18014398509481984,{"superTagged":"[Tagged]","subTagged":"[Tagged]","subTaggedNonEmpty":{"foo":"x"}}]',
+    '["[Promise]","[Function foo]","[[hilbert]]","[undefined]","undefined","[URIError: wut?]",["[33n]","[Symbol(foo)]","[Symbol(bar)]","[Symbol(Symbol.asyncIterator)]"],{"NaN":"[NaN]","Infinity":"[Infinity]","neg":"[-Infinity]"},18014398509481984,{"superTagged":"[Tagged]","subTagged":"[Tagged]","subTaggedNonEmpty":{"foo":"x"}}]',
   );
   t.is(
     `${q(challenges, '  ')}`,
@@ -428,19 +426,20 @@ test('q as best efforts stringify', t => {
 [
   "[Promise]",
   "[Function foo]",
-  "undefined",
+  "[[hilbert]]",
+  "[undefined]",
   "undefined",
   "[URIError: wut?]",
   [
-    "33",
-    "Symbol(foo)",
-    "Symbol(bar)",
-    "Symbol(Symbol.asyncIterator)"
+    "[33n]",
+    "[Symbol(foo)]",
+    "[Symbol(bar)]",
+    "[Symbol(Symbol.asyncIterator)]"
   ],
   {
-    "NaN": "NaN",
-    "Infinity": "Infinity",
-    "neg": "-Infinity"
+    "NaN": "[NaN]",
+    "Infinity": "[Infinity]",
+    "neg": "[-Infinity]"
   },
   18014398509481984,
   {

--- a/packages/ses/test/error/throws-and-logs.js
+++ b/packages/ses/test/error/throws-and-logs.js
@@ -1,44 +1,14 @@
 import { freeze, getPrototypeOf, is } from '../../src/commons.js';
-import { loggedErrorHandler } from '../../src/error/assert.js';
+import { loggedErrorHandler, assert } from '../../src/error/assert.js';
 import {
   makeLoggingConsoleKit,
   makeCausalConsole,
 } from '../../src/error/console.js';
 
+const { quote: q } = assert;
+
 // For our internal debugging purposes
 // const internalDebugConsole = console;
-
-/**
- * Like `JSON.stringify` but does not blow up if given a cycle. This is not
- * intended to be a serialization to support any useful unserialization,
- * or any programmatic use of the resulting string. The string is intended
- * only for showing a human, in order to be informative enough for some
- * logging purposes. As such, this `cycleTolerantStringify` has an
- * imprecise specification and may change over time.
- *
- * The current `cycleTolerantStringify` possibly emits too many "seen"
- * markings: Not only for cycles, but also for repeated subtrees by
- * object identity.
- *
- * (Started off as a duplicate of the cycleTolerantStringify internal
- * to the assert module.)
- *
- * @param {any} payload
- */
-const cycleTolerantStringify = payload => {
-  const seenSet = new Set();
-  const replacer = (_, val) => {
-    if (typeof val === 'object' && val !== null) {
-      if (seenSet.has(val)) {
-        return '<**seen**>';
-      }
-      seenSet.add(val);
-    }
-    return val;
-  };
-  return JSON.stringify(payload, replacer);
-};
-freeze(cycleTolerantStringify);
 
 const compareLogs = freeze((t, log, goldenLog) => {
   // For our internal debugging purposes
@@ -67,9 +37,7 @@ const compareLogs = freeze((t, log, goldenLog) => {
         // t.is(logEntry, goldenEntry);
         t.assert(
           is(logEntry, goldenEntry),
-          `${cycleTolerantStringify(
-            logEntry,
-          )} not same as ${cycleTolerantStringify(goldenEntry)}`,
+          `${q(logEntry)} not same as ${q(goldenEntry)}`,
         );
       }
     });


### PR DESCRIPTION
From the text added to `NEWS.md`

* The `assert.quote` function re-exported by `@agoric/assert` as `q`
  has always done only a best effort stringify, intended only to
  be interpreted by a human under benign conditions. Within that constraint
  its best effort is now better, providing informative though ambiguous
  renderings of values problematic for `JSON.stringify`, still including
  cycles, but now also functions, promises, `undefined`, `NaN`, `Infinity`,
  bigints, and symbols.
