### PR TITLE
fix: comments only

### DIFF
--- a/packages/ses/src/enablements.js
+++ b/packages/ses/src/enablements.js
@@ -71,7 +71,7 @@ export const moderateEnablements = {
     // the following line and let us know why. The only known
     // cost is the ugly display from the Node console.
     //
-    // constructor: true, // set by acorn 7
+    // constructor: true, // set by acorn 7, d3-color
 
     hasOwnProperty: true, // set by "vega-util".
     toString: true,

--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -218,7 +218,7 @@
  * @callback MakeAssert
  *
  * Makes and returns an `assert` function object that shares the bookkeeping
- * state defined by this module with other `assert` function objects make by
+ * state defined by this module with other `assert` function objects made by
  * `makeAssert`. This state is per-module-instance and is exposed by the
  * `loggedErrorHandler` above. We refer to `assert` as a "function object"
  * because it can be called directly as a function, but also has methods that


### PR DESCRIPTION
Record that d3-color also overrides `O.p.constructor` by assignment.

Fix typo.