### PR TITLE
Fix typing

### DIFF
--- a/packages/compartment-mapper/jsconfig.json
+++ b/packages/compartment-mapper/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "esnext",
     "module": "esnext",
     "noEmit": true,
     "downlevelIteration": true,

--- a/packages/endo/jsconfig.json
+++ b/packages/endo/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "esnext",
     "module": "esnext",
     "noEmit": true,
     "downlevelIteration": true,

--- a/packages/make-hardener/jsconfig.json
+++ b/packages/make-hardener/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "esnext",
     "module": "esnext",
     "noEmit": true,
     "downlevelIteration": true,

--- a/packages/make-hardener/src/main.js
+++ b/packages/make-hardener/src/main.js
@@ -25,15 +25,13 @@ const { freeze, getOwnPropertyDescriptors, getPrototypeOf } = Object;
 const { ownKeys } = Reflect;
 
 /**
- * @template T
- * @typedef {(root: T) => T} Hardener
+ * @typedef {<T>(root: T) => T} Hardener
  */
 
 /**
  * Create a `harden` function.
  *
- * @template T
- * @returns {Hardener<T>}
+ * @returns {Hardener}
  */
 function makeHardener() {
   const hardened = new WeakSet();

--- a/packages/ses/index.d.ts
+++ b/packages/ses/index.d.ts
@@ -1,12 +1,19 @@
+/* eslint-disable */
 /**
  * Transitively freeze an object.
  */
 import type { Hardener } from '@agoric/make-hardener';
-import { makeLockdown } from './src/lockdown-shim.js';
-import { makeCompartmentConstructor } from './src/compartment-shim.js';
+import type { CompartmentConstructor } from './src/compartment-shim';
+import type { Lockdown } from './src/lockdown-shim';
 
-namespace global {
-  declare let harden : Hardener<T>;
-  declare let lockdown : ReturnType<makeLockdown>;
-  declare let Compartment : ReturnType<makeCompartmentConstructor>;
+// For scripts.
+declare var harden: Hardener;
+declare var lockdown: Lockdown;
+declare var Compartment: CompartmentConstructor;
+
+declare global {
+  // For modules.
+  var harden: Hardener;
+  var lockdown : Lockdown;
+  var Compartment : CompartmentConstructor;
 }

--- a/packages/ses/jsconfig.json
+++ b/packages/ses/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "esnext",
     "module": "esnext",
     "noEmit": true,
     "downlevelIteration": true,

--- a/packages/ses/src/compartment-shim.js
+++ b/packages/ses/src/compartment-shim.js
@@ -117,32 +117,34 @@ defineProperties(InertCompartment, {
 });
 
 /**
- * @template CompartmentConstructor
- * @callback CompartmentConstructorMaker
- * @param {CompartmentConstructorMaker<CompartmentConstructor>} targetMakeCompartmentConstructor
- * @param {Object} intrinsics
- * @param {(object: Object) => void} nativeBrander
- * @returns CompartmentConstructor
+ * @callback CompartmentConstructor
+ * Each Compartment constructor is a global. A host that wants to execute
+ * code in a context bound to a new global creates a new compartment.
+ *
+ * @param {Object} endowments
+ * @param {Object} _moduleMap
+ * @param {Object} [options]
+ * @param {string} [options.name]
+ * @param {Array<Transform>} [options.transforms]
+ * @param {Array<Transform>} [options.__shimTransforms__]
+ * @param {Object} [options.globalLexicals]
  */
 
-/** @type {CompartmentConstructorMaker<Compartment>} */
+/**
+ * @callback MakeCompartmentConstructor
+ * @param {MakeCompartmentConstructor} targetMakeCompartmentConstructor
+ * @param {Object} intrinsics
+ * @param {(object: Object) => void} nativeBrander
+ * @returns {CompartmentConstructor}
+ */
+
+/** @type {MakeCompartmentConstructor} */
 export const makeCompartmentConstructor = (
   targetMakeCompartmentConstructor,
   intrinsics,
   nativeBrander,
 ) => {
-  /**
-   * Each Compartment constructor is a global. A host that wants to execute
-   * code in a context bound to a new global creates a new compartment.
-   *
-   * @param {Object} endowments
-   * @param {Object} _moduleMap
-   * @param {Object} [options]
-   * @param {string} [options.name]
-   * @param {Array<Transform>} [options.transforms]
-   * @param {Array<Transform>} [options.__shimTransforms__]
-   * @param {Object} [options.globalLexicals]
-   */
+  /** @type {CompartmentConstructor} */
   function Compartment(endowments = {}, _moduleMap = {}, options = {}) {
     if (new.target === undefined) {
       throw new TypeError(

--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -32,7 +32,9 @@ import './internal-types.js';
 // In theory we should do a deep inspection to detect for example an array
 // containing an error. We currently do not detect these and may never.
 
-/** @type {readonly [keyof VirtualConsole, LogSeverity | undefined][]} */
+/** @typedef {keyof VirtualConsole | 'profile' | 'profileEnd'} ConsoleProps */
+
+/** @type {readonly [ConsoleProps, LogSeverity | undefined][]} */
 const consoleLevelMethods = freeze([
   ['debug', 'debug'], // (fmt?, ...args) verbose level on Chrome
   ['log', 'log'], // (fmt?, ...args) info level on Chrome
@@ -46,7 +48,7 @@ const consoleLevelMethods = freeze([
   ['groupCollapsed', 'log'], // (fmt?, ...args)
 ]);
 
-/** @type {readonly [keyof VirtualConsole, LogSeverity | undefined][]} */
+/** @type {readonly [ConsoleProps, LogSeverity | undefined][]} */
 const consoleOtherMethods = freeze([
   ['assert', 'error'], // (value, fmt?, ...args)
   ['timeLog', 'log'], // (label?, ...args) no fmt string
@@ -70,7 +72,7 @@ const consoleOtherMethods = freeze([
   ['timeStamp', undefined], // (label?)
 ]);
 
-/** @type {readonly [keyof VirtualConsole, LogSeverity | undefined][]} */
+/** @type {readonly [ConsoleProps, LogSeverity | undefined][]} */
 export const consoleWhitelist = freeze([
   ...consoleLevelMethods,
   ...consoleOtherMethods,

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -315,9 +315,18 @@
  * @property {Console['table']} table
  * @property {Console['time']} time
  * @property {Console['timeEnd']} timeEnd
- * property {Console['profile']} profile
- * property {Console['profileEnd']} profileEnd
  * @property {Console['timeStamp']} timeStamp
+ */
+
+/* This is deliberately *not* JSDoc, it is a regular comment.
+ *
+ * TODO: We'd like to add the following properties to the above
+ * VirtualConsole, but they currently cause conflicts where
+ * some Typescript implementations don't have these properties
+ * on the Console type.
+ *
+ * @property {Console['profile']} profile
+ * @property {Console['profileEnd']} profileEnd
  */
 
 /**

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -315,8 +315,8 @@
  * @property {Console['table']} table
  * @property {Console['time']} time
  * @property {Console['timeEnd']} timeEnd
- * @property {Console['profile']} profile
- * @property {Console['profileEnd']} profileEnd
+ * property {Console['profile']} profile
+ * property {Console['profileEnd']} profileEnd
  * @property {Console['timeStamp']} timeStamp
  */
 

--- a/packages/ses/src/lockdown-shim.js
+++ b/packages/ses/src/lockdown-shim.js
@@ -287,3 +287,5 @@ export const makeLockdown = (
   };
   return lockdown;
 };
+
+/** @typedef {ReturnType<typeof makeLockdown>} Lockdown */

--- a/packages/transform-module/jsconfig.json
+++ b/packages/transform-module/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "esnext",
     "module": "esnext",
     "noEmit": true,
     "downlevelIteration": true,


### PR DESCRIPTION
These fixes are needed to correctly export global types to consumers of ses.

We also standardize on `"target": "esnext"` in anticipation of future Javascript.
