### PR TITLE
Lenient stackTraceLimit works across browsers

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -25,6 +25,16 @@ User-visible changes in SES:
   passed through to the underlying `JSON.stringfiy`. Passing in a space or
   two spaces makes the output much more readable using indentation and other
   whitespace, but takes multiple lines.
+* The SES enhanced `console` had previously only produced meaningful stack
+  traces on v8-based browsers such as Brave, Chromium, or Chrome. It now
+  works on Firefox and Safari as well. It should work on all major browsers
+  but have not yet been tested on others.
+* On all platforms `Error.stackTrace` is now an assignable accessor property.
+  On v8-based platforms, for the `Error` constructor in the start compartment,
+  it has the same effect that it does outside SES. Outside the start
+  compartment, or outside v8-based platforms, the assignment succeeds silently
+  with no effect.
+  This accommodates a de facto standard idiom encouraged by Google.
 * The "SES Demo Console" and "SES Challenge" have been fixed to work with
   modern SES. Both now run in browsers, though these are not yet hosted
   for visiting as an external web page.

--- a/packages/ses/demos/challenge/main.js
+++ b/packages/ses/demos/challenge/main.js
@@ -146,7 +146,12 @@ lockdown();
   }
 
   harden(guess);
-  const compartent = new Compartment({ console, guess, ...dateEndowment });
+  const compartent = new Compartment({
+    console,
+    assert,
+    guess,
+    ...dateEndowment,
+  });
 
   function submitProgram(program) {
     // the attacker's code will be submitted here. We expect it to be a

--- a/packages/ses/demos/console/main.js
+++ b/packages/ses/demos/console/main.js
@@ -13,7 +13,7 @@ lockdown();
 
   // Under the default `lockdown` settings, it is safe enough
   // to endow with the safe `console`.
-  const compartment = new Compartment({ console });
+  const compartment = new Compartment({ console, assert });
 
   execute.addEventListener('click', () => {
     const sourceText = input.value;

--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -226,11 +226,11 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
   /**
    * Logs the `subErrors` within a group name mentioning `optTag`.
    *
-   * @param {string | undefined} optTag
    * @param {Error[]} subErrors
+   * @param {string | undefined} optTag
    * @returns {void}
    */
-  const logSubErrors = (optTag = undefined, subErrors) => {
+  const logSubErrors = (subErrors, optTag = undefined) => {
     if (subErrors.length === 0) {
       return;
     }
@@ -267,7 +267,7 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
     // Annotation arrived after the error has already been logged,
     // so just log the annotation immediately, rather than remembering it.
     logErrorInfo(error, ErrorInfo.NOTE, noteLogArgs, subErrors);
-    logSubErrors(tagError(error), subErrors);
+    logSubErrors(subErrors, tagError(error));
   };
 
   /**
@@ -307,7 +307,7 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
       logErrorInfo(error, ErrorInfo.NOTE, noteLogArgs, subErrors);
     }
     // explain all the errors seen in the messages already emitted.
-    logSubErrors(errorTag, subErrors);
+    logSubErrors(subErrors, errorTag);
   };
 
   const levelMethods = consoleLevelMethods.map(([level, _]) => {
@@ -319,7 +319,7 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
       const argTags = extractErrorArgs(logArgs, subErrors);
       // @ts-ignore
       baseConsole[level](...argTags);
-      logSubErrors(undefined, subErrors);
+      logSubErrors(subErrors);
     };
     defineProperty(levelMethod, 'name', { value: level });
     return [level, freeze(levelMethod)];

--- a/packages/ses/src/error/console.js
+++ b/packages/ses/src/error/console.js
@@ -224,32 +224,38 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
   };
 
   /**
-   * Logs the `subErrors` within a group named `label`.
+   * Logs the `subErrors` within a group name mentioning `optTag`.
    *
    * @param {string | undefined} optTag
    * @param {Error[]} subErrors
    * @returns {void}
    */
   const logSubErrors = (optTag = undefined, subErrors) => {
-    if (subErrors.length >= 1) {
-      let label;
-      if (subErrors.length === 1) {
-        label = `Nested error`;
-      } else {
-        label = `Nested ${subErrors.length} errors`;
+    if (subErrors.length === 0) {
+      return;
+    }
+    if (subErrors.length === 1 && optTag === undefined) {
+      // eslint-disable-next-line no-use-before-define
+      logError(subErrors[0]);
+      return;
+    }
+    let label;
+    if (subErrors.length === 1) {
+      label = `Nested error`;
+    } else {
+      label = `Nested ${subErrors.length} errors`;
+    }
+    if (optTag !== undefined) {
+      label = `${label} under ${optTag}`;
+    }
+    baseConsole.group(label);
+    try {
+      for (const subError of subErrors) {
+        // eslint-disable-next-line no-use-before-define
+        logError(subError);
       }
-      if (optTag !== undefined) {
-        label = `${label} under ${optTag}`;
-      }
-      baseConsole.group(label);
-      try {
-        for (const subError of subErrors) {
-          // eslint-disable-next-line no-use-before-define
-          logError(subError);
-        }
-      } finally {
-        baseConsole.groupEnd();
-      }
+    } finally {
+      baseConsole.groupEnd();
     }
   };
 
@@ -295,7 +301,7 @@ const makeCausalConsole = (baseConsole, loggedErrorHandler) => {
     ) {
       stackString += '\n';
     }
-    baseConsole[BASE_CONSOLE_LEVEL]('', stackString);
+    baseConsole[BASE_CONSOLE_LEVEL](stackString);
     // Show the other annotations on error
     for (const noteLogArgs of noteLogArgsArray) {
       logErrorInfo(error, ErrorInfo.NOTE, noteLogArgs, subErrors);

--- a/packages/ses/src/error/tame-error-constructor.js
+++ b/packages/ses/src/error/tame-error-constructor.js
@@ -3,13 +3,25 @@ import {
   construct,
   defineProperties,
   setPrototypeOf,
+  getOwnPropertyDescriptor,
 } from '../commons.js';
 import { NativeErrors } from '../whitelist.js';
 import { tameV8ErrorConstructor } from './tame-v8-error-constructor.js';
 
+// Present on at least FF. Proposed by Error-proposal. Not on SES whitelist
+// so grab it before it is removed.
+const stackDesc = getOwnPropertyDescriptor(Error.prototype, 'stack');
+const stackGetter = stackDesc && stackDesc.get;
+
 // Use concise methods to obtain named functions without constructors.
 const tamedMethods = {
-  getStackString(_error) {
+  getStackString(error) {
+    if (typeof stackGetter === 'function') {
+      return apply(stackGetter, error, []);
+    } else if ('stack' in error) {
+      // The fallback is to just use the de facto `error.stack` if present
+      return `${error.stack}`;
+    }
     return '';
   },
 };
@@ -39,6 +51,7 @@ export default function tameErrorConstructor(
         error = construct(OriginalError, rest, new.target);
       }
       if (platform === 'v8') {
+        // TODO Likely expensive!
         OriginalError.captureStackTrace(error, ResultError);
       }
       return error;
@@ -73,6 +86,55 @@ export default function tameErrorConstructor(
   for (const NativeError of NativeErrors) {
     setPrototypeOf(NativeError, SharedError);
   }
+
+  // https://v8.dev/docs/stack-trace-api#compatibility advises that
+  // programmers can "always" set `Error.stackTraceLimit`
+  // even on non-v8 platforms. On non-v8
+  // it will have no effect, but this advice only makes sense
+  // if the assignment itself does not fail, which it would
+  // if `Error` were naively frozen. Hence, we add setters that
+  // accept but ignore the assignment on non-v8 platforms.
+  defineProperties(InitialError, {
+    stackTraceLimit: {
+      get() {
+        if (typeof OriginalError.stackTraceLimit === 'number') {
+          // OriginalError.stackTraceLimit is only on v8
+          return OriginalError.stackTraceLimit;
+        }
+        return undefined;
+      },
+      set(newLimit) {
+        if (typeof OriginalError.stackTraceLimit === 'number') {
+          // OriginalError.stackTraceLimit is only on v8
+          OriginalError.stackTraceLimit = newLimit;
+          // We place the useless return on the next line to ensure
+          // that anything we place after the if in the future only
+          // happens if the then-case does not.
+          // eslint-disable-next-line no-useless-return
+          return;
+        }
+      },
+      // WTF on v8 stackTraceLimit is enumerable
+      enumerable: false,
+      configurable: true,
+    },
+  });
+
+  // The default SharedError much be completely powerless even on v8,
+  // so the lenient `stackTraceLimit` accessor does nothing on all
+  // platforms.
+  defineProperties(SharedError, {
+    stackTraceLimit: {
+      get() {
+        return undefined;
+      },
+      set(_newLimit) {
+        // do nothing
+      },
+      enumerable: false,
+      configurable: true,
+    },
+  });
 
   let initialGetStackString = tamedMethods.getStackString;
   if (platform === 'v8') {

--- a/packages/ses/src/error/tame-error-constructor.js
+++ b/packages/ses/src/error/tame-error-constructor.js
@@ -104,6 +104,13 @@ export default function tameErrorConstructor(
         return undefined;
       },
       set(newLimit) {
+        if (typeof newLimit !== 'number') {
+          // silently do nothing. This behavior doesn't precisely
+          // emulate v8 edge-case behavior. But given the purpose
+          // of this emulation, having edge cases err towards
+          // harmless seems the safer option.
+          return;
+        }
         if (typeof OriginalError.stackTraceLimit === 'number') {
           // OriginalError.stackTraceLimit is only on v8
           OriginalError.stackTraceLimit = newLimit;

--- a/packages/ses/src/error/tame-v8-error-constructor.js
+++ b/packages/ses/src/error/tame-v8-error-constructor.js
@@ -245,40 +245,12 @@ export function tameV8ErrorConstructor(
     return systemMethods.prepareStackTrace;
   };
 
+  // Note `stackTraceLimit` accessor already defined by
+  // tame-error-constructor.js
   defineProperties(InitialError, {
     captureStackTrace: {
       value: tamedMethods.captureStackTrace,
       writable: true,
-      enumerable: false,
-      configurable: true,
-    },
-    stackTraceLimit: {
-      get() {
-        if (typeof OriginalError.stackTraceLimit === 'number') {
-          // OriginalError.stackTraceLimit is only on v8
-          return OriginalError.stackTraceLimit;
-        }
-        return undefined;
-      },
-      // https://v8.dev/docs/stack-trace-api#compatibility advises that
-      // programmers can "always" set `Error.stackTraceLimit` and
-      // `Error.prepareStackTrace` even on non-v8 platforms. On non-v8
-      // it will have no effect, but this advise only makes sense
-      // if the assignment itself does not fail, which it would
-      // if `Error` were naively frozen. Hence, we add setters that
-      // accept but ignore the assignment on non-v8 platforms.
-      set(newLimit) {
-        if (typeof OriginalError.stackTraceLimit === 'number') {
-          // OriginalError.stackTraceLimit is only on v8
-          OriginalError.stackTraceLimit = newLimit;
-          // We place the useless return on the next line to ensure
-          // that anything we place after the if in the future only
-          // happens if the then-case does not.
-          // eslint-disable-next-line no-useless-return
-          return;
-        }
-      },
-      // WTF on v8 stackTraceLimit is enumerable
       enumerable: false,
       configurable: true,
     },

--- a/packages/ses/src/whitelist-intrinsics.js
+++ b/packages/ses/src/whitelist-intrinsics.js
@@ -238,7 +238,16 @@ export default function whitelistIntrinsics(intrinsics, nativeBrander) {
         // explanation.
         console.log(`Removing ${subPath}`);
       }
-      delete obj[prop];
+      try {
+        delete obj[prop];
+      } catch (err) {
+        if (prop in obj) {
+          console.error(`failed to delete ${subPath}`, err);
+        } else {
+          console.error(`deleting ${subPath} threw`, err);
+        }
+        throw err;
+      }
     }
   }
 

--- a/packages/ses/src/whitelist.js
+++ b/packages/ses/src/whitelist.js
@@ -1101,6 +1101,7 @@ export const whitelist = {
   DataView: {
     // Properties of the DataView Constructor
     '[[Proto]]': '%FunctionPrototype%',
+    BYTES_PER_ELEMENT: 'number', // Non std but undeletable on Safari.
     prototype: '%DataViewPrototype%',
   },
 

--- a/packages/ses/test/error/test-assert-log.js
+++ b/packages/ses/test/error/test-assert-log.js
@@ -29,10 +29,8 @@ test('throwsAndLogs with data', t => {
     [
       ['error', 'what', obj],
       ['log', 'Caught', '(TypeError#1)'],
-      ['group', 'Nested error'],
       ['debug', 'TypeError#1:', 'foo'],
-      ['debug', '', 'stack of TypeError\n'],
-      ['groupEnd'],
+      ['debug', 'stack of TypeError\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -66,10 +64,8 @@ test('assert', t => {
     /Check failed/,
     [
       ['log', 'Caught', '(Error#1)'],
-      ['group', 'Nested error'],
       ['debug', 'Error#1:', 'Check failed'],
-      ['debug', '', 'stack of Error\n'],
-      ['groupEnd'],
+      ['debug', 'stack of Error\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -114,16 +110,14 @@ test('causal tree', t => {
     /because/,
     [
       ['log', 'Caught', '(Error#1)'],
-      ['group', 'Nested error'],
       ['debug', 'Error#1:', 'because', '(Error#2)'],
-      ['debug', '', 'stack of Error\n'],
+      ['debug', 'stack of Error\n'],
       ['group', 'Nested error under Error#1'],
       ['debug', 'Error#2:', 'synful', '(SyntaxError#3)'],
-      ['debug', '', 'stack of Error\n'],
+      ['debug', 'stack of Error\n'],
       ['group', 'Nested error under Error#2'],
       ['debug', 'SyntaxError#3:', 'foo'],
-      ['debug', '', 'stack of SyntaxError\n'],
-      ['groupEnd'],
+      ['debug', 'stack of SyntaxError\n'],
       ['groupEnd'],
       ['groupEnd'],
     ],
@@ -208,10 +202,8 @@ test('assert equals', t => {
     /Expected \(a number\) is same as \(a number\)/,
     [
       ['log', 'Caught', '(RangeError#1)'],
-      ['group', 'Nested error'],
       ['debug', 'RangeError#1:', 'Expected', 5, 'is same as', 6],
-      ['debug', '', 'stack of RangeError\n'],
-      ['groupEnd'],
+      ['debug', 'stack of RangeError\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -224,10 +216,8 @@ test('assert equals', t => {
     /foo/,
     [
       ['log', 'Caught', '(RangeError#1)'],
-      ['group', 'Nested error'],
       ['debug', 'RangeError#1:', 'foo'],
-      ['debug', '', 'stack of RangeError\n'],
-      ['groupEnd'],
+      ['debug', 'stack of RangeError\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -250,10 +240,8 @@ test('assert equals', t => {
     /Expected \(a number\) is same as \(a number\)/,
     [
       ['log', 'Caught', '(RangeError#1)'],
-      ['group', 'Nested error'],
       ['debug', 'RangeError#1:', 'Expected', -0, 'is same as', 0],
-      ['debug', '', 'stack of RangeError\n'],
-      ['groupEnd'],
+      ['debug', 'stack of RangeError\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -292,10 +280,8 @@ test('assert error default', t => {
     /<\(a string\),"baz">/,
     [
       ['log', 'Caught', '(Error#1)'],
-      ['group', 'Nested error'],
       ['debug', 'Error#1:', '<', 'bar', ',', 'baz', '>'],
-      ['debug', '', 'stack of Error\n'],
-      ['groupEnd'],
+      ['debug', 'stack of Error\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -321,10 +307,8 @@ test('assert error explicit', t => {
     /<\(a string\),"baz">/,
     [
       ['log', 'Caught', '(URIError#1)'],
-      ['group', 'Nested error'],
       ['debug', 'URIError#1:', '<', 'bar', ',', 'baz', '>'],
-      ['debug', '', 'stack of URIError\n'],
-      ['groupEnd'],
+      ['debug', 'stack of URIError\n'],
     ],
     { wrapWithCausal: true },
   );
@@ -343,10 +327,8 @@ test('assert q', t => {
     /<\(a string\),"baz">/,
     [
       ['log', 'Caught', '(Error#1)'],
-      ['group', 'Nested error'],
       ['debug', 'Error#1:', '<', 'bar', ',', 'baz', '>'],
-      ['debug', '', 'stack of Error\n'],
-      ['groupEnd'],
+      ['debug', 'stack of Error\n'],
     ],
     { wrapWithCausal: true },
   );


### PR DESCRIPTION
Fixes #525 

Using #590 to iterate within several browsers, I repaired several issues.

   * #525 was that assigning `Error.stackTraceLimit` was failing in non-v8-based browsers because `Error` had no such property and is frozen. Although the property is indeed non-standard and absent in non-v8 systems, Google's documentation encourages assignments to it anyway. This is a noop elsewhere, but is harmless when `Error` is unfrozen. To accommodate this practice, this PR installs a noop `Error.stackTraceLimit` accessor property on every platform. It is a noop everywhere except in the start compartment of a v8-based platform.
   * On the Safari browser (and presumably on any host using the JSC engine) `DataView` has a non-standard but non-deletable `BYTES_PER_ELEMENT` property whose value is a number. Since it is non-deletable but harmless, we added it to our whitelist.
   * We added logic for obtaining the stack string for FF (using the proposed `Error.prototype.stack` accessor property`) and others including Safari using the `error.stack` property if present. Otherwise (such as on XS currently) the default stack remains the empty string.

In the process, made the console output more pleasant for the common case of console messages containing only one error argument. For this case, nothing is gained by nesting the error within a group. Removing this extra visual noise helps this common case.

Because I built it using #590 it was easy to build it on #590 , which is fine if #590 gets merged first. If #590 gets delayed, I can make this independently mergeable since it has no logical dependence on #590.