### PR TITLE
Manually force yarn.lock to acorn8

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2432,7 +2432,7 @@ acorn-globals@^4.3.0:
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.4.tgz#9fa1926addc11c97308c4e66d7add0d40c3272e7"
   integrity sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==
   dependencies:
-    acorn "^6.0.1"
+    acorn "^8.0.1".0.1"
     acorn-walk "^6.0.1"
 
 acorn-jsx@^5.2.0:
@@ -7584,7 +7584,7 @@ jsdom@^14.1.0:
   integrity sha512-O901mfJSuTdwU2w3Sn+74T+RnDVP+FuV5fH8tcPWyqrseRAb0s5xOtPgCFiPOtLcyK7CLIJwPyD83ZqQWvA5ng==
   dependencies:
     abab "^2.0.0"
-    acorn "^6.0.4"
+    acorn "^8.0.1".0.4"
     acorn-globals "^4.3.0"
     array-equal "^1.0.0"
     cssom "^0.3.4"
@@ -12925,7 +12925,7 @@ webpack@^4.29.6:
     "@webassemblyjs/helper-module-context" "1.9.0"
     "@webassemblyjs/wasm-edit" "1.9.0"
     "@webassemblyjs/wasm-parser" "1.9.0"
-    acorn "^6.4.1"
+    acorn "^8.0.1".4.1"
     ajv "^6.10.2"
     ajv-keywords "^3.4.1"
     chrome-trace-event "^1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2445,7 +2445,7 @@ acorn-node@^1.2.0, acorn-node@^1.3.0, acorn-node@^1.5.2, acorn-node@^1.6.1:
   resolved "https://registry.yarnpkg.com/acorn-node/-/acorn-node-1.8.2.tgz#114c95d64539e53dede23de8b9d96df7c7ae2af8"
   integrity sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==
   dependencies:
-    acorn "^7.0.0"
+    acorn "^8.0.1"
     acorn-walk "^7.0.0"
     xtend "^4.0.2"
 
@@ -5462,7 +5462,7 @@ espree@^6.1.2:
   resolved "https://registry.yarnpkg.com/espree/-/espree-6.2.1.tgz#77fc72e1fd744a2052c20f38a5b575832e82734a"
   integrity sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==
   dependencies:
-    acorn "^7.1.1"
+    acorn "^8.0.1"
     acorn-jsx "^5.2.0"
     eslint-visitor-keys "^1.1.0"
 
@@ -5668,7 +5668,7 @@ falafel@^2.1.0:
   resolved "https://registry.yarnpkg.com/falafel/-/falafel-2.2.4.tgz#b5d86c060c2412a43166243cb1bce44d1abd2819"
   integrity sha512-0HXjo8XASWRmsS0X1EkhwEMZaD3Qvp7FfURwjLKjG1ghfRm/MGZl2r4cWUTv41KdNghTw4OUMmVtdGQp3+H+uQ==
   dependencies:
-    acorn "^7.1.1"
+    acorn "^8.0.1"
     foreach "^2.0.5"
     isarray "^2.0.1"
     object-keys "^1.0.6"
@@ -10991,7 +10991,7 @@ rollup@1.31.0:
   dependencies:
     "@types/estree" "*"
     "@types/node" "*"
-    acorn "^7.1.0"
+    acorn "^8.0.1"
 
 rollup@^2.0.0:
   version "2.34.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2432,7 +2432,7 @@ acorn-globals@^4.3.0:
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.4.tgz#9fa1926addc11c97308c4e66d7add0d40c3272e7"
   integrity sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==
   dependencies:
-    acorn "^8.0.1".0.1"
+    acorn "^8.0.1"
     acorn-walk "^6.0.1"
 
 acorn-jsx@^5.2.0:
@@ -7584,7 +7584,7 @@ jsdom@^14.1.0:
   integrity sha512-O901mfJSuTdwU2w3Sn+74T+RnDVP+FuV5fH8tcPWyqrseRAb0s5xOtPgCFiPOtLcyK7CLIJwPyD83ZqQWvA5ng==
   dependencies:
     abab "^2.0.0"
-    acorn "^8.0.1".0.4"
+    acorn "^8.0.1"
     acorn-globals "^4.3.0"
     array-equal "^1.0.0"
     cssom "^0.3.4"
@@ -12925,7 +12925,7 @@ webpack@^4.29.6:
     "@webassemblyjs/helper-module-context" "1.9.0"
     "@webassemblyjs/wasm-edit" "1.9.0"
     "@webassemblyjs/wasm-parser" "1.9.0"
-    acorn "^8.0.1".4.1"
+    acorn "^8.0.1"
     ajv "^6.10.2"
     ajv-keywords "^3.4.1"
     chrome-trace-event "^1.0.2"


### PR DESCRIPTION
None of our own package.json files state any dependency on `"acorn"` other than `"^8.0.1"`. Nevertheless, somehow acorn v7 links end up in our `yarn.lock`.  I have no idea what the proper way is to ensure that no acorn 7s get linked into our system, but we need to because acorn 7 has a bug that interferes with SES fixed in acorn 8. So I'm making this draft until either
   * we determine that it is ok to force version linkage in this manner, or
   * we do this whatever the proper way to do this is.