### PR TITLE
Repair Array Push

### DIFF
--- a/packages/ses/src/enablements.js
+++ b/packages/ses/src/enablements.js
@@ -80,6 +80,7 @@ export const moderateEnablements = {
 
   '%ArrayPrototype%': {
     toString: true,
+    push: true,
   },
 
   // Function.prototype has no 'prototype' property to enable.

--- a/packages/ses/test/test-enable-property-overrides.js
+++ b/packages/ses/test/test-enable-property-overrides.js
@@ -94,7 +94,7 @@ test('enablePropertyOverrides - on', t => {
   testOverriding(t, 'Object', {}, ['hasOwnProperty', 'toString', 'valueOf']);
   // We allow 'length' *not* because it is in enablements; it is not;
   // but because each array instance has its own.
-  testOverriding(t, 'Array', [], ['toString', 'length']);
+  testOverriding(t, 'Array', [], ['toString', 'length', 'push']);
   // eslint-disable-next-line func-names
   testOverriding(t, 'Function', function() {}, [
     'constructor',

--- a/packages/ses/test/test-property-override.js
+++ b/packages/ses/test/test-property-override.js
@@ -109,8 +109,5 @@ test('packages in-the-wild', t => {
     const list = [];
     list.push = function newPush() {};
   }
-  t.notThrows(
-    () => c.evaluate(`(${testContent6})`)(),
-    'list push override',
-  )
+  t.notThrows(() => c.evaluate(`(${testContent6})`)(), 'list push override');
 });

--- a/packages/ses/test/test-property-override.js
+++ b/packages/ses/test/test-property-override.js
@@ -107,10 +107,10 @@ test('packages in-the-wild', t => {
 
   function testContent6() {
     const list = [];
-    list.push = function newPush() {}
+    list.push = function newPush() {};
   }
   t.notThrows(
     () => c.evaluate(`(${testContent6})`)(),
-    'list push override'
+    'list push override',
   )
 });

--- a/packages/ses/test/test-property-override.js
+++ b/packages/ses/test/test-property-override.js
@@ -104,4 +104,13 @@ test('packages in-the-wild', t => {
     () => c.evaluate(`(${testContent5})`)(),
     'core-js promise instance constructor',
   );
+
+  function testContent6() {
+    const list = [];
+    list.push = function newPush() {}
+  }
+  t.notThrows(
+    () => c.evaluate(`(${testContent6})`)(),
+    'list push override'
+  )
 });


### PR DESCRIPTION
# Description

I have been trying to use SES to sandbox third party scripts for services like Twitter Widgets and Google Analytics. My goal is to be able to fetch these scripts from their servers, and run them in a SES compartment with limited capabilities. 

The issue that I ran into is that these scripts frequently overwrite an array's push function like in the example below.
```
const list = []
list.push = function newPush {}
```
This becomes impossible after `lockdown()` has been called due to [The Override Mistake](https://web.archive.org/web/20141230041441/http://wiki.ecmascript.org/doku.php?id=strawman:fixing_override_mistake). This PR aims to fix the problem by allowing an Array's `push` method to be overwritten.

Fixes (https://github.com/Agoric/SES-shim/issues/593)

## Type of change

- New feature (non-breaking change which adds functionality).

# How Has This Been Tested?

- Updated `test-enable-property-overrides.js` to reflect change.
- Added test case in `test-property-override` to ensure required functionality.
- All tests in SES package pass.