### PR TITLE
Don't enable hasOwnProperty to be overridden by assignment

### DIFF
--- a/packages/ses/NEWS.md
+++ b/packages/ses/NEWS.md
@@ -5,6 +5,18 @@ User-visible changes in SES:
 - Expand TypeScript definitions to include Compartment, StaticModuleRecord,
   StaticModuleType, RedirectStaticModuleInterface, FinalStaticModuleType,
   ThirdPartyStaticModuleInterface, Transform, ImportHook, and ModuleMapHook.
+- As with 'constructor' in the previous release,
+  We no longer enable overriding `Object.prototype.hasOwnProperty` by assigning
+  to the `hasOwnProperty` property of a derived object. As explained at
+  https://github.com/vega/vega/issues/3075
+  vega overrides `Object.prototype.hasOwnProperty` by
+  assignment. Those running into this should consider applying
+  the patch
+  https://github.com/Agoric/agoric-sdk/blob/master/patches/vega-util%2B1.16.0.patch
+  as we do, or
+  https://github.com/vega/vega/pull/3109/commits/50741c7e9035c407205ae45983470b8cb27c2da7
+  The owner of vega is aware of the concern, so this
+  may eventually be fixed at the source.
 
 ## Release 0.12.3 (1-Mar-2021)
 

--- a/packages/ses/src/enablements.js
+++ b/packages/ses/src/enablements.js
@@ -73,7 +73,17 @@ export const moderateEnablements = {
     //
     // constructor: true, // set by acorn 7, d3-color
 
-    hasOwnProperty: true, // set by "vega-util".
+    // As explained at
+    // https://github.com/vega/vega/issues/3075
+    // vega overrides `Object.prototype.hasOwnProperty` by
+    // assignment. Those running into this should consider applying
+    // the patch
+    // https://github.com/Agoric/agoric-sdk/blob/master/patches/vega-util%2B1.16.0.patch
+    // as we do, or
+    // https://github.com/vega/vega/pull/3109/commits/50741c7e9035c407205ae45983470b8cb27c2da7
+    // The owner of vega is aware of the concern, so this
+    // may eventually be fixed at the source.
+    // hasOwnProperty: true, // set by "vega-util".
     toString: true,
     valueOf: true,
   },

--- a/packages/ses/src/enablements.js
+++ b/packages/ses/src/enablements.js
@@ -84,6 +84,7 @@ export const moderateEnablements = {
     // The owner of vega is aware of the concern, so this
     // may eventually be fixed at the source.
     // hasOwnProperty: true, // set by "vega-util".
+
     toString: true,
     valueOf: true,
   },

--- a/packages/ses/test/test-enable-property-overrides.js
+++ b/packages/ses/test/test-enable-property-overrides.js
@@ -91,7 +91,7 @@ test('enablePropertyOverrides - on', t => {
 
   harden(intrinsics);
 
-  testOverriding(t, 'Object', {}, ['hasOwnProperty', 'toString', 'valueOf']);
+  testOverriding(t, 'Object', {}, ['toString', 'valueOf']);
   // We allow 'length' *not* because it is in enablements; it is not;
   // but because each array instance has its own.
   testOverriding(t, 'Array', [], ['toString', 'length', 'push']);


### PR DESCRIPTION
The vega package is the only one we are aware of that causes this problem.

In light of the patch fixing vega in agoric-sdk , the issue filed at https://github.com/vega/vega/issues/3075 and the PR https://github.com/vega/vega/pull/3109 , this PR removes `hasOwnProperty` from the enablements.js list. See new NEWS text for more explanation.