### PR TITLE
fix: assert.typeof(xxx, 'object') should assert record or null

### DIFF
--- a/packages/ses/src/error/types.js
+++ b/packages/ses/src/error/types.js
@@ -88,7 +88,7 @@
  * @param {any} specimen
  * @param {'object'} typename
  * @param {Details=} optDetails
- * @returns {asserts specimen is object}
+ * @returns {asserts specimen is Record<any, any> | null}
  *
  * @callback AssertTypeofString
  * @param {any} specimen


### PR DESCRIPTION
This refinement makes the assertion meaningful (before it was just asserting the equivalent of `any`).
