### PR TITLE
Symbol.toStringTag dominates default q stringify

### DIFF
--- a/packages/ses/src/error/stringify-utils.js
+++ b/packages/ses/src/error/stringify-utils.js
@@ -58,13 +58,10 @@ const bestEffortStringify = (payload, spaces = undefined) => {
           return '[Seen]';
         }
         seenSet.add(val);
-        if (Promise.resolve(val) === val) {
-          return '[Promise]';
-        }
         if (val instanceof Error) {
           return `[${val.name}: ${val.message}]`;
         }
-        if (Object.keys(val).length === 0 && Symbol.toStringTag in val) {
+        if (Symbol.toStringTag in val) {
           // Note that this test is `Object.keys` rather than `Refect.ownKeys`.
           // Like `JSON.stringify`, `Object.ownKeys` will enumerate only
           // string-named enumerable own properties, which will therefore

--- a/packages/ses/src/error/stringify-utils.js
+++ b/packages/ses/src/error/stringify-utils.js
@@ -62,15 +62,27 @@ const bestEffortStringify = (payload, spaces = undefined) => {
           return `[${val.name}: ${val.message}]`;
         }
         if (Symbol.toStringTag in val) {
-          // Note that this test is `Object.keys` rather than `Refect.ownKeys`.
-          // Like `JSON.stringify`, `Object.ownKeys` will enumerate only
-          // string-named enumerable own properties, which will therefore
-          // omit Symbol.toStringTag even if it is own and enumerable.
-          // This case will happen to do a good job with presences without
+          // For the built-ins that have or inherit a `Symbol.toStringTag`-named
+          // property, most of them inherit the default `toString` method,
+          // which will print in a similar manner: `"[object Foo]"` vs
+          // `"[Foo]"`. The exceptions are
+          //    * `Symbol.prototype`, `BigInt.prototype`, `String.prototype`
+          //      which don't matter to us since we handle primitives
+          //      separately and we don't care about primitive wrapper objects.
+          //    * TODO
+          //      `Date.prototype`, `TypedArray.prototype`.
+          //      Hmmm, we probably should make special cases for these. We're
+          //      not using these yet, so it's not urgent. But others will run
+          //      into these.
+          //
+          // Once #2018 is closed, the only objects in our code that have or
+          // inherit a `Symbol.toStringTag`-named property are remotables
+          // or their remote presences.
+          // This printing will do a good job for these without
           // violating abstraction layering. This behavior makes sense
           // purely in terms of JavaScript concepts. That's some of the
           // motivation for choosing that representation of remotables
-          // in the first place.
+          // and their remote presences in the first place.
           return `[${val[Symbol.toStringTag]}]`;
         }
         return val;

--- a/packages/ses/test/error/test-assert-log.js
+++ b/packages/ses/test/error/test-assert-log.js
@@ -400,7 +400,7 @@ test('q as best efforts stringify', t => {
   ];
   t.is(
     `${q(challenges)}`,
-    '["[Promise]","[Function foo]","[[hilbert]]","[undefined]","undefined","[URIError: wut?]",["[33n]","[Symbol(foo)]","[Symbol(bar)]","[Symbol(Symbol.asyncIterator)]"],{"NaN":"[NaN]","Infinity":"[Infinity]","neg":"[-Infinity]"},18014398509481984,{"superTagged":"[Tagged]","subTagged":"[Tagged]","subTaggedNonEmpty":{"foo":"x"}}]',
+    '["[Promise]","[Function foo]","[[hilbert]]","[undefined]","undefined","[URIError: wut?]",["[33n]","[Symbol(foo)]","[Symbol(bar)]","[Symbol(Symbol.asyncIterator)]"],{"NaN":"[NaN]","Infinity":"[Infinity]","neg":"[-Infinity]"},18014398509481984,{"superTagged":"[Tagged]","subTagged":"[Tagged]","subTaggedNonEmpty":"[Tagged]"}]',
   );
   t.is(
     `${q(challenges, '  ')}`,
@@ -427,9 +427,7 @@ test('q as best efforts stringify', t => {
   {
     "superTagged": "[Tagged]",
     "subTagged": "[Tagged]",
-    "subTaggedNonEmpty": {
-      "foo": "x"
-    }
+    "subTaggedNonEmpty": "[Tagged]"
   }
 ]`,
   );


### PR DESCRIPTION
Previously, if an object had a property named by the `Symbol.toStringTag` symbol *and it was empty*, then the human readable "quoted" printing by `q` would be `"[<value of that property>]"`.

This PR removes the "and it was empty" part of that condition. This PR should wait until https://github.com/Agoric/agoric-sdk/issues/2018 is closed, because until then data objects, whether empty or not, will pass this test, preventing `q` from providing a pleasant display of their properties.

Until then, however, we have a painful difference in how `q` renders a remotable vs a remote presence of that remotable. Currently, for our objects-as-closures style of remotable, `q` will show the method names. This difference means that `t.throws` tests will see different quoted text in error messages depending on where the error was thrown. Attn @Chris-Hibbert 