### PR TITLE
feat(ses): Expand TypeScript coverage for Compartment and lockdown

### DIFF
--- a/packages/ses/index.d.ts
+++ b/packages/ses/index.d.ts
@@ -1,10 +1,12 @@
 /**
  * Transitively freeze an object.
  */
-type Harden = <T>(x: T) => T;
-
-declare var harden: Harden;
+import type { Hardener } from '@agoric/make-hardener';
+import { makeLockdown } from './src/lockdown-shim.js';
+import { makeCompartmentConstructor } from './src/compartment-shim.js';
 
 namespace global {
-  declare var harden: Harden;
+  declare let harden : Hardener<T>;
+  declare let lockdown : ReturnType<makeLockdown>;
+  declare let Compartment : ReturnType<makeCompartmentConstructor>;
 }

--- a/packages/ses/jsconfig.json
+++ b/packages/ses/jsconfig.json
@@ -7,5 +7,5 @@
     "strictNullChecks": true,
     "moduleResolution": "node"
   },
-  "include": ["src/**/*.js"]
+  "include": ["src/**/*.js", "index.d.ts"]
 }

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -53,28 +53,7 @@ freeze(quote);
  */
 const hiddenDetailsMap = new WeakMap();
 
-// TODO Move this type declaration to types.js as a separate @callback type,
-// without breaking the meaning of the type. As currently written, if it is
-// moved into a separate @callback type, it no longer understands that `args`
-// is a rest parameter. I have not yet figured out how to declare that it is,
-// except by having it here directly annotating the `details` function.
-/**
- * Use the `details` function as a template literal tag to create
- * informative error messages. The assertion functions take such messages
- * as optional arguments:
- * ```js
- * assert(sky.isBlue(), details`${sky.color} should be "blue"`);
- * ```
- * The details template tag returns an object that can print itself with the
- * formatted message in two ways. It will report the real details to
- * the console but include only the typeof information in the thrown error
- * to prevent revealing secrets up the exceptional path. In the example
- * above, the thrown error may reveal only that `sky.color` is a string,
- * whereas the same diagnostic printed to the console reveals that the
- * sky was green.
- *
- * @type {DetailsTag}
- */
+/** @type {DetailsTag} */
 const details = (template, ...args) => {
   // Keep in mind that the vast majority of calls to `details` creates
   // a details token that is never used, so this path must remain as fast as

--- a/packages/ses/src/error/assert.js
+++ b/packages/ses/src/error/assert.js
@@ -53,7 +53,28 @@ freeze(quote);
  */
 const hiddenDetailsMap = new WeakMap();
 
-/** @type {DetailsTag} */
+// TODO Move this type declaration to types.js as a separate @callback type,
+// without breaking the meaning of the type. As currently written, if it is
+// moved into a separate @callback type, it no longer understands that `args`
+// is a rest parameter. I have not yet figured out how to declare that it is,
+// except by having it here directly annotating the `details` function.
+/**
+ * Use the `details` function as a template literal tag to create
+ * informative error messages. The assertion functions take such messages
+ * as optional arguments:
+ * ```js
+ * assert(sky.isBlue(), details`${sky.color} should be "blue"`);
+ * ```
+ * The details template tag returns an object that can print itself with the
+ * formatted message in two ways. It will report the real details to
+ * the console but include only the typeof information in the thrown error
+ * to prevent revealing secrets up the exceptional path. In the example
+ * above, the thrown error may reveal only that `sky.color` is a string,
+ * whereas the same diagnostic printed to the console reveals that the
+ * sky was green.
+ *
+ * @type {DetailsTag}
+ */
 const details = (template, ...args) => {
   // Keep in mind that the vast majority of calls to `details` creates
   // a details token that is never used, so this path must remain as fast as

--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -115,6 +115,9 @@ const makeLoggingConsoleKit = () => {
       // Use an arrow function so that it doesn't come with its own name in
       // its printed form. Instead, we're hoping that tooling uses only
       // the `.name` property set below.
+      /**
+       * @param {...any} args
+       */
       const method = (...args) => {
         logArray.push([name, ...args]);
       };
@@ -188,6 +191,11 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
     return `${err.name}#${errNum}`;
   };
 
+  /**
+   * @param {ReadonlyArray<any>} logArgs
+   * @param {Array<any>} subErrorsSink
+   * @returns {any}
+   */
   const extractErrorArgs = (logArgs, subErrorsSink) => {
     const argTags = logArgs.map(arg => {
       if (arg instanceof Error) {
@@ -254,6 +262,9 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
     logSubErrors(tagError(error), subErrors);
   };
 
+  /**
+   * @param {Error} error
+   */
   const logError = error => {
     if (errorsLogged.has(error)) {
       return;
@@ -292,6 +303,9 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
   };
 
   const levelMethods = consoleLevelMethods.map(([level, _]) => {
+    /**
+     * @param {...any} logArgs
+     */
     const levelMethod = (...logArgs) => {
       const subErrors = [];
       const argTags = extractErrorArgs(logArgs, subErrors);
@@ -306,6 +320,9 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
     ([name, _]) => name in baseConsole,
   );
   const otherMethods = otherMethodNames.map(([name, _]) => {
+    /**
+     * @param {...any} args
+     */
     const otherMethod = (...args) => {
       // @ts-ignore
       baseConsole[name](...args);
@@ -328,6 +345,9 @@ const filterConsole = (baseConsole, filter, _topic = undefined) => {
   // TODO do something with optional topic string
   const whilelist = consoleWhitelist.filter(([name, _]) => name in baseConsole);
   const methods = whilelist.map(([name, severity]) => {
+    /**
+     * @param {...any} args
+     */
     const method = (...args) => {
       if (severity === undefined || filter.canLog(severity)) {
         // @ts-ignore

--- a/packages/ses/src/error/internal-types.js
+++ b/packages/ses/src/error/internal-types.js
@@ -1,5 +1,4 @@
 // @ts-check
-/// <reference types="ses"/>
 
 /**
  * @typedef {readonly any[]} LogArgs

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 // Much of this file is duplicated at
 // https://github.com/Agoric/agoric-sdk/blob/master/packages/assert/src/types.js
 // Coordinate edits until we refactor to avoid this duplication

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -1,9 +1,10 @@
 // @ts-check
-/// <reference types="ses"/>
 
 // Much of this file is duplicated at
 // https://github.com/Agoric/agoric-sdk/blob/master/packages/assert/src/types.js
 // Coordinate edits until we refactor to avoid this duplication
+
+// @ts-check
 
 /**
  * @callback BaseAssert


### PR DESCRIPTION
This change includes Compartment and lockdown in the SES shim’s exported types and generally extends the reach of TypeScript verification into SES sources. This change uses the expedient of reexporting the return types of functions that are checked by `yarn tsc:lint` which may not be sufficient. In a subsequent change, it will likely be necessary to convert the Compartment and lockdown types into interface definitions that are imported by the sources and also exported by `index.d.ts`.